### PR TITLE
fix(router): socket emits with specified receivers misbehaving (backport #109)

### DIFF
--- a/packages/router/src/controllers/Socket/Socket.ts
+++ b/packages/router/src/controllers/Socket/Socket.ts
@@ -151,13 +151,7 @@ export class SocketController extends ConduitRouter {
       if (isNil(push.receivers) || push.receivers!.length === 0) {
         this.io.of(push.namespace).emit(push.event, push.data);
       } else {
-        this.io.of(push.namespace).adapter.fetchSockets({
-          rooms: new Set(push.receivers)
-        }).then(sockets => {
-          sockets.forEach(r => {
-            r.to(push.receivers).emit(push.event, push.data);
-          })
-        })
+        this.io.of(push.namespace).to(push.receivers).emit(push.event, push.data);
       }
     } else {
       throw new Error('Cannot join room in this context');


### PR DESCRIPTION
Backport of #109 for v10.
Socket behavior was retested before and after backport.

**What kind of change does this PR introduce?** (check at least one)

- [X] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [X] No
