### PR TITLE
fix(router, admin): Admin Swagger headers and route paths

### DIFF
--- a/packages/admin/src/index.ts
+++ b/packages/admin/src/index.ts
@@ -28,10 +28,10 @@ const swaggerRouterMetadata: SwaggerRouterMetadata = {
       description: 'Your administrative secret key, configurable through MASTER_KEY env var in Conduit Core',
     },
     adminToken: {
-      name: 'Authorization',
-      type: 'apiKey',
-      in: 'header',
-      description: 'An admin authentication token, retrievable through [POST] /admin/login (format: JWT token)',
+      type: 'http',
+      scheme: 'bearer',
+      bearerFormat: 'Bearer',
+      description: 'An admin authentication token, retrievable through [POST] /admin/login',
     },
   },
   globalSecurityHeaders: [{

--- a/packages/admin/src/index.ts
+++ b/packages/admin/src/index.ts
@@ -18,6 +18,25 @@ import { hashPassword } from './utils/auth';
 import AdminConfigSchema from './config';
 import * as models from './models';
 
+const swaggerSecuritySchemes = {
+  masterKey: {
+    name: 'masterkey',
+    type: 'apiKey',
+    in: 'header',
+    description: 'Your administrative secret key, configurable through MASTER_KEY env var in Conduit Core',
+  },
+  adminToken: {
+    name: 'Authorization',
+    type: 'apiKey',
+    in: 'header',
+    description: 'An admin authentication token, retrievable through [POST] /admin/login (format: JWT token)',
+  },
+}
+
+const globalSecurityHeaders = {
+  masterKey: [],
+}
+
 export default class AdminModule extends IConduitAdmin {
   conduit: ConduitCommons;
   grpcSdk: ConduitGrpcSdk;
@@ -38,7 +57,7 @@ export default class AdminModule extends IConduitAdmin {
     this.grpcSdk = grpcSdk;
 
     this._app = app;
-    this._restRouter = new RestController(this._app);
+    this._restRouter = new RestController(this._app, swaggerSecuritySchemes, globalSecurityHeaders);
 
     this._restRouter.registerRoute('*', middleware.getAdminMiddleware(this.conduit));
     this._restRouter.registerRoute(

--- a/packages/admin/src/index.ts
+++ b/packages/admin/src/index.ts
@@ -37,6 +37,11 @@ const swaggerRouterMetadata: SwaggerRouterMetadata = {
   globalSecurityHeaders: [{
     masterKey: [],
   }],
+  setExtraRouteHeaders(route: ConduitRoute, swaggerRouteDoc: any): void {
+    if (route.input.path !== '/login' && route.input.path !== '/modules') {
+      swaggerRouteDoc.security[0].adminToken = [];
+    }
+  },
 };
 
 export default class AdminModule extends IConduitAdmin {

--- a/packages/admin/src/middleware/Auth.middleware.ts
+++ b/packages/admin/src/middleware/Auth.middleware.ts
@@ -28,10 +28,10 @@ export function getAuthMiddleware(grpcSdk: ConduitGrpcSdk, conduit: ConduitCommo
     }
 
     const [prefix, token] = args;
-    if (prefix !== 'JWT') {
+    if (prefix !== 'Bearer' && prefix !== 'JWT') { // Compat (<=0.12.2): JWT
       return res
         .status(401)
-        .json({ error: 'The authorization header must begin with JWT' });
+        .json({ error: "The Authorization header must be prefixed by 'Bearer '" });
     }
     let decoded;
     try {

--- a/packages/router/src/controllers/Rest/Rest.ts
+++ b/packages/router/src/controllers/Rest/Rest.ts
@@ -31,10 +31,10 @@ export class RestController extends ConduitRouter {
     return this._registeredRoutes;
   }
 
-  constructor(readonly app: Application) {
+  constructor(readonly app: Application, swaggerSecuritySchemes: any, globalSecurityHeaders: any) {
     super(app);
     this._registeredLocalRoutes = new Map();
-    this._swagger = new SwaggerGenerator();
+    this._swagger = new SwaggerGenerator(swaggerSecuritySchemes, globalSecurityHeaders);
     this.initializeRouter();
   }
 

--- a/packages/router/src/controllers/Rest/Rest.ts
+++ b/packages/router/src/controllers/Rest/Rest.ts
@@ -15,7 +15,7 @@ import {
   ConduitRouteActions,
   TYPE,
 } from '@conduitplatform/commons';
-import { SwaggerGenerator } from './Swagger';
+import { SwaggerGenerator, SwaggerRouterMetadata } from './Swagger';
 import { extractRequestData, validateParams } from './util';
 import { createHashKey, extractCaching } from '../cache.utils';
 import { ConduitRouter } from '../Router';
@@ -31,10 +31,10 @@ export class RestController extends ConduitRouter {
     return this._registeredRoutes;
   }
 
-  constructor(readonly app: Application, swaggerSecuritySchemes: any, globalSecurityHeaders: any) {
+  constructor(readonly app: Application, swaggerRouterMetadata: SwaggerRouterMetadata) {
     super(app);
     this._registeredLocalRoutes = new Map();
-    this._swagger = new SwaggerGenerator(swaggerSecuritySchemes, globalSecurityHeaders);
+    this._swagger = new SwaggerGenerator(swaggerRouterMetadata);
     this.initializeRouter();
   }
 

--- a/packages/router/src/controllers/Rest/Swagger.ts
+++ b/packages/router/src/controllers/Rest/Swagger.ts
@@ -18,6 +18,7 @@ export type SwaggerRouterMetadata = {
 export class SwaggerGenerator {
   private readonly _swaggerDoc: any;
   private readonly _routerMetadata: SwaggerRouterMetadata;
+  private readonly _stringifiedGlobalSecurityHeaders: string;
   private _parser: SwaggerParser;
 
   constructor(routerMetadata: SwaggerRouterMetadata) {
@@ -40,6 +41,7 @@ export class SwaggerGenerator {
     };
     this._parser = new SwaggerParser();
     this._routerMetadata = routerMetadata;
+    this._stringifiedGlobalSecurityHeaders = JSON.stringify(this._routerMetadata.globalSecurityHeaders);
   }
 
   get swaggerDoc() {
@@ -67,7 +69,7 @@ export class SwaggerGenerator {
           },
         },
       },
-      security: JSON.parse(JSON.stringify(this._routerMetadata.globalSecurityHeaders)),
+      security: JSON.parse(this._stringifiedGlobalSecurityHeaders),
     };
 
     if (!isNil(route.input.urlParams) && (route.input.urlParams as any) !== '') {

--- a/packages/router/src/controllers/Routing.ts
+++ b/packages/router/src/controllers/Routing.ts
@@ -10,6 +10,32 @@ import { GraphQLController } from './GraphQl/GraphQL';
 import { SocketController } from './Socket/Socket';
 import { SocketPush } from '../models/SocketPush.model';
 
+const swaggerSecuritySchemes = {
+  clientId: {
+    name: 'clientid',
+    type: 'apiKey',
+    in: 'header',
+    description: 'A security client id, retrievable through [POST] /security/client',
+  },
+  clientSecret: {
+    name: 'clientSecret',
+    type: 'apiKey',
+    in: 'header',
+    description: 'A security client secret, retrievable through [POST] /security/client',
+  },
+  userToken: {
+    type: 'http',
+    scheme: 'bearer',
+    bearerFormat: 'Bearer',
+    description: 'A user authentication token, retrievable through [POST] /authentication/local or [POST] /authentication/renew',
+  },
+}
+
+const globalSecurityHeaders = {
+  clientId: [],
+  clientSecret: [],
+}
+
 export class ConduitRoutingController {
   private _restRouter: RestController;
   private _graphQLRouter?: GraphQLController;
@@ -19,7 +45,7 @@ export class ConduitRoutingController {
 
   constructor(app: Application) {
     this._app = app;
-    this._restRouter = new RestController(this._app);
+    this._restRouter = new RestController(this._app, swaggerSecuritySchemes, globalSecurityHeaders);
     this._middlewareRouter = Router();
     this._middlewareRouter.use((req: Request, res: Response, next: NextFunction) => {
       next();

--- a/packages/router/src/controllers/Routing.ts
+++ b/packages/router/src/controllers/Routing.ts
@@ -37,6 +37,11 @@ const swaggerRouterMetadata: SwaggerRouterMetadata = {
     clientId: [],
     clientSecret: [],
   }],
+  setExtraRouteHeaders(route: ConduitRoute, swaggerRouteDoc: any): void {
+    if (route.input.middlewares?.includes('authMiddleware')) {
+      swaggerRouteDoc.security[0].userToken = [];
+    }
+  },
 };
 
 export class ConduitRoutingController {

--- a/packages/router/src/controllers/Routing.ts
+++ b/packages/router/src/controllers/Routing.ts
@@ -9,32 +9,35 @@ import {
 import { GraphQLController } from './GraphQl/GraphQL';
 import { SocketController } from './Socket/Socket';
 import { SocketPush } from '../models/SocketPush.model';
+import { SwaggerRouterMetadata } from './Rest';
 
-const swaggerSecuritySchemes = {
-  clientId: {
-    name: 'clientid',
-    type: 'apiKey',
-    in: 'header',
-    description: 'A security client id, retrievable through [POST] /security/client',
+const swaggerRouterMetadata: SwaggerRouterMetadata = {
+  urlPrefix: '',
+  securitySchemes: {
+    clientId: {
+      name: 'clientid',
+      type: 'apiKey',
+      in: 'header',
+      description: 'A security client id, retrievable through [POST] /security/client',
+    },
+    clientSecret: {
+      name: 'clientSecret',
+      type: 'apiKey',
+      in: 'header',
+      description: 'A security client secret, retrievable through [POST] /security/client',
+    },
+    userToken: {
+      type: 'http',
+      scheme: 'bearer',
+      bearerFormat: 'Bearer',
+      description: 'A user authentication token, retrievable through [POST] /authentication/local or [POST] /authentication/renew',
+    },
   },
-  clientSecret: {
-    name: 'clientSecret',
-    type: 'apiKey',
-    in: 'header',
-    description: 'A security client secret, retrievable through [POST] /security/client',
-  },
-  userToken: {
-    type: 'http',
-    scheme: 'bearer',
-    bearerFormat: 'Bearer',
-    description: 'A user authentication token, retrievable through [POST] /authentication/local or [POST] /authentication/renew',
-  },
-}
-
-const globalSecurityHeaders = {
-  clientId: [],
-  clientSecret: [],
-}
+  globalSecurityHeaders: [{
+    clientId: [],
+    clientSecret: [],
+  }],
+};
 
 export class ConduitRoutingController {
   private _restRouter: RestController;
@@ -45,7 +48,7 @@ export class ConduitRoutingController {
 
   constructor(app: Application) {
     this._app = app;
-    this._restRouter = new RestController(this._app, swaggerSecuritySchemes, globalSecurityHeaders);
+    this._restRouter = new RestController(this._app, swaggerRouterMetadata);
     this._middlewareRouter = Router();
     this._middlewareRouter.use((req: Request, res: Response, next: NextFunction) => {
       next();


### PR DESCRIPTION
Closes #80 and generally improves Swagger route doc generation.
- Admin routes are now properly prefixed by `/admin/` so that Swagger users no longer need to guess the proper baseUrl.
- Admin routes now require proper admin headers.

This PR also converts Admin router's `Authentication` header format from `JWT adminToken` to `Bearer adminToken`.
This change improves compatibility with OpenAPI and Swagger, while also improving consistency with user authentication.

This bit is not a breaking change as backwards compatibility has been preserved.

**What kind of change does this PR introduce?** (check at least one)

- [X] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [X] No

**The PR fulfills these requirements:**

- [X] It's submitted to the `main` branch
- [X] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx`, where "xxx" is the issue number)
