### PR TITLE
chore: bump Makefile backend tag (v0.12.4)

### DIFF
--- a/docker/Makefile
+++ b/docker/Makefile
@@ -15,7 +15,7 @@
 
 # ------ Default Values ------ #
 
-TAG         ?= v0.12.3
+TAG         ?= v0.12.4
 UI_TAG      ?= v0.12.0
 DOCKER      ?= docker
 CONTAINER_NETWORK_NAME ?= "conduit"


### PR DESCRIPTION
Bumped backend container tags to v0.12.4.

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [X] Other, please describe:

Container Makefile update.

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [X] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [X] It's submitted to the `main` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx`, where "xxx" is the issue number)
