### PR TITLE
fix(authentication): googleHandlers being validated in place of githubHandlers (backport #101)

### DIFF
--- a/modules/authentication/src/routes/routes.ts
+++ b/modules/authentication/src/routes/routes.ts
@@ -274,7 +274,7 @@ export class AuthenticationRoutes {
 
     this.githubHandlers = new GithubHandlers(this.grpcSdk, this._routingController, new GithubSettings(this.grpcSdk, config, serverConfig.url));
     errorMessage = null;
-    authActive = await this.googleHandlers
+    authActive = await this.githubHandlers
       .validate()
       .catch((e: any) => (errorMessage = e));
     if (!errorMessage && authActive) {


### PR DESCRIPTION
Backport of #101 for v0.11.

Google handlers were getting re-validated in place of Github handlers.
Way more importantly, this fixes Authentication not registering certain routes on initial config request (eg local auth login after setting username identifier)!

**What kind of change does this PR introduce?** (check at least one)

- [X] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [X] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [X] It's submitted to the `main` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx`, where "xxx" is the issue number)
