### PR TITLE
fix(grpc-sdk): route rpc strings not generated for function names comprised of registered subsets

### DIFF
--- a/libraries/grpc-sdk/src/helpers/RoutingUtilities.ts
+++ b/libraries/grpc-sdk/src/helpers/RoutingUtilities.ts
@@ -90,7 +90,7 @@ function createProtoFunctionsForSocket(
   Object.keys(events).forEach((event) => {
     const newFunction = createGrpcFunctionName(events[event].grpcFunction);
 
-    if (protoFunctions.indexOf(newFunction) !== -1) {
+    if (protoFunctions.indexOf(`rpc ${newFunction}(`) !== -1) {
       return;
     }
 
@@ -103,7 +103,7 @@ function createProtoFunctionsForSocket(
 function createProtoFunctionForRoute(path: any, protoFunctions: string) {
   const newFunction = createGrpcFunctionName(path.grpcFunction);
 
-  if (protoFunctions.indexOf(newFunction) !== -1) {
+  if (protoFunctions.indexOf(`rpc ${newFunction}(`) !== -1) {
     return '';
   }
 


### PR DESCRIPTION
Example: 'PostLogin' wouldn't register after 'PostLoginNew'

**What kind of change does this PR introduce?** (check at least one)

- [X] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [X] No

**The PR fulfills these requirements:**

- [X] It's submitted to the `main` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx`, where "xxx" is the issue number)
