### PR TITLE
v0.10 backport sockets

### DIFF
--- a/libraries/grpc-sdk/src/classes/ConduitModule.ts
+++ b/libraries/grpc-sdk/src/classes/ConduitModule.ts
@@ -1,4 +1,5 @@
 import { ChannelCredentials, ChannelOptions, Client, credentials } from '@grpc/grpc-js';
+import { getModuleNameInterceptor } from '../interceptors';
 
 export class ConduitModule<T extends Client> {
   // protected descriptorObj?: string;
@@ -11,11 +12,15 @@ export class ConduitModule<T extends Client> {
     ): T;
   };
   protected client?: T;
-  protected readonly _url: string;
   protected protoPath?: string;
+  protected readonly _url: string;
+  protected readonly _name: string;
+  private readonly _interceptors: any[];
 
-  constructor(url: string) {
+  constructor(name: string, url: string) {
+    this._name = name;
     this._url = url;
+    this._interceptors = [getModuleNameInterceptor(this._name)];
   }
 
   initializeClient(constObj?: {
@@ -31,10 +36,15 @@ export class ConduitModule<T extends Client> {
     } else if (!this.constructorObj && !constObj) {
       throw new Error('Client cannot be initialized, both constructor objects are null!');
     }
-    this.client = new this.constructorObj!(this._url, credentials.createInsecure(), {
-      'grpc.max_receive_message_length': 1024 * 1024 * 100,
-      'grpc.max_send_message_length': 1024 * 1024 * 100,
-    });
+    this.client = new this.constructorObj!(
+      this._url,
+      credentials.createInsecure(),
+      {
+        'grpc.max_receive_message_length': 1024 * 1024 * 100,
+        'grpc.max_send_message_length': 1024 * 1024 * 100,
+        interceptors: this._interceptors,
+      }
+    );
     this.active = true;
   }
 

--- a/libraries/grpc-sdk/src/index.ts
+++ b/libraries/grpc-sdk/src/index.ts
@@ -49,9 +49,9 @@ export default class ConduitGrpcSdk {
       this.name = name;
     }
     this.serverUrl = serverUrl;
-    this._config = new Config(this.serverUrl);
-    this._admin = new Admin(this.serverUrl, this.name);
-    this._router = new Router(this.serverUrl, this.name);
+    this._config = new Config(this.name, this.serverUrl);
+    this._admin = new Admin(this.name, this.serverUrl);
+    this._router = new Router(this.name, this.serverUrl);
     this.initializeModules().then(() => {});
     this.watchModules();
   }
@@ -186,7 +186,7 @@ export default class ConduitGrpcSdk {
       });
       modules.forEach((m: any) => {
         if (!this._modules[m.moduleName] && this._availableModules[m.moduleName]) {
-          this._modules[m.moduleName] = new this._availableModules[m.moduleName](m.url);
+          this._modules[m.moduleName] = new this._availableModules[m.moduleName](m.moduleName, m.url);
         } else if (this._availableModules[m.moduleName]) {
           this._modules[m.moduleName]?.initializeClient();
         }
@@ -220,7 +220,7 @@ export default class ConduitGrpcSdk {
         this.lastSearch = Date.now();
         r.forEach((m) => {
           if (!this._modules[m.moduleName] && this._availableModules[m.moduleName]) {
-            this._modules[m.moduleName] = new this._availableModules[m.moduleName](m.url);
+            this._modules[m.moduleName] = new this._availableModules[m.moduleName](m.moduleName, m.url);
           }
         });
         return 'ok';

--- a/libraries/grpc-sdk/src/interceptors/index.ts
+++ b/libraries/grpc-sdk/src/interceptors/index.ts
@@ -1,0 +1,1 @@
+export * from './moduleName';

--- a/libraries/grpc-sdk/src/interceptors/moduleName.ts
+++ b/libraries/grpc-sdk/src/interceptors/moduleName.ts
@@ -1,0 +1,20 @@
+import { Metadata, InterceptingCall } from '@grpc/grpc-js';
+
+export function getModuleNameInterceptor(moduleName: string) {
+  return (options: any, nextCall: Function) => {
+    return new InterceptingCall(nextCall(options), {
+      start: (metadata, _, next) => {
+        // outbound
+        metadata.set('module-name', moduleName);
+        const newListener = {
+          // inbound
+          onReceiveMetadata: function (metadata: Metadata, next: Function) {
+            metadata.set('module-name', moduleName);
+            next(metadata);
+          },
+        };
+        next(metadata, newListener);
+      },
+    });
+  };
+}

--- a/libraries/grpc-sdk/src/modules/admin/index.ts
+++ b/libraries/grpc-sdk/src/modules/admin/index.ts
@@ -27,8 +27,8 @@ message AdminResponse {
 `;
 
 export class Admin extends ConduitModule<AdminClient> {
-  constructor(url: string, private readonly moduleName: string) {
-    super(url);
+  constructor(private readonly moduleName: string, url: string) {
+    super(moduleName, url);
     this.initializeClient(AdminClient);
   }
 

--- a/libraries/grpc-sdk/src/modules/authentication/index.ts
+++ b/libraries/grpc-sdk/src/modules/authentication/index.ts
@@ -9,8 +9,8 @@ import {
 import { ServiceError } from '@grpc/grpc-js';
 
 export class Authentication extends ConduitModule<AuthenticationClient> {
-  constructor(url: string) {
-    super(url);
+  constructor(moduleName: string, url: string) {
+    super(moduleName, url);
     this.initializeClient(AuthenticationClient);
   }
 

--- a/libraries/grpc-sdk/src/modules/chat/index.ts
+++ b/libraries/grpc-sdk/src/modules/chat/index.ts
@@ -8,8 +8,8 @@ import {
 import { ServiceError } from '@grpc/grpc-js';
 
 export class Chat extends ConduitModule<ChatClient> {
-  constructor(url: string) {
-    super(url);
+  constructor(moduleName: string, url: string) {
+    super(moduleName, url);
     this.initializeClient(ChatClient);
   }
 

--- a/libraries/grpc-sdk/src/modules/cms/index.ts
+++ b/libraries/grpc-sdk/src/modules/cms/index.ts
@@ -2,8 +2,8 @@ import { ConduitModule } from '../../classes/ConduitModule';
 import { CMSClient } from '../../protoUtils/cms';
 
 export class CMS extends ConduitModule<CMSClient> {
-  constructor(url: string) {
-    super(url);
+  constructor(moduleName: string, url: string) {
+    super(moduleName, url);
     this.initializeClient(CMSClient);
   }
 }

--- a/libraries/grpc-sdk/src/modules/config/index.ts
+++ b/libraries/grpc-sdk/src/modules/config/index.ts
@@ -6,8 +6,8 @@ export class Config extends ConduitModule<ConfigClient> {
   private emitter = new EventEmitter();
   private coreLive = false;
 
-  constructor(url: string) {
-    super(url);
+  constructor(moduleName: string, url: string) {
+    super(moduleName, url);
     this.initializeClient(ConfigClient);
   }
 

--- a/libraries/grpc-sdk/src/modules/databaseProvider/index.ts
+++ b/libraries/grpc-sdk/src/modules/databaseProvider/index.ts
@@ -3,8 +3,8 @@ import { DatabaseProviderClient } from '../../protoUtils/database-provider';
 import { ConduitSchema } from '../../classes';
 
 export class DatabaseProvider extends ConduitModule<DatabaseProviderClient> {
-  constructor(url: string) {
-    super(url);
+  constructor(moduleName: string, url: string) {
+    super(moduleName, url);
     this.initializeClient(DatabaseProviderClient);
   }
 

--- a/libraries/grpc-sdk/src/modules/email/index.ts
+++ b/libraries/grpc-sdk/src/modules/email/index.ts
@@ -2,8 +2,8 @@ import { ConduitModule } from '../../classes/ConduitModule';
 import { EmailClient } from '../../protoUtils/email';
 
 export class Email extends ConduitModule<EmailClient> {
-  constructor(url: string) {
-    super(url);
+  constructor(moduleName: string, url: string) {
+    super(moduleName, url);
     this.initializeClient(EmailClient);
   }
 

--- a/libraries/grpc-sdk/src/modules/forms/index.ts
+++ b/libraries/grpc-sdk/src/modules/forms/index.ts
@@ -2,22 +2,23 @@ import { ConduitModule } from "../../classes/ConduitModule";
 import { FormsClient } from "../../protoUtils/forms";
 
 export class Forms extends ConduitModule<FormsClient>{
-    constructor(url: string) {
-        super(url);
-        this.initializeClient(FormsClient);
-    }
-    setConfig(newConfig: any) {
-      return new Promise((resolve, reject) => {
-        this.client?.setConfig(
-          { newConfig: JSON.stringify(newConfig) },
-          (err: any, res: any) => {
-            if (err || !res) {
-              reject(err || 'Something went wrong');
-            } else {
-              resolve(JSON.parse(res.updatedConfig));
-            }
+  constructor(moduleName: string, url: string) {
+    super(moduleName, url);
+    this.initializeClient(FormsClient);
+  }
+
+  setConfig(newConfig: any) {
+    return new Promise((resolve, reject) => {
+      this.client?.setConfig(
+        { newConfig: JSON.stringify(newConfig) },
+        (err: any, res: any) => {
+          if (err || !res) {
+            reject(err || 'Something went wrong');
+          } else {
+            resolve(JSON.parse(res.updatedConfig));
           }
-        );
-      });
-    }
+        }
+      );
+    });
+  }
 }

--- a/libraries/grpc-sdk/src/modules/payments/index.ts
+++ b/libraries/grpc-sdk/src/modules/payments/index.ts
@@ -2,8 +2,8 @@ import { ConduitModule } from '../../classes/ConduitModule';
 import { PaymentsClient } from '../../protoUtils/payments';
 
 export class Payments extends ConduitModule<PaymentsClient> {
-  constructor(url: string) {
-    super(url);
+  constructor(moduleName: string, url: string) {
+    super(moduleName, url);
     this.initializeClient(PaymentsClient);
   }
 

--- a/libraries/grpc-sdk/src/modules/pushNotifications/index.ts
+++ b/libraries/grpc-sdk/src/modules/pushNotifications/index.ts
@@ -2,8 +2,8 @@ import { ConduitModule } from '../../classes/ConduitModule';
 import { PushNotificationsClient } from '../../protoUtils/push-notifications';
 
 export class PushNotifications extends ConduitModule<PushNotificationsClient> {
-  constructor(url: string) {
-    super(url);
+  constructor(moduleName: string, url: string) {
+    super(moduleName, url);
     this.initializeClient(PushNotificationsClient);
   }
 

--- a/libraries/grpc-sdk/src/modules/router/index.ts
+++ b/libraries/grpc-sdk/src/modules/router/index.ts
@@ -41,8 +41,8 @@ message SocketResponse {
 }
 `;
 export class Router extends ConduitModule<RouterClient> {
-  constructor(url: string, private readonly moduleName: string) {
-    super(url);
+  constructor(private readonly moduleName: string, url: string) {
+    super(moduleName, url);
     this.initializeClient(RouterClient);
   }
 

--- a/libraries/grpc-sdk/src/modules/sms/index.ts
+++ b/libraries/grpc-sdk/src/modules/sms/index.ts
@@ -9,8 +9,8 @@ import {
 import { ServiceError } from '@grpc/grpc-js';
 
 export class SMS extends ConduitModule<SmsClient> {
-  constructor(url: string) {
-    super(url);
+  constructor(moduleName: string, url: string) {
+    super(moduleName, url);
     this.initializeClient(SmsClient);
   }
 

--- a/libraries/grpc-sdk/src/modules/storage/index.ts
+++ b/libraries/grpc-sdk/src/modules/storage/index.ts
@@ -3,8 +3,8 @@ import { FileResponse, GetFileDataResponse, SetConfigResponse, StorageClient } f
 import { ServiceError } from '@grpc/grpc-js';
 
 export class Storage extends ConduitModule<StorageClient> {
-  constructor(url: string) {
-    super(url);
+  constructor(moduleName: string, url: string) {
+    super(moduleName, url);
     this.initializeClient(StorageClient);
   }
 

--- a/packages/router/src/index.ts
+++ b/packages/router/src/index.ts
@@ -184,7 +184,7 @@ export class ConduitDefaultRouter implements IConduitRouter {
         );
         this.registerRouteMiddleware(r);
       } else if (r instanceof ConduitSocket) {
-        console.log('New socker registered: ' + r.input.path + ' handler url: ' + url);
+        console.log('New socket registered: ' + r.input.path + ' handler url: ' + url);
         this.registerSocket(r);
       } else {
         console.log(
@@ -209,6 +209,7 @@ export class ConduitDefaultRouter implements IConduitRouter {
         data: JSON.parse(call.request.data),
         receivers: call.request.receivers,
         rooms: call.request.rooms,
+        namespace: `/${(call as any).metadata.get('module-name')[0]}/`
       };
       await this._internalRouter.socketPush(socketData);
     } catch (err) {

--- a/packages/router/src/models/SocketPush.model.ts
+++ b/packages/router/src/models/SocketPush.model.ts
@@ -3,4 +3,5 @@ export interface SocketPush {
   data: any;
   receivers: string[];
   rooms: string[];
+  namespace: string;
 }


### PR DESCRIPTION
Backport of #82 for v0.10.
This also backports 'module-name' being passed as gRPC call metadata due to the socket fix depending on it.

**What kind of change does this PR introduce?** (check at least one)

- [X] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [X] No