### PR TITLE
feat(cms): remove cms-only filtering from getSchema, getSchemas

### DIFF
--- a/modules/cms/src/admin/admin.ts
+++ b/modules/cms/src/admin/admin.ts
@@ -48,7 +48,6 @@ export class AdminHandlers {
         // Schemas
         getSchema: this.schemaAdmin.getSchema.bind(this.schemaAdmin),
         getSchemas: this.schemaAdmin.getSchemas.bind(this.schemaAdmin),
-        getSchemasFromOtherModules: this.schemaAdmin.getSchemasFromOtherModules.bind(this.schemaAdmin),
         createSchema: this.schemaAdmin.createSchema.bind(this.schemaAdmin),
         patchSchema: this.schemaAdmin.patchSchema.bind(this.schemaAdmin),
         deleteSchema: this.schemaAdmin.deleteSchema.bind(this.schemaAdmin),
@@ -86,6 +85,9 @@ export class AdminHandlers {
           urlParams: {
             id: { type: RouteOptionType.String, required: true },
           },
+          queryParams: {
+            owner: ConduitString.Optional,
+          },
         },
         new ConduitRouteReturnDefinition('GetSchema', _DeclaredSchema.getInstance().fields),
         'getSchema'
@@ -100,6 +102,7 @@ export class AdminHandlers {
             search: ConduitString.Optional,
             sort: ConduitString.Optional,
             enabled: ConduitBoolean.Optional,
+            owner: ConduitString.Optional,
           },
         },
         new ConduitRouteReturnDefinition('GetSchemas', {
@@ -107,16 +110,6 @@ export class AdminHandlers {
           count: ConduitNumber.Required,
         }),
         'getSchemas'
-      ),
-      constructConduitRoute(
-        {
-          path: '/schemasFromOtherModules',
-          action: ConduitRouteActions.GET,
-        },
-        new ConduitRouteReturnDefinition('GetSchemasFromOtherModules', {
-          externalSchemas: [ConduitJson.Required],
-        }),
-        'getSchemasFromOtherModules'
       ),
       constructConduitRoute(
         {

--- a/modules/cms/src/admin/schema.admin.ts
+++ b/modules/cms/src/admin/schema.admin.ts
@@ -31,7 +31,10 @@ export class SchemaAdmin {
   }
 
   async getSchema(call: ParsedRouterRequest): Promise<UnparsedRouterResponse> {
-    const query: {[p: string]: any} = { _id: call.request.params.id, name: { $nin: CMS_SYSTEM_SCHEMAS } };
+    const query: {[p: string]: any} = {
+      _id: call.request.params.id,
+      name: { $nin: CMS_SYSTEM_SCHEMAS }
+    };
     if (!isNil(call.request.params.owner)) {
       query.ownerModule = call.request.params.owner;
     }
@@ -79,16 +82,6 @@ export class SchemaAdmin {
     ]).catch((e) => {
       throw new GrpcError(status.INTERNAL, e.message);
     });
-
-    for (const schema of schemas) {
-      if (schema.ownerModule !== 'cms') { // || CMS_SYSTEM_SCHEMAS.includes(schema.name)) {
-        schema.modelOptions.conduit.cms = {
-          enabled: true,
-          crudOperations: false,
-          authentication: false, // here due to type restriction
-        };
-      }
-    }
 
     return { schemas, count };
   }

--- a/modules/cms/src/admin/schema.admin.ts
+++ b/modules/cms/src/admin/schema.admin.ts
@@ -31,10 +31,11 @@ export class SchemaAdmin {
   }
 
   async getSchema(call: ParsedRouterRequest): Promise<UnparsedRouterResponse> {
-    const requestedSchema = await _DeclaredSchema.getInstance().findOne({
-      ownerModule: 'cms', name: { $nin: CMS_SYSTEM_SCHEMAS },
-      _id: call.request.params.id,
-    });
+    const query: {[p: string]: any} = { _id: call.request.params.id, name: { $nin: CMS_SYSTEM_SCHEMAS } };
+    if (!isNil(call.request.params.owner)) {
+      query.ownerModule = call.request.params.owner;
+    }
+    const requestedSchema = await _DeclaredSchema.getInstance().findOne(query);
     if (isNil(requestedSchema)) {
       throw new GrpcError(status.NOT_FOUND, 'Schema does not exist');
     }
@@ -45,14 +46,22 @@ export class SchemaAdmin {
     const { search, sort, enabled } = call.request.params;
     const skip = call.request.params.skip ?? 0;
     const limit = call.request.params.limit ?? 25;
-    let query: any = { ownerModule: 'cms', name: { $nin: CMS_SYSTEM_SCHEMAS } },
-      identifier;
+    let query: {[p: string]: any} = { name: { $nin: CMS_SYSTEM_SCHEMAS } };
+    if (!isNil(call.request.params.owner)) {
+      query.ownerModule = call.request.params.owner;
+    }
+    let identifier;
     if (!isNil(search)) {
       identifier = escapeStringRegexp(search);
       query['name'] = { $regex: `.*${identifier}.*`, $options: 'i' };
     }
     if (!isNil(enabled)) {
-      query['modelOptions.conduit.cms.enabled'] = enabled;
+      const enabledQuery = { $or: [{ ownerModule: { $ne: 'cms' } }, { 'modelOptions.conduit.cms.enabled': true }] };
+      const disabledQuery = { 'modelOptions.conduit.cms.enabled': false };
+      query = { $and: [
+        query,
+        enabled ? enabledQuery : disabledQuery
+      ]};
     }
 
     const schemasPromise = _DeclaredSchema.getInstance().findMany(
@@ -71,31 +80,17 @@ export class SchemaAdmin {
       throw new GrpcError(status.INTERNAL, e.message);
     });
 
+    for (const schema of schemas) {
+      if (schema.ownerModule !== 'cms') { // || CMS_SYSTEM_SCHEMAS.includes(schema.name)) {
+        schema.modelOptions.conduit.cms = {
+          enabled: true,
+          crudOperations: false,
+          authentication: false, // here due to type restriction
+        };
+      }
+    }
+
     return { schemas, count };
-  }
-
-  async getSchemasFromOtherModules(
-    call: ParsedRouterRequest
-  ): Promise<UnparsedRouterResponse> {
-    const allSchemas = await this.database.getSchemas().catch((e: Error) => {
-      throw new GrpcError(status.INTERNAL, e.message);
-    });
-
-    const schemasFromCMS = await _DeclaredSchema.getInstance().findMany({
-      ownerModule: 'cms', name: { $nin: CMS_SYSTEM_SCHEMAS }
-    });
-    const schemaNamesFromCMS = (schemasFromCMS as _DeclaredSchema[]).map(
-      (schema: _DeclaredSchema) => schema.name
-    );
-    const schemasFromOtherModules = allSchemas.filter((schema: any) => {
-      return !schemaNamesFromCMS.includes(schema.name);
-    });
-
-    return {
-      externalSchemas: schemasFromOtherModules.map((schema: any) => {
-        return { name: schema.name, fields: schema.modelSchema };
-      }),
-    };
   }
 
   async createSchema(call: ParsedRouterRequest): Promise<UnparsedRouterResponse> {


### PR DESCRIPTION
CMS.getSchema and CMS.getSchemas now also return schemas not-owned by CMS.
CustomEndpoints remains blacklisted and therefore won't show up.

This PR also drops getSchemasFromOtherModules route as it's now pointless and unused in production, therefore branding as Breaking Change and deprecating straight away to avoid cluttering up the codebase.
@KostasFeg I believe Conduit-UI makes use of it to some extent?

BREAKING CHANGE:
Removed CMS.getSchemasFromOtherModules (GET: /admin/cms/schemasFromOtherModules)

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/ConduitPlatform/Conduit/blob/master/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [x] Yes
- [ ] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx`, where "xxx" is the issue number)

If adding a **new feature**, the PR's description includes:
- [x] A convincing reason for adding this feature

**Other information:**
