### PR TITLE
fix(email,authentication,forms): email activation bus event pub/sub

### DIFF
--- a/modules/authentication/src/Authentication.ts
+++ b/modules/authentication/src/Authentication.ts
@@ -45,16 +45,14 @@ export default class Authentication extends ManagedModule {
   }
 
   async onRegister() {
-    this.grpcSdk.bus!.subscribe('email:status:activated', (message: string) => {
-      if (message === 'enabled') {
-        this.onConfig()
-          .then(() => {
-            console.log('Updated authentication configuration');
-          })
-          .catch(() => {
-            console.log('Failed to update authentication config');
-          });
-      }
+    this.grpcSdk.bus!.subscribe('email:status:onConfig', _ => {
+      this.onConfig()
+        .then(() => {
+          console.log('Updated authentication configuration');
+        })
+        .catch(() => {
+          console.log('Failed to update authentication config');
+        });
     });
   }
 

--- a/modules/email/src/Email.ts
+++ b/modules/email/src/Email.ts
@@ -88,11 +88,14 @@ export default class Email extends ManagedModule {
       this.adminRouter = new AdminHandlers(this.grpcServer, this.grpcSdk);
       this.adminRouter.setEmailService(this.emailService);
       this.isRunning = true;
-      this.grpcSdk.bus?.publish('email:status:activated', '');
     } else {
       await this.initEmailProvider(ConfigController.getInstance().config);
       this.emailService.updateProvider(this.emailProvider);
     }
+    this.grpcSdk.bus?.publish(
+      'email:status:onConfig',
+      this.isRunning ? 'active' : 'inactive',
+    );
   }
 
   private async initEmailProvider(newConfig?: any) {

--- a/modules/forms/src/Forms.ts
+++ b/modules/forms/src/Forms.ts
@@ -33,8 +33,8 @@ export default class Forms extends ManagedModule {
   }
 
   async onRegister() {
-    this.grpcSdk.bus!.subscribe('email-provider:status:activated', (message: string) => {
-      if (message === 'enabled') {
+    this.grpcSdk.bus!.subscribe('email:status:onConfig', (message: string) => {
+      if (message === 'active') {
         this.onConfig()
           .then(() => {
             console.log('Updated forms configuration');


### PR DESCRIPTION
Fixes #104.

Authentication's bus subscription to `email:status:onConfig` no longer triggers its own reconfiguration exclusively on an active Email configuration update, but in any Email config event.
This change is intentional and should pave the way towards Authentication being capable of handling email service going down (due to provider issues for instance as we don't support explicit module deactivation) once we actually introduce any such checks in Email.

Notice: Authentication no longer assumes Email service is available on local auth after #103.

**What kind of change does this PR introduce?** (check at least one)

- [X] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [X] No

**The PR fulfills these requirements:**

- [X] It's submitted to the `main` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx`, where "xxx" is the issue number)
