### PR TITLE
Makefile fixes and updates (v0.12.5)

### DIFF
--- a/docker/Makefile
+++ b/docker/Makefile
@@ -1,4 +1,4 @@
-.PHONY: zero-to-hero setup create-network start-conduit start-all stop-all clean mrproper \
+.PHONY: zero-to-hero setup create-network start-conduit start-all stop-all clean mrproper update \
 				start-core stop-core rm-core rmi-core \
 				start-authentication stop-authentication rm-authentication rmi-authentication \
 				start-chat stop-chat rm-chat rmi-chat \
@@ -144,6 +144,11 @@ mrproper:
 	else \
 		echo "Network already removed"; \
 	fi
+
+update:
+	@rm $(abspath $(lastword $(MAKEFILE_LIST)))
+	curl -L https://raw.githubusercontent.com/ConduitPlatform/Conduit/main/docker/Makefile > \
+		$(abspath $(lastword $(MAKEFILE_LIST)))
 
 # ----- Docker Functions ----- #
 

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -15,8 +15,8 @@
 
 # ------ Default Values ------ #
 
-TAG         ?= v0.12.4
-UI_TAG      ?= v0.12.0
+TAG         ?= v0.12.5
+UI_TAG      ?= v0.12.1
 DOCKER      ?= docker
 CONTAINER_NETWORK_NAME ?= "conduit"
 CONDUIT_CORE_NETWORK_NAME = conduit
@@ -126,9 +126,6 @@ mrproper:
 # 	@$(MAKE) --no-print-directory rmi-redis
 # 	@$(MAKE) --no-print-directory rmi-mongo
 # 	@$(MAKE) --no-print-directory rmi-postgres
-	@$(MAKE) --no-print-directory rm-redis
-	@$(MAKE) --no-print-directory rm-mongo
-	@$(MAKE) --no-print-directory rm-postgres
 	@$(MAKE) --no-print-directory rmi-ui
 	@$(MAKE) --no-print-directory rmi-core
 	@$(MAKE) --no-print-directory rmi-authentication
@@ -212,9 +209,9 @@ start-chat:
 	       -d -e REGISTER_NAME="true" -e CONDUIT_SERVER="conduit-core:55152")
 
 start-database:
-	@if [ ${DB_TYPE} == "mongodb" ]; then \
+	@if [ ${DB_TYPE} = "mongodb" ]; then \
 		make start-mongo; \
-	elif [ ${DB_TYPE} == "postgres" ]; then \
+	elif [ ${DB_TYPE} = "postgres" ]; then \
 		make start-postgres; \
 	else \
 		printf "\nInvalid DB_TYPE override. Choose between 'mongodb' and 'postgres' (default: mongodb)\n"; \
@@ -252,7 +249,7 @@ start-storage:
 
 start-ui:
 	$(call start,Conduit Admin Panel,conduit-ui,ghcr.io/conduitplatform/conduit-ui,${UI_TAG},conduit-ui,yarn start, \
-	       -d -p 8080:8080 -e CONDUIT_URL=${CONDUIT_URL})
+	       -d -p 8080:8080 -e CONDUIT_URL=${CONDUIT_URL} -e MASTER_KEY=${MASTER_KEY})
 
 start-redis:
 	$(call start,Redis,conduit-redis,docker.io/library/redis,latest,redis,redis-server,-d -p 6379:6379)

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -62,7 +62,7 @@ start-conduit:
 	@$(MAKE) --no-print-directory start-core
 	@sleep 3
 	@$(MAKE) --no-print-directory start-database
-	@sleep 0.5
+	@sleep 2
 	@$(MAKE) --no-print-directory start-authentication
 	@$(MAKE) --no-print-directory start-ui
 
@@ -70,7 +70,7 @@ start-all:
 	@$(MAKE) --no-print-directory start-conduit
 	@sleep 1
 	@$(MAKE) --no-print-directory start-database
-	@sleep 0.5
+	@sleep 2
 	@$(MAKE) --no-print-directory start-authentication
 	@sleep 0.2
 	@$(MAKE) --no-print-directory start-chat

--- a/docker/get-conduit.sh
+++ b/docker/get-conduit.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-TAG=master
+TAG=main
 
 curl -L https://raw.githubusercontent.com/ConduitPlatform/Conduit/$TAG/docker/Makefile > Makefile
 make zero-to-hero


### PR DESCRIPTION
Bumped Conduit version to 0.12.5.
Bumped Conduit UI version to 0.12.1.
Fixed UI container missing `MASTER_KEY` env var (issue ever since master key fix in 0.12.4).
Added an `update` target to conveniently replace the `Makefile` with the latest version available without the users actively looking it up.
Most likely fixed a string comparison check in `start-database`.

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [X] Other, please describe:

Makefile related updates, fixes, additions.

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [X] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [X] It's submitted to the `main` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx`, where "xxx" is the issue number)