### PR TITLE
chore(database,admin): convert env var names to macro case, update PostgreSQL db type value

### DIFF
--- a/modules/database/src/Database.ts
+++ b/modules/database/src/Database.ts
@@ -55,12 +55,12 @@ export default class DatabaseModule extends ManagedModule {
   private userRouter: DatabaseRoutes;
   private readonly _activeAdapter: DatabaseAdapter<MongooseSchema | SequelizeSchema>;
 
-  constructor(dbType: string, dbUrl: string) {
+  constructor(dbType: string, dbUri: string) {
     super('database');
     if (dbType === 'mongodb') {
-      this._activeAdapter = new MongooseAdapter(dbUrl);
-    } else if (dbType === 'sql') {
-      this._activeAdapter = new SequelizeAdapter(dbUrl);
+      this._activeAdapter = new MongooseAdapter(dbUri);
+    } else if (dbType === 'postgres' || dbType === 'sql') { // Compat (<=0.12.2): sql
+      this._activeAdapter = new SequelizeAdapter(dbUri);
     } else {
       throw new Error('Database type not supported');
     }

--- a/modules/database/src/index.ts
+++ b/modules/database/src/index.ts
@@ -1,9 +1,13 @@
 import { ModuleManager } from "@conduitplatform/grpc-sdk";
 import DatabaseModule from './Database';
 
-const dbType = process.env.databaseType ?? 'mongodb';
-const dbUrl = process.env.databaseURL ?? 'mongodb://localhost:27017';
+const dbType = process.env.DB_TYPE ??
+               process.env.databaseType ?? // Compat (<=0.12.2)
+               'mongodb';
+const dbUri = process.env.DB_CONN_URI ??
+              process.env.databaseURL ?? // Compat (<=0.12.2)
+              'mongodb://localhost:27017';
 
-const database = new DatabaseModule(dbType, dbUrl);
+const database = new DatabaseModule(dbType, dbUri);
 const moduleManager = new ModuleManager(database);
 moduleManager.start();

--- a/packages/admin/src/middleware/Admin.middleware.ts
+++ b/packages/admin/src/middleware/Admin.middleware.ts
@@ -10,12 +10,12 @@ export function getAdminMiddleware(conduit: ConduitCommons) {
     ) {
       return next();
     }
-    const masterkey = req.headers.masterkey;
+    const masterKey = req.headers.masterkey;
     if (!process.env.masterkey || process.env.masterkey.length === 0) {
       console.warn('!Security issue!: Master key not set, defaulting to insecure string');
     }
-    let master = process.env.masterkey ?? 'M4ST3RK3Y';
-    if (isNil(masterkey) || masterkey !== master)
+    const master = process.env.MASTER_KEY ?? process.env.masterkey ?? 'M4ST3RK3Y'; // Compat (<=0.12.2): masterkey
+    if (isNil(masterKey) || masterKey !== master)
       return res.status(401).json({ error: 'Unauthorized' });
     next();
   }


### PR DESCRIPTION
Converted env vars names to macro case.
DB_TYPE for PostgreSQL is now 'postgres' (previously 'sql').

This is **not** a breaking change.
Backwards compatibility has been preserved.

Database:
- databaseType (mongodb/sql) -> DB_TYPE (mongodb/postgres)
- databaseUrl -> DB_URL

Admin:
- masterkey -> MASTER_KEY

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [X] Other, please describe:

Updated env var names based on macro case convention.

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [X] No

**The PR fulfills these requirements:**

- [X] It's submitted to the `main` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx`, where "xxx" is the issue number)