### PR TITLE
CMS getSchemas ownerModule array filter, getSchemaOwners route

### DIFF
--- a/modules/cms/src/admin/admin.ts
+++ b/modules/cms/src/admin/admin.ts
@@ -85,9 +85,6 @@ export class AdminHandlers {
           urlParams: {
             id: { type: RouteOptionType.String, required: true },
           },
-          queryParams: {
-            owner: ConduitString.Optional,
-          },
         },
         new ConduitRouteReturnDefinition('GetSchema', _DeclaredSchema.getInstance().fields),
         'getSchema'
@@ -102,7 +99,7 @@ export class AdminHandlers {
             search: ConduitString.Optional,
             sort: ConduitString.Optional,
             enabled: ConduitBoolean.Optional,
-            owner: ConduitString.Optional,
+            owner: [ConduitString.Optional],
           },
         },
         new ConduitRouteReturnDefinition('GetSchemas', {

--- a/modules/cms/src/admin/admin.ts
+++ b/modules/cms/src/admin/admin.ts
@@ -55,6 +55,7 @@ export class AdminHandlers {
         toggleSchema: this.schemaAdmin.toggleSchema.bind(this.schemaAdmin),
         toggleSchemas: this.schemaAdmin.toggleSchemas.bind(this.schemaAdmin),
         setSchemaPerms: this.schemaAdmin.setSchemaPerms.bind(this.schemaAdmin),
+        getSchemaOwners: this.schemaAdmin.getSchemaOwners.bind(this.schemaAdmin),
         // Documents
         getDocument: this.documentsAdmin.getDocument.bind(this.documentsAdmin),
         getDocuments: this.documentsAdmin.getDocuments.bind(this.documentsAdmin),
@@ -78,6 +79,16 @@ export class AdminHandlers {
   private getRegisteredRoutes(): any[] {
     return [
       // Schemas
+      constructConduitRoute(
+        {
+          path: '/schemas/owners',
+          action: ConduitRouteActions.GET,
+        },
+        new ConduitRouteReturnDefinition('GetSchemaOwners', {
+          modules: [ConduitString.Required],
+        }),
+        'getSchemaOwners'
+      ),
       constructConduitRoute(
         {
           path: '/schemas/:id',

--- a/modules/cms/src/admin/schema.admin.ts
+++ b/modules/cms/src/admin/schema.admin.ts
@@ -436,4 +436,13 @@ export class SchemaAdmin {
     (schema.modelOptions.conduit as any).permissions.canDelete =
       perms!.canDelete ?? (schema.modelOptions.conduit as any).permissions.canDelete;
   }
+
+  async getSchemaOwners(call: ParsedRouterRequest): Promise<UnparsedRouterResponse> {
+    const modules: string[] = [];
+    const schemas = await _DeclaredSchema.getInstance().findMany({}, 'ownerModule');
+    schemas.forEach((schema) => {
+      if (!modules.includes(schema.ownerModule)) modules.push(schema.ownerModule);
+    });
+    return { modules };
+  }
 }

--- a/modules/cms/src/admin/schema.admin.ts
+++ b/modules/cms/src/admin/schema.admin.ts
@@ -35,9 +35,6 @@ export class SchemaAdmin {
       _id: call.request.params.id,
       name: { $nin: CMS_SYSTEM_SCHEMAS },
     };
-    if (!isNil(call.request.params.owner)) {
-      query.ownerModule = call.request.params.owner;
-    }
     const requestedSchema = await _DeclaredSchema.getInstance().findOne(query);
     if (isNil(requestedSchema)) {
       throw new GrpcError(status.NOT_FOUND, 'Schema does not exist');
@@ -46,12 +43,17 @@ export class SchemaAdmin {
   }
 
   async getSchemas(call: ParsedRouterRequest): Promise<UnparsedRouterResponse> {
-    const { search, sort, enabled } = call.request.params;
+    const { search, sort, enabled, owner } = call.request.params;
     const skip = call.request.params.skip ?? 0;
     const limit = call.request.params.limit ?? 25;
     let query: { [p: string]: any } = { name: { $nin: CMS_SYSTEM_SCHEMAS } };
-    if (!isNil(call.request.params.owner)) {
-      query.ownerModule = call.request.params.owner;
+    if (owner && owner.length !== 0) {
+      query = {
+        $and: [
+          query,
+          { ownerModule: { $in: owner } },
+        ]
+      };
     }
     let identifier;
     if (!isNil(search)) {


### PR DESCRIPTION
Schemas may now be filtered based on multiple valid owner names.
CMS.getSchemas's owner query param now accepts an array of strings (previously a string containing a single module name).
CMS.getSchema's owner query param got dropped.
This is not a breaking change as said params were only introduced in master (not branched into a release).

Adding a route returning all the module names that currently own schemas was required for filtering on Conduit-UI as existing module getters only list modules currently online and don't filter out modules with no schemas. 

**What kind of change does this PR introduce?**

- [ ] Bugfix
- [X] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [X] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [X] It's submitted to the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx`, where "xxx" is the issue number)

If adding a **new feature**, the PR's description includes:
- [X] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)
