### PR TITLE
fix(storage): updateFile handler backports #73

### DIFF
--- a/modules/storage/src/handlers/file.ts
+++ b/modules/storage/src/handlers/file.ts
@@ -144,7 +144,11 @@ export class FileHandlers {
       }
 
       const newName = name ?? found.name;
-      const newFolder = folder ?? found.folder;
+      let newFolder = folder ?? found.folder;
+      if (!newFolder.endsWith('/')) {
+        // existing folder names are currently suffixed by "/" upon creation
+        newFolder += '/';
+      }
       const newContainer = container ?? found.container;
 
       const shouldRemove =
@@ -183,24 +187,14 @@ export class FileHandlers {
         }
       }
 
-      let exists = await File.getInstance().findOne({
-        name: name,
-        container: newContainer,
-        folder: newFolder,
-      });
-      if (exists) {
-        throw new GrpcError(status.ALREADY_EXISTS, 'File already exists');
-      }
-
-      await this.storageProvider
-        .container(newContainer)
-        .store((newFolder ?? '') + name, fileData)
-
       if (shouldRemove) {
         await this.storageProvider
           .container(found.container)
           .delete((found.folder ?? '') + found.name);
       }
+      await this.storageProvider
+        .container(newContainer)
+        .store((newFolder ?? '') + newName, fileData);
 
       found.name = newName;
       found.folder = newFolder;


### PR DESCRIPTION
Fixes updateFile saving File.name as undefined on requests where name param is not provided.
Fixes folder names requiring a slash suffix (pain-free workraound).

**What kind of change does this PR introduce?** (check at least one)

- [X] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [X] No

**The PR fulfills these requirements:**

- [ ] It's submitted to the `main` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx`, where "xxx" is the issue number)
