### PR TITLE
Cookies #23dq8hb

### DIFF
--- a/libraries/grpc-sdk/src/helpers/RoutingUtilities.ts
+++ b/libraries/grpc-sdk/src/helpers/RoutingUtilities.ts
@@ -44,6 +44,10 @@ message Options {
   bool secure = 2;
   bool signed = 3;
   int32 maxAge = 4;
+  string path = 5;
+  string domain = 6;
+  string sameSite = 7;
+  
 }
 message SocketResponse {
   string event = 1;

--- a/libraries/grpc-sdk/src/helpers/RoutingUtilities.ts
+++ b/libraries/grpc-sdk/src/helpers/RoutingUtilities.ts
@@ -24,6 +24,7 @@ message RouterResponse {
   string redirect = 2;
   repeated Cookie setCookies = 3;
   repeated string removeCookies = 4;
+  Options cookieOptions = 5;
 }
 
 message SocketRequest {

--- a/libraries/grpc-sdk/src/helpers/RoutingUtilities.ts
+++ b/libraries/grpc-sdk/src/helpers/RoutingUtilities.ts
@@ -22,8 +22,8 @@ message RouterRequest {
 message RouterResponse {
   string result = 1;
   string redirect = 2;
-  optional string setCookies = 3;
-  optional string removeCookies = 4;
+  repeated Cookie setCookies = 3;
+  repeated string removeCookies = 4;
 }
 
 message SocketRequest {
@@ -33,6 +33,18 @@ message SocketRequest {
   string context = 4;
 }
 
+message Cookie {
+  string name = 1;
+  string value = 2;
+  Options options = 3;
+}
+
+message Options {
+  bool httpOnly = 1;
+  bool secure = 2;
+  bool signed = 3;
+  int32 maxAge = 4;
+}
 message SocketResponse {
   string event = 1;
   string data = 2;

--- a/libraries/grpc-sdk/src/helpers/RoutingUtilities.ts
+++ b/libraries/grpc-sdk/src/helpers/RoutingUtilities.ts
@@ -23,8 +23,7 @@ message RouterResponse {
   string result = 1;
   string redirect = 2;
   repeated Cookie setCookies = 3;
-  repeated string removeCookies = 4;
-  Options cookieOptions = 5;
+  repeated Cookie removeCookies = 4;
 }
 
 message SocketRequest {
@@ -36,7 +35,7 @@ message SocketRequest {
 
 message Cookie {
   string name = 1;
-  string value = 2;
+  optional string value = 2;
   Options options = 3;
 }
 

--- a/libraries/grpc-sdk/src/helpers/RoutingUtilities.ts
+++ b/libraries/grpc-sdk/src/helpers/RoutingUtilities.ts
@@ -22,6 +22,8 @@ message RouterRequest {
 message RouterResponse {
   string result = 1;
   string redirect = 2;
+  optional string setCookies = 3;
+  optional string removeCookies = 4;
 }
 
 message SocketRequest {

--- a/libraries/grpc-sdk/src/helpers/wrapRouterFunctions.ts
+++ b/libraries/grpc-sdk/src/helpers/wrapRouterFunctions.ts
@@ -72,8 +72,8 @@ export function wrapRouterGrpcFunction(
             if (r.removeCookies || r.setCookies) {
               return callback(null, {
                 result: result,
-                removeCookies: r.removeCookies ?? undefined,
-                setCookies: JSON.stringify(r.setCookies) ?? undefined,
+                removeCookies: r.removeCookies,
+                setCookies: r.setCookies,
               });
             }
             if (r.result || r.redirect) {

--- a/libraries/grpc-sdk/src/helpers/wrapRouterFunctions.ts
+++ b/libraries/grpc-sdk/src/helpers/wrapRouterFunctions.ts
@@ -69,16 +69,11 @@ export function wrapRouterGrpcFunction(
             callback(null, { result: r });
           } else {
             const result = r.result ? JSON.stringify(r.result) : undefined;
-            if (r.removeCookies) {
-              callback(null, {
+            if (r.removeCookies || r.setCookies) {
+              return callback(null, {
                 result: result,
-                removeCookies: r.removeCookies,
-              });
-            }
-            if (r.setCookies) {
-              callback(null, {
-                result: result,
-                setCookies: JSON.stringify(r.setCookies),
+                removeCookies: r.removeCookies ?? undefined,
+                setCookies: JSON.stringify(r.setCookies) ?? undefined,
               });
             }
             if (r.result || r.redirect) {

--- a/libraries/grpc-sdk/src/helpers/wrapRouterFunctions.ts
+++ b/libraries/grpc-sdk/src/helpers/wrapRouterFunctions.ts
@@ -72,14 +72,16 @@ export function wrapRouterGrpcFunction(
             if (r.removeCookies) {
               callback(null, {
                 result: result,
-                removeCookies: JSON.stringify(r.removeCookies),
+                removeCookies: r.removeCookies,
               });
-            } else if (r.setCookies) {
+            }
+            if (r.setCookies) {
               callback(null, {
                 result: result,
                 setCookies: JSON.stringify(r.setCookies),
               });
-            } else if (r.result || r.redirect) {
+            }
+            if (r.result || r.redirect) {
               callback(null, {
                 redirect: r.redirect ?? undefined,
                 result: result,

--- a/libraries/grpc-sdk/src/helpers/wrapRouterFunctions.ts
+++ b/libraries/grpc-sdk/src/helpers/wrapRouterFunctions.ts
@@ -72,6 +72,7 @@ export function wrapRouterGrpcFunction(
             if (r.removeCookies || r.setCookies) {
               respObject = {
                 removeCookies: r.removeCookies,
+                cookieOptions: r.cookieOptions,
                 setCookies: r.setCookies,
               };
             }

--- a/libraries/grpc-sdk/src/helpers/wrapRouterFunctions.ts
+++ b/libraries/grpc-sdk/src/helpers/wrapRouterFunctions.ts
@@ -68,23 +68,22 @@ export function wrapRouterGrpcFunction(
           if (typeof r === 'string') {
             callback(null, { result: r });
           } else {
-            const result = r.result ? JSON.stringify(r.result) : undefined;
+            let respObject;
             if (r.removeCookies || r.setCookies) {
-              return callback(null, {
-                result: result,
+              respObject = {
                 removeCookies: r.removeCookies,
                 setCookies: r.setCookies,
-              });
+              };
             }
             if (r.result || r.redirect) {
               callback(null, {
+                ...respObject,
                 redirect: r.redirect ?? undefined,
-                result: result,
+                result: r.result ? JSON.stringify(r.result) : undefined,
               });
             } else {
-              callback(null, { result: JSON.stringify(r) });
+              callback(null, { ...respObject, result: JSON.stringify(r) });
             }
-
           }
         } else {
           if (r.hasOwnProperty('data')) (r as any).data = JSON.stringify((r as any).data);

--- a/libraries/grpc-sdk/src/helpers/wrapRouterFunctions.ts
+++ b/libraries/grpc-sdk/src/helpers/wrapRouterFunctions.ts
@@ -72,7 +72,6 @@ export function wrapRouterGrpcFunction(
             if (r.removeCookies || r.setCookies) {
               respObject = {
                 removeCookies: r.removeCookies,
-                cookieOptions: r.cookieOptions,
                 setCookies: r.setCookies,
               };
             }

--- a/libraries/grpc-sdk/src/helpers/wrapRouterFunctions.ts
+++ b/libraries/grpc-sdk/src/helpers/wrapRouterFunctions.ts
@@ -49,9 +49,6 @@ export function wrapRouterGrpcFunction(
       call.request.params = parseRequestData(call.request.params);
 
       routerRequest = !call.request.hasOwnProperty('event');
-      if (routerRequest) {
-        call.request.headers = parseRequestData(call.request.headers);
-      }
     } catch (e) {
       generateLog(routerRequest, requestReceive, call, status.INTERNAL);
       console.log(e.message ?? 'Something went wrong');

--- a/libraries/grpc-sdk/src/types/index.ts
+++ b/libraries/grpc-sdk/src/types/index.ts
@@ -28,7 +28,7 @@ export type ParsedRouterRequest = GrpcRequest<{
 }>;
 
 export type UnparsedRouterResponse =
-  | { result?: { [key: string]: any }; redirect?: string, setCookies?: { [key: string]: any }, removeCookies?: string }
+  | { result?: { [key: string]: any }; redirect?: string, setCookies?: { [key: string]: any }, removeCookies?: string[] }
   | { [key: string]: any }
   | string;
 

--- a/libraries/grpc-sdk/src/types/index.ts
+++ b/libraries/grpc-sdk/src/types/index.ts
@@ -28,7 +28,7 @@ export type ParsedRouterRequest = GrpcRequest<{
 }>;
 
 export type UnparsedRouterResponse =
-  | { result?: { [key: string]: any }; redirect?: string, setCookies: { [key: string]: any }, removeCookies: string[] }
+  | { result?: { [key: string]: any }; redirect?: string, setCookies: { [key: string]: any }, removeCookies: string[], cookieOptions: { [key: string]: any } }
   | { [key: string]: any }
   | string;
 

--- a/libraries/grpc-sdk/src/types/index.ts
+++ b/libraries/grpc-sdk/src/types/index.ts
@@ -28,7 +28,7 @@ export type ParsedRouterRequest = GrpcRequest<{
 }>;
 
 export type UnparsedRouterResponse =
-  | { result?: { [key: string]: any }; redirect?: string, setCookies?: { [key: string]: any }, removeCookies?: { [key: string]: any } }
+  | { result?: { [key: string]: any }; redirect?: string, setCookies?: { [key: string]: any }, removeCookies?: string }
   | { [key: string]: any }
   | string;
 

--- a/libraries/grpc-sdk/src/types/index.ts
+++ b/libraries/grpc-sdk/src/types/index.ts
@@ -28,7 +28,7 @@ export type ParsedRouterRequest = GrpcRequest<{
 }>;
 
 export type UnparsedRouterResponse =
-  | { result?: { [key: string]: any }; redirect?: string, setCookies?: { [key: string]: any }, removeCookies?: string[] }
+  | { result?: { [key: string]: any }; redirect?: string, setCookies: { [key: string]: any }, removeCookies: string[] }
   | { [key: string]: any }
   | string;
 

--- a/libraries/grpc-sdk/src/types/index.ts
+++ b/libraries/grpc-sdk/src/types/index.ts
@@ -28,7 +28,7 @@ export type ParsedRouterRequest = GrpcRequest<{
 }>;
 
 export type UnparsedRouterResponse =
-  | { result?: { [key: string]: any }; redirect?: string }
+  | { result?: { [key: string]: any }; redirect?: string, setCookies?: { [key: string]: any }, removeCookies?: { [key: string]: any } }
   | { [key: string]: any }
   | string;
 

--- a/libraries/grpc-sdk/src/types/index.ts
+++ b/libraries/grpc-sdk/src/types/index.ts
@@ -28,7 +28,7 @@ export type ParsedRouterRequest = GrpcRequest<{
 }>;
 
 export type UnparsedRouterResponse =
-  | { result?: { [key: string]: any }; redirect?: string, setCookies: { [key: string]: any }, removeCookies: string[], cookieOptions: { [key: string]: any } }
+  | { result?: { [key: string]: any }; redirect?: string, setCookies: { [key: string]: any }, removeCookies: { [key: string]: any } }
   | { [key: string]: any }
   | string;
 

--- a/modules/authentication/src/config/config.ts
+++ b/modules/authentication/src/config/config.ts
@@ -249,6 +249,18 @@ export default {
         format: 'Number',
         default: 900000,
       },
+      domain: {
+        format: 'String',
+        default: ''
+      },
+      path: {
+        format: 'String',
+        default: '',
+      },
+      sameSite: {
+        format: 'String',
+        default: 'Lax',
+      },
     },
   },
   generateRefreshToken: {

--- a/modules/authentication/src/config/config.ts
+++ b/modules/authentication/src/config/config.ts
@@ -204,7 +204,7 @@ export default {
     },
     accountLinking: {
       doc:
-          'When enabled, if a new twitch user matches with an existing email on the database, they will be enriched with twitch details',
+        'When enabled, if a new twitch user matches with an existing email on the database, they will be enriched with twitch details',
       format: 'Boolean',
       default: true,
     },
@@ -222,6 +222,12 @@ export default {
     },
   },
   phoneAuthentication: {
+    enabled: {
+      format: 'Boolean',
+      default: false,
+    },
+  },
+  set_cookies: {
     enabled: {
       format: 'Boolean',
       default: false,

--- a/modules/authentication/src/config/config.ts
+++ b/modules/authentication/src/config/config.ts
@@ -251,11 +251,11 @@ export default {
       },
       domain: {
         format: 'String',
-        default: ''
+        default: '',
       },
       path: {
         format: 'String',
-        default: '',
+        default: null,
       },
       sameSite: {
         format: 'String',

--- a/modules/authentication/src/config/config.ts
+++ b/modules/authentication/src/config/config.ts
@@ -255,7 +255,7 @@ export default {
       },
       path: {
         format: 'String',
-        default: null,
+        default: '',
       },
       sameSite: {
         format: 'String',

--- a/modules/authentication/src/config/config.ts
+++ b/modules/authentication/src/config/config.ts
@@ -227,10 +227,28 @@ export default {
       default: false,
     },
   },
-  set_cookies: {
+  setCookies: {
     enabled: {
       format: 'Boolean',
       default: false,
+    },
+    options: {
+      httpOnly: {
+        format: 'Boolean',
+        default: false,
+      },
+      secure: {
+        format: 'Boolean',
+        default: false,
+      },
+      signed: {
+        format: 'Boolean',
+        default: false,
+      },
+      maxAge: {
+        format: 'Number',
+        default: 900000,
+      },
     },
   },
   generateRefreshToken: {

--- a/modules/authentication/src/handlers/AuthenticationProviders/OAuth2.ts
+++ b/modules/authentication/src/handlers/AuthenticationProviders/OAuth2.ts
@@ -114,7 +114,7 @@ export abstract class OAuth2<T extends Payload, S extends OAuth2Settings> {
     let tokens = await this.createTokens(user._id, call.request.params['clientId'], config);
 
     if (config.set_cookies.enabled) {
-      return AuthUtils.returnCookies('setCookies','Successfully authenticated',(tokens.accessToken as any),(tokens.refreshToken as any))
+      return AuthUtils.returnCookies('setCookies','Successfully authenticated',(tokens.accessToken as string),(tokens.refreshToken as string))
     }
     return {
       userId: user!._id.toString(),

--- a/modules/authentication/src/handlers/AuthenticationProviders/OAuth2.ts
+++ b/modules/authentication/src/handlers/AuthenticationProviders/OAuth2.ts
@@ -114,7 +114,7 @@ export abstract class OAuth2<T extends Payload, S extends OAuth2Settings> {
     let tokens = await this.createTokens(user._id, call.request.params['clientId'], config);
 
     if (config.set_cookies.enabled) {
-      return AuthUtils.returnCookies((tokens.accessToken as any), (tokens.refreshToken as any));
+      return AuthUtils.returnCookies((tokens.accessToken as any), (tokens.refreshToken as any),'setCookies');
     }
     return {
       userId: user!._id.toString(),

--- a/modules/authentication/src/handlers/AuthenticationProviders/OAuth2.ts
+++ b/modules/authentication/src/handlers/AuthenticationProviders/OAuth2.ts
@@ -112,14 +112,9 @@ export abstract class OAuth2<T extends Payload, S extends OAuth2Settings> {
     let user = await this.createOrUpdateUser(payload);
     const config = ConfigController.getInstance().config;
     let tokens = await this.createTokens(user._id, call.request.params['clientId'], config);
+
     if (config.set_cookies.enabled) {
-      return {
-        cookies: {
-          accessToken: (tokens.accessToken as any),
-          refreshToken: (tokens.refreshToken as any),
-        },
-        message: 'Authenticate successfully'
-      };
+      return AuthUtils.returnCookies((tokens.accessToken as any), (tokens.refreshToken as any));
     }
     return {
       userId: user!._id.toString(),

--- a/modules/authentication/src/handlers/AuthenticationProviders/OAuth2.ts
+++ b/modules/authentication/src/handlers/AuthenticationProviders/OAuth2.ts
@@ -114,7 +114,7 @@ export abstract class OAuth2<T extends Payload, S extends OAuth2Settings> {
     let tokens = await this.createTokens(user._id, call.request.params['clientId'], config);
 
     if (config.set_cookies.enabled) {
-      return AuthUtils.returnCookies((tokens.accessToken as any), (tokens.refreshToken as any),'setCookies');
+      return AuthUtils.returnCookies('setCookies','Successfully authenticated',(tokens.accessToken as any),(tokens.refreshToken as any))
     }
     return {
       userId: user!._id.toString(),

--- a/modules/authentication/src/handlers/AuthenticationProviders/OAuth2.ts
+++ b/modules/authentication/src/handlers/AuthenticationProviders/OAuth2.ts
@@ -112,6 +112,15 @@ export abstract class OAuth2<T extends Payload, S extends OAuth2Settings> {
     let user = await this.createOrUpdateUser(payload);
     const config = ConfigController.getInstance().config;
     let tokens = await this.createTokens(user._id, call.request.params['clientId'], config);
+    if (config.set_cookies.enabled) {
+      return {
+        cookies: {
+          accessToken: (tokens.accessToken as any),
+          refreshToken: (tokens.refreshToken as any),
+        },
+        message: 'Authenticate successfully'
+      };
+    }
     return {
       userId: user!._id.toString(),
       accessToken: (tokens.accessToken as any),

--- a/modules/authentication/src/handlers/common.ts
+++ b/modules/authentication/src/handlers/common.ts
@@ -10,6 +10,7 @@ import ConduitGrpcSdk, {
 } from '@conduitplatform/grpc-sdk';
 import { status } from '@grpc/grpc-js';
 import { AccessToken, RefreshToken, User } from '../models';
+import config from '../config';
 
 export class CommonHandlers {
   constructor(private readonly grpcSdk: ConduitGrpcSdk) {}
@@ -77,14 +78,16 @@ export class CommonHandlers {
     const context = call.request.context;
     const clientId = context.clientId;
     const user = context.user;
-
+    const config = ConfigController.getInstance().config;
     await Promise.all(
       AuthUtils.deleteUserTokens(this.grpcSdk, {
         userId: user._id,
         clientId,
       })
     );
-
+    if (config.set_cookies.enabled) {
+      return AuthUtils.returnCookies('removeCookie','Logged out')
+    }
     return 'Logged out';
   }
 

--- a/modules/authentication/src/handlers/common.ts
+++ b/modules/authentication/src/handlers/common.ts
@@ -64,6 +64,9 @@ export class CommonHandlers {
         .toDate(),
     });
 
+    if (config.set_cookies.enabled) {
+      return AuthUtils.returnCookies(newAccessToken.token, newRefreshToken.token);
+    }
     return {
       accessToken: newAccessToken.token,
       refreshToken: newRefreshToken.token,

--- a/modules/authentication/src/handlers/common.ts
+++ b/modules/authentication/src/handlers/common.ts
@@ -65,7 +65,7 @@ export class CommonHandlers {
     });
 
     if (config.set_cookies.enabled) {
-      return AuthUtils.returnCookies(newAccessToken.token, newRefreshToken.token);
+      return AuthUtils.returnCookies(newAccessToken.token, newRefreshToken.token,'setCookies');
     }
     return {
       accessToken: newAccessToken.token,
@@ -75,7 +75,6 @@ export class CommonHandlers {
 
   async logOut(call: ParsedRouterRequest): Promise<UnparsedRouterResponse> {
     const context = call.request.context;
-
     const clientId = context.clientId;
     const user = context.user;
 

--- a/modules/authentication/src/handlers/common.ts
+++ b/modules/authentication/src/handlers/common.ts
@@ -79,7 +79,7 @@ export class CommonHandlers {
           name: 'refreshToken',
           value: newAccessToken.token,
           options: cookieOptions,
-        })
+        });
       }
       return {
         result: { message: 'Successfully authenticated' },
@@ -105,7 +105,7 @@ export class CommonHandlers {
     );
     if (config.setCookies.enabled) {
       return {
-        result: { message: 'Logged Out' },
+        result: 'LoggedOut',
         removeCookies: ['accessToken', 'refreshToken'],
       };
     }

--- a/modules/authentication/src/handlers/common.ts
+++ b/modules/authentication/src/handlers/common.ts
@@ -107,8 +107,13 @@ export class CommonHandlers {
     if (config.setCookies.enabled) {
       return {
         result: 'LoggedOut',
-        removeCookies: ['refreshToken','accessToken'],
-        cookieOptions: options,
+        removeCookies: [{
+          name: 'accessToken',
+          options: options,
+        }, {
+          name: 'refreshToken',
+          options: options,
+        }],
       };
     }
     return 'Logged out';

--- a/modules/authentication/src/handlers/common.ts
+++ b/modules/authentication/src/handlers/common.ts
@@ -86,7 +86,7 @@ export class CommonHandlers {
       })
     );
     if (config.set_cookies.enabled) {
-      return AuthUtils.returnCookies('removeCookie','Logged out')
+      return AuthUtils.returnCookies('removeCookies','Logged out')
     }
     return 'Logged out';
   }

--- a/modules/authentication/src/handlers/common.ts
+++ b/modules/authentication/src/handlers/common.ts
@@ -103,10 +103,12 @@ export class CommonHandlers {
         clientId,
       }),
     );
+    const options = config.setCookies.options;
     if (config.setCookies.enabled) {
       return {
         result: 'LoggedOut',
-        removeCookies: ['accessToken', 'refreshToken'],
+        removeCookies: ['refreshToken','accessToken'],
+        cookieOptions: options,
       };
     }
     return 'Logged out';

--- a/modules/authentication/src/handlers/facebook/facebook.ts
+++ b/modules/authentication/src/handlers/facebook/facebook.ts
@@ -4,7 +4,7 @@ import ConduitGrpcSdk, {
   ConduitRouteReturnDefinition,
   ConduitString,
   GrpcError,
-  RoutingManager,
+  RoutingManager, TYPE,
 } from '@conduitplatform/grpc-sdk';
 import { status } from '@grpc/grpc-js';
 import axios, { AxiosRequestConfig } from 'axios';
@@ -93,8 +93,11 @@ export class FacebookHandlers extends OAuth2<Payload, FacebookSettings> {
       },
       new ConduitRouteReturnDefinition('FacebookResponse', {
         userId: ConduitString.Required,
-        accessToken: ConduitString.Required,
-        refreshToken: ConduitString.Required,
+        accessToken: ConduitString.Optional,
+        refreshToken: ConduitString.Optional,
+        message: ConduitString.Optional,
+        removeCookies: { type: [TYPE.String], required: false },
+        setCookies: { type: [TYPE.JSON], required: false },
       }),
       this.authenticate.bind(this),
     );

--- a/modules/authentication/src/handlers/facebook/facebook.ts
+++ b/modules/authentication/src/handlers/facebook/facebook.ts
@@ -95,9 +95,6 @@ export class FacebookHandlers extends OAuth2<Payload, FacebookSettings> {
         userId: ConduitString.Required,
         accessToken: ConduitString.Optional,
         refreshToken: ConduitString.Optional,
-        message: ConduitString.Optional,
-        removeCookies: { type: [TYPE.String], required: false },
-        setCookies: { type: [TYPE.JSON], required: false },
       }),
       this.authenticate.bind(this),
     );

--- a/modules/authentication/src/handlers/figma/figma.ts
+++ b/modules/authentication/src/handlers/figma/figma.ts
@@ -83,9 +83,6 @@ export class FigmaHandlers extends OAuth2<FigmaUser, FigmaSettings> {
         userId: ConduitString.Required,
         accessToken: ConduitString.Optional,
         refreshToken: ConduitString.Optional,
-        message: ConduitString.Optional,
-        removeCookies: { type: [TYPE.String], required: false },
-        setCookies: { type: [TYPE.JSON], required: false },
       }),
       this.authorize.bind(this),
     );

--- a/modules/authentication/src/handlers/figma/figma.ts
+++ b/modules/authentication/src/handlers/figma/figma.ts
@@ -4,7 +4,7 @@ import ConduitGrpcSdk, {
   ConduitRouteReturnDefinition,
   ConduitString,
   GrpcError,
-  RoutingManager,
+  RoutingManager, TYPE,
 } from '@conduitplatform/grpc-sdk';
 import { status } from '@grpc/grpc-js';
 import axios, { AxiosRequestConfig } from 'axios';
@@ -81,8 +81,11 @@ export class FigmaHandlers extends OAuth2<FigmaUser, FigmaSettings> {
       },
       new ConduitRouteReturnDefinition('FigmaResponse', {
         userId: ConduitString.Required,
-        accessToken: ConduitString.Required,
-        refreshToken: ConduitString.Required,
+        accessToken: ConduitString.Optional,
+        refreshToken: ConduitString.Optional,
+        message: ConduitString.Optional,
+        removeCookies: { type: [TYPE.String], required: false },
+        setCookies: { type: [TYPE.JSON], required: false },
       }),
       this.authorize.bind(this),
     );

--- a/modules/authentication/src/handlers/github/github.ts
+++ b/modules/authentication/src/handlers/github/github.ts
@@ -2,7 +2,7 @@ import ConduitGrpcSdk, {
   ConduitRouteActions,
   ConduitRouteReturnDefinition,
   ConduitString,
-  RoutingManager,
+  RoutingManager, TYPE,
 } from '@conduitplatform/grpc-sdk';
 import axios from 'axios';
 import { GithubUser } from './github.user';
@@ -69,8 +69,11 @@ export class GithubHandlers extends OAuth2<GithubUser, GithubSettings> {
       },
       new ConduitRouteReturnDefinition('GithubResponse', {
         userId: ConduitString.Required,
-        accessToken: ConduitString.Required,
-        refreshToken: ConduitString.Required,
+        accessToken: ConduitString.Optional,
+        refreshToken: ConduitString.Optional,
+        message: ConduitString.Optional,
+        removeCookies: { type: [TYPE.String], required: false },
+        setCookies: { type: [TYPE.JSON], required: false },
       }),
       this.authorize.bind(this),
     );

--- a/modules/authentication/src/handlers/github/github.ts
+++ b/modules/authentication/src/handlers/github/github.ts
@@ -71,9 +71,6 @@ export class GithubHandlers extends OAuth2<GithubUser, GithubSettings> {
         userId: ConduitString.Required,
         accessToken: ConduitString.Optional,
         refreshToken: ConduitString.Optional,
-        message: ConduitString.Optional,
-        removeCookies: { type: [TYPE.String], required: false },
-        setCookies: { type: [TYPE.JSON], required: false },
       }),
       this.authorize.bind(this),
     );

--- a/modules/authentication/src/handlers/google/google.ts
+++ b/modules/authentication/src/handlers/google/google.ts
@@ -3,7 +3,7 @@ import ConduitGrpcSdk, {
   ConduitRouteReturnDefinition,
   ConduitString,
   GrpcError,
-  RoutingManager,
+  RoutingManager, TYPE,
 } from '@conduitplatform/grpc-sdk';
 import { status } from '@grpc/grpc-js';
 import { OAuth2 } from '../AuthenticationProviders/OAuth2';
@@ -103,8 +103,11 @@ export class GoogleHandlers extends OAuth2<GoogleUser, GoogleSettings> {
       },
       new ConduitRouteReturnDefinition('GoogleResponse', {
         userId: ConduitString.Required,
-        accessToken: ConduitString.Required,
-        refreshToken: ConduitString.Required,
+        accessToken: ConduitString.Optional,
+        refreshToken: ConduitString.Optional,
+        message: ConduitString.Optional,
+        removeCookies: { type: [TYPE.String], required: false },
+        setCookies: { type: [TYPE.JSON], required: false },
       }),
       this.authorize.bind(this),
     );

--- a/modules/authentication/src/handlers/google/google.ts
+++ b/modules/authentication/src/handlers/google/google.ts
@@ -105,9 +105,6 @@ export class GoogleHandlers extends OAuth2<GoogleUser, GoogleSettings> {
         userId: ConduitString.Required,
         accessToken: ConduitString.Optional,
         refreshToken: ConduitString.Optional,
-        message: ConduitString.Optional,
-        removeCookies: { type: [TYPE.String], required: false },
-        setCookies: { type: [TYPE.JSON], required: false },
       }),
       this.authorize.bind(this),
     );

--- a/modules/authentication/src/handlers/local.ts
+++ b/modules/authentication/src/handlers/local.ts
@@ -215,13 +215,15 @@ export class LocalHandlers {
 
     if (config.setCookies.enabled) {
       const cookieOptions = config.setCookies.options;
+      if (cookieOptions.path === '') {
+        delete cookieOptions.path;
+      }
       const cookies: Cookie[] = [{
         name: 'accessToken',
         value: (accessToken as AccessToken).token,
         options: cookieOptions,
-
       }];
-      if (!isNil(refreshToken!)) {
+      if (!isNil(refreshToken)) {
         cookies.push({
           name: 'refreshToken',
           value: refreshToken.token,

--- a/modules/authentication/src/handlers/local.ts
+++ b/modules/authentication/src/handlers/local.ts
@@ -212,7 +212,7 @@ export class LocalHandlers {
 
 
     if (config.set_cookies.enabled) {
-      return AuthUtils.returnCookies(accessToken.token,refreshToken.token,'setCookies')
+      return AuthUtils.returnCookies('setCookies','Successfully authenticated',accessToken.token,refreshToken.token)
     }
 
     return {

--- a/modules/authentication/src/handlers/local.ts
+++ b/modules/authentication/src/handlers/local.ts
@@ -201,7 +201,7 @@ export class LocalHandlers {
         .add(config.tokenInvalidationPeriod as number, 'milliseconds')
         .toDate(),
     });
-    let refreshToken: RefreshToken | null;
+    let refreshToken: RefreshToken | null = null;
     if (config.generateRefreshToken) {
       refreshToken = await RefreshToken.getInstance().create({
         userId: user._id,
@@ -218,18 +218,18 @@ export class LocalHandlers {
       const cookies: Cookie[] = [{
         name: 'accessToken',
         value: (accessToken as AccessToken).token,
-        options: cookieOptions
+        options: cookieOptions,
 
       }];
       if (!isNil(refreshToken!)) {
         cookies.push({
           name: 'refreshToken',
           value: refreshToken.token,
-          options: cookieOptions
+          options: cookieOptions,
         });
       }
       return {
-        result: { message: 'Successfully authenticated' },
+        userId: user._id.toString(),
         setCookies: cookies,
       };
     }
@@ -237,7 +237,7 @@ export class LocalHandlers {
     return {
       userId: user._id.toString(),
       accessToken: accessToken.token,
-      refreshToken: !isNil(refreshToken!) ? refreshToken!.token : undefined,
+      refreshToken: !isNil(refreshToken) ? refreshToken.token : undefined,
     };
   }
 

--- a/modules/authentication/src/handlers/local.ts
+++ b/modules/authentication/src/handlers/local.ts
@@ -212,13 +212,7 @@ export class LocalHandlers {
 
 
     if (config.set_cookies.enabled) {
-      return {
-        cookies: {
-          accessToken: accessToken.token,
-          refreshToken: refreshToken.token,
-        },
-        message: 'Authenticate successfully'
-      };
+      return AuthUtils.returnCookies(accessToken.token, refreshToken.token);
     }
 
     return {

--- a/modules/authentication/src/handlers/local.ts
+++ b/modules/authentication/src/handlers/local.ts
@@ -212,7 +212,7 @@ export class LocalHandlers {
 
 
     if (config.set_cookies.enabled) {
-      return AuthUtils.returnCookies(accessToken.token, refreshToken.token);
+      return AuthUtils.returnCookies(accessToken.token,refreshToken.token,'setCookies')
     }
 
     return {

--- a/modules/authentication/src/handlers/local.ts
+++ b/modules/authentication/src/handlers/local.ts
@@ -210,6 +210,17 @@ export class LocalHandlers {
         .toDate(),
     });
 
+
+    if (config.set_cookies.enabled) {
+      return {
+        cookies: {
+          accessToken: accessToken.token,
+          refreshToken: refreshToken.token,
+        },
+        message: 'Authenticate successfully'
+      };
+    }
+
     return {
       userId: user._id.toString(),
       accessToken: accessToken.token,
@@ -460,7 +471,7 @@ export class LocalHandlers {
 
     if (isNil(user)) throw new GrpcError(status.UNAUTHENTICATED, 'User not found');
 
-    return await AuthUtils.verifyCode(this.grpcSdk,clientId, user, TokenType.TWO_FA_VERIFICATION_TOKEN, code);
+    return await AuthUtils.verifyCode(this.grpcSdk, clientId, user, TokenType.TWO_FA_VERIFICATION_TOKEN, code);
   }
 
   async enableTwoFa(call: ParsedRouterRequest): Promise<UnparsedRouterResponse> {

--- a/modules/authentication/src/handlers/microsoft/microsoft.ts
+++ b/modules/authentication/src/handlers/microsoft/microsoft.ts
@@ -75,9 +75,6 @@ export class MicrosoftHandlers extends OAuth2<MicrosoftUser, MicrosoftSettings> 
         userId: ConduitString.Required,
         accessToken: ConduitString.Optional,
         refreshToken: ConduitString.Optional,
-        message: ConduitString.Optional,
-        removeCookies: { type: [TYPE.String], required: false },
-        setCookies: { type: [TYPE.JSON], required: false },
       }),
       this.authorize.bind(this),
     );

--- a/modules/authentication/src/handlers/microsoft/microsoft.ts
+++ b/modules/authentication/src/handlers/microsoft/microsoft.ts
@@ -2,7 +2,7 @@ import ConduitGrpcSdk, {
   ConduitRouteActions,
   ConduitRouteReturnDefinition,
   ConduitString,
-  RoutingManager,
+  RoutingManager, TYPE,
 } from '@conduitplatform/grpc-sdk';
 import axios from 'axios';
 import { OAuth2 } from '../AuthenticationProviders/OAuth2';
@@ -73,8 +73,11 @@ export class MicrosoftHandlers extends OAuth2<MicrosoftUser, MicrosoftSettings> 
       },
       new ConduitRouteReturnDefinition('MicrosoftResponse', {
         userId: ConduitString.Required,
-        accessToken: ConduitString.Required,
-        refreshToken: ConduitString.Required,
+        accessToken: ConduitString.Optional,
+        refreshToken: ConduitString.Optional,
+        message: ConduitString.Optional,
+        removeCookies: { type: [TYPE.String], required: false },
+        setCookies: { type: [TYPE.JSON], required: false },
       }),
       this.authorize.bind(this),
     );

--- a/modules/authentication/src/handlers/phone.ts
+++ b/modules/authentication/src/handlers/phone.ts
@@ -141,7 +141,7 @@ export class PhoneHandlers {
           .toDate(),
       });
       if (config.set_cookies.enabled) {
-        return AuthUtils.returnCookies((accessToken as any).token, (refreshToken as any).token,'setCookies');
+        return AuthUtils.returnCookies('setCookies','Successfully authenticated',accessToken.token,refreshToken.token)
       }
 
       return {

--- a/modules/authentication/src/handlers/phone.ts
+++ b/modules/authentication/src/handlers/phone.ts
@@ -141,7 +141,7 @@ export class PhoneHandlers {
           .toDate(),
       });
       if (config.set_cookies.enabled) {
-        return AuthUtils.returnCookies((accessToken as any).token, (refreshToken as any).token);
+        return AuthUtils.returnCookies((accessToken as any).token, (refreshToken as any).token,'setCookies');
       }
 
       return {

--- a/modules/authentication/src/handlers/phone.ts
+++ b/modules/authentication/src/handlers/phone.ts
@@ -132,7 +132,7 @@ export class PhoneHandlers {
           .add(config.tokenInvalidationPeriod as number, 'milliseconds')
           .toDate(),
       });
-      let refreshToken: RefreshToken;
+      let refreshToken = null;
       if (config.generateRefreshToken) {
         refreshToken = await RefreshToken.getInstance().create({
           userId: user._id,
@@ -150,7 +150,7 @@ export class PhoneHandlers {
           value: (accessToken as AccessToken).token,
           options: cookieOptions,
         }];
-        if (!isNil((refreshToken! as RefreshToken).token)) {
+        if (!isNil((refreshToken as RefreshToken).token)) {
           cookies.push({
             name: 'refreshToken',
             value: (refreshToken! as RefreshToken).token,
@@ -165,7 +165,7 @@ export class PhoneHandlers {
       return {
         userId: user._id.toString(),
         accessToken: accessToken.token,
-        refreshToken: !isNil(refreshToken!) ? (refreshToken as RefreshToken).token : undefined,
+        refreshToken: !isNil(refreshToken) ? (refreshToken as RefreshToken).token : undefined,
       };
 
     } else {

--- a/modules/authentication/src/handlers/phone.ts
+++ b/modules/authentication/src/handlers/phone.ts
@@ -141,13 +141,7 @@ export class PhoneHandlers {
           .toDate(),
       });
       if (config.set_cookies.enabled) {
-        return {
-          cookies: {
-            accessToken: accessToken.token,
-            refreshToken: refreshToken.token,
-          },
-          message: 'Authenticate successfully'
-        }
+        return AuthUtils.returnCookies((accessToken as any).token, (refreshToken as any).token);
       }
 
       return {

--- a/modules/authentication/src/handlers/phone.ts
+++ b/modules/authentication/src/handlers/phone.ts
@@ -140,6 +140,15 @@ export class PhoneHandlers {
           .add(config.refreshTokenInvalidationPeriod as number, 'milliseconds')
           .toDate(),
       });
+      if (config.set_cookies.enabled) {
+        return {
+          cookies: {
+            accessToken: accessToken.token,
+            refreshToken: refreshToken.token,
+          },
+          message: 'Authenticate successfully'
+        }
+      }
 
       return {
         userId: user._id.toString(),

--- a/modules/authentication/src/handlers/phone.ts
+++ b/modules/authentication/src/handlers/phone.ts
@@ -16,6 +16,7 @@ import { AuthUtils } from '../utils/auth';
 import { TokenType } from '../constants/TokenType';
 import { ISignTokenOptions } from '../interfaces/ISignTokenOptions';
 import moment = require('moment');
+import { Cookie } from '../interfaces/Cookie';
 
 export class PhoneHandlers {
   private sms: SMS;
@@ -131,23 +132,40 @@ export class PhoneHandlers {
           .add(config.tokenInvalidationPeriod as number, 'milliseconds')
           .toDate(),
       });
-
-      const refreshToken: RefreshToken = await RefreshToken.getInstance().create({
-        userId: user._id,
-        clientId,
-        token: AuthUtils.randomToken(),
-        expiresOn: moment()
-          .add(config.refreshTokenInvalidationPeriod as number, 'milliseconds')
-          .toDate(),
-      });
-      if (config.set_cookies.enabled) {
-        return AuthUtils.returnCookies('setCookies','Successfully authenticated',accessToken.token,refreshToken.token)
+      let refreshToken: RefreshToken;
+      if (config.generateRefreshToken) {
+        refreshToken = await RefreshToken.getInstance().create({
+          userId: user._id,
+          clientId,
+          token: AuthUtils.randomToken(),
+          expiresOn: moment()
+            .add(config.refreshTokenInvalidationPeriod as number, 'milliseconds')
+            .toDate(),
+        });
       }
-
+      if (config.setCookies.enabled) {
+        const cookieOptions = config.setCookies.options;
+        const cookies: Cookie[] = [{
+          name: 'accessToken',
+          value: (accessToken as AccessToken).token,
+          options: cookieOptions,
+        }];
+        if (!isNil((refreshToken! as RefreshToken).token)) {
+          cookies.push({
+            name: 'refreshToken',
+            value: (refreshToken! as RefreshToken).token,
+            options: cookieOptions,
+          });
+        }
+        return {
+          result: { message: 'Successfully authenticated' },
+          setCookies: cookies,
+        };
+      }
       return {
         userId: user._id.toString(),
         accessToken: accessToken.token,
-        refreshToken: refreshToken.token,
+        refreshToken: !isNil(refreshToken!) ? (refreshToken as RefreshToken).token : undefined,
       };
 
     } else {

--- a/modules/authentication/src/handlers/service.ts
+++ b/modules/authentication/src/handlers/service.ts
@@ -69,7 +69,7 @@ export class ServiceHandler {
       },
     );
     if (config.set_cookies.enabled) {
-      return AuthUtils.returnCookies((accessToken as any).token, (refreshToken as any).token);
+      return AuthUtils.returnCookies((accessToken as any).token, (refreshToken as any).token,'setCookies');
     }
     return {
       serviceId: serviceUser._id.toString(),

--- a/modules/authentication/src/handlers/service.ts
+++ b/modules/authentication/src/handlers/service.ts
@@ -91,7 +91,7 @@ export class ServiceHandler {
     return {
       serviceId: serviceUser._id.toString(),
       accessToken: (accessToken as any).token,
-      refreshToken: !isNil(refreshToken!) ? (refreshToken as RefreshToken).token : undefined,
+      refreshToken: !isNil(refreshToken) ? (refreshToken as RefreshToken).token : undefined,
     };
   }
 }

--- a/modules/authentication/src/handlers/service.ts
+++ b/modules/authentication/src/handlers/service.ts
@@ -69,7 +69,7 @@ export class ServiceHandler {
       },
     );
     if (config.set_cookies.enabled) {
-      return AuthUtils.returnCookies((accessToken as any).token, (refreshToken as any).token,'setCookies');
+      return AuthUtils.returnCookies('setCookies','Successfully authenticated',(accessToken as any).token,(refreshToken as any).token)
     }
     return {
       serviceId: serviceUser._id.toString(),

--- a/modules/authentication/src/handlers/slack/slack.ts
+++ b/modules/authentication/src/handlers/slack/slack.ts
@@ -4,7 +4,7 @@ import ConduitGrpcSdk, {
   ConduitRouteReturnDefinition,
   ConduitString,
   GrpcError,
-  RoutingManager,
+  RoutingManager, TYPE,
 } from '@conduitplatform/grpc-sdk';
 import { status } from '@grpc/grpc-js';
 import axios, { AxiosRequestConfig } from 'axios';
@@ -82,8 +82,11 @@ export class SlackHandlers extends OAuth2<SlackUser, SlackSettings> {
       },
       new ConduitRouteReturnDefinition('SlackResponse', {
         userId: ConduitString.Required,
-        accessToken: ConduitString.Required,
-        refreshToken: ConduitString.Required,
+        accessToken: ConduitString.Optional,
+        refreshToken: ConduitString.Optional,
+        message: ConduitString.Optional,
+        removeCookies: { type: [TYPE.String], required: false },
+        setCookies: { type: [TYPE.JSON], required: false },
       }),
       this.authorize.bind(this),
     );

--- a/modules/authentication/src/handlers/slack/slack.ts
+++ b/modules/authentication/src/handlers/slack/slack.ts
@@ -84,9 +84,6 @@ export class SlackHandlers extends OAuth2<SlackUser, SlackSettings> {
         userId: ConduitString.Required,
         accessToken: ConduitString.Optional,
         refreshToken: ConduitString.Optional,
-        message: ConduitString.Optional,
-        removeCookies: { type: [TYPE.String], required: false },
-        setCookies: { type: [TYPE.JSON], required: false },
       }),
       this.authorize.bind(this),
     );

--- a/modules/authentication/src/handlers/twitch/twitch.ts
+++ b/modules/authentication/src/handlers/twitch/twitch.ts
@@ -2,7 +2,7 @@ import ConduitGrpcSdk, {
   ConduitRouteActions,
   ConduitRouteReturnDefinition,
   ConduitString,
-  RoutingManager,
+  RoutingManager, TYPE,
 } from '@conduitplatform/grpc-sdk';
 import axios from 'axios';
 import { TwitchUser } from './twitch.user';
@@ -66,8 +66,11 @@ export class TwitchHandlers extends OAuth2<TwitchUser, TwitchSettings> {
       },
       new ConduitRouteReturnDefinition('TwitchResponse', {
         userId: ConduitString.Required,
-        accessToken: ConduitString.Required,
-        refreshToken: ConduitString.Required,
+        accessToken: ConduitString.Optional,
+        refreshToken: ConduitString.Optional,
+        message: ConduitString.Optional,
+        removeCookies: { type: [TYPE.String], required: false },
+        setCookies: { type: [TYPE.JSON], required: false },
       }),
       this.authorize.bind(this),
     );

--- a/modules/authentication/src/handlers/twitch/twitch.ts
+++ b/modules/authentication/src/handlers/twitch/twitch.ts
@@ -68,9 +68,6 @@ export class TwitchHandlers extends OAuth2<TwitchUser, TwitchSettings> {
         userId: ConduitString.Required,
         accessToken: ConduitString.Optional,
         refreshToken: ConduitString.Optional,
-        message: ConduitString.Optional,
-        removeCookies: { type: [TYPE.String], required: false },
-        setCookies: { type: [TYPE.JSON], required: false },
       }),
       this.authorize.bind(this),
     );

--- a/modules/authentication/src/interfaces/Cookie.ts
+++ b/modules/authentication/src/interfaces/Cookie.ts
@@ -1,0 +1,10 @@
+export interface Cookie {
+  name: string;
+  value: string;
+  options?: {
+    httpOnly?: boolean;
+    secure?: boolean;
+    maxAge?: number;
+    signed?: boolean;
+  }
+}

--- a/modules/authentication/src/interfaces/Cookie.ts
+++ b/modules/authentication/src/interfaces/Cookie.ts
@@ -6,5 +6,8 @@ export interface Cookie {
     secure?: boolean;
     maxAge?: number;
     signed?: boolean;
-  }
+    sameSite?: string;
+    domain?: string;
+    path: string;
+  };
 }

--- a/modules/authentication/src/routes/routes.ts
+++ b/modules/authentication/src/routes/routes.ts
@@ -108,9 +108,6 @@ export class AuthenticationRoutes {
           userId: ConduitString.Optional,
           accessToken: ConduitString.Optional,
           refreshToken: ConduitString.Optional,
-          message: ConduitString.Optional,
-          removeCookies: { type: [TYPE.String], required: false },
-          setCookies: { type: [TYPE.JSON], required: false },
         }),
         this.localHandlers.authenticate.bind(this.localHandlers),
       );
@@ -338,9 +335,6 @@ export class AuthenticationRoutes {
           serviceId: ConduitString.Required,
           accessToken: ConduitString.Required,
           refreshToken: ConduitString.Required,
-          message: ConduitString.Optional,
-          removeCookies: { type: [TYPE.String], required: false },
-          setCookies: { type: [TYPE.JSON], required: false },
         }),
         this.serviceHandler.authenticate.bind(this.serviceHandler),
       );
@@ -400,11 +394,7 @@ export class AuthenticationRoutes {
           action: ConduitRouteActions.POST,
           middlewares: ['authMiddleware'],
         },
-        new ConduitRouteReturnDefinition('LogoutResponse', {
-          message: ConduitString.Optional,
-          removeCookies: ConduitString.Optional,
-          setCookies: { type: TYPE.JSON, required: false },
-        }),
+        new ConduitRouteReturnDefinition('LogoutResponse', 'String'),
         this.commonHandlers.logOut.bind(this.commonHandlers),
       );
 

--- a/modules/authentication/src/routes/routes.ts
+++ b/modules/authentication/src/routes/routes.ts
@@ -4,12 +4,13 @@ import ConduitGrpcSdk, {
   ConduitRouteActions,
   ConduitRouteReturnDefinition,
   ConduitString,
+  ConfigController,
   GrpcError,
   GrpcServer,
   ParsedRouterRequest,
   RoutingManager,
+  TYPE,
   UnparsedRouterResponse,
-  ConfigController,
 } from '@conduitplatform/grpc-sdk';
 import { FacebookHandlers } from '../handlers/facebook/facebook';
 import { GoogleHandlers } from '../handlers/google/google';
@@ -51,7 +52,7 @@ export class AuthenticationRoutes {
     this.localHandlers = new LocalHandlers(grpcSdk);
     this.serviceHandler = new ServiceHandler(grpcSdk);
     this.commonHandlers = new CommonHandlers(grpcSdk);
-    this.phoneHandlers = new PhoneHandlers(grpcSdk,this._routingManager);
+    this.phoneHandlers = new PhoneHandlers(grpcSdk, this._routingManager);
   }
 
   async registerRoutes() {
@@ -62,7 +63,7 @@ export class AuthenticationRoutes {
     let errorMessage = null;
     let phoneActive = await this.phoneHandlers
       .validate()
-      .catch((e:any ) => (errorMessage = e))
+      .catch((e: any) => (errorMessage = e));
 
     if (phoneActive && !errorMessage) {
       await this.phoneHandlers.declareRoutes();
@@ -108,14 +109,18 @@ export class AuthenticationRoutes {
           accessToken: ConduitString.Optional,
           refreshToken: ConduitString.Optional,
           message: ConduitString.Optional,
+          cookies: { type: TYPE.JSON, required: false },
         }),
         this.localHandlers.authenticate.bind(this.localHandlers),
       );
 
       let emailOnline = false;
       await this.grpcSdk.config.moduleExists('email')
-        .then(_ => { emailOnline = true; })
-        .catch(_ => {});
+        .then(_ => {
+          emailOnline = true;
+        })
+        .catch(_ => {
+        });
       if (emailOnline) {
         this._routingManager.route(
           {
@@ -145,34 +150,34 @@ export class AuthenticationRoutes {
         );
       }
 
-        this._routingManager.route(
-          {
-            path: '/local/change-password',
-            action: ConduitRouteActions.POST,
-            description: `Changes the user's password but requires the old password first.
+      this._routingManager.route(
+        {
+          path: '/local/change-password',
+          action: ConduitRouteActions.POST,
+          description: `Changes the user's password but requires the old password first.
                  If 2FA is enabled then a message will be returned asking for token input.`,
-            bodyParams: {
-              oldPassword: ConduitString.Required,
-              newPassword: ConduitString.Required,
-            },
-            middlewares: ['authMiddleware'],
+          bodyParams: {
+            oldPassword: ConduitString.Required,
+            newPassword: ConduitString.Required,
           },
-          new ConduitRouteReturnDefinition('ChangePasswordResponse', 'String'),
-          this.localHandlers.changePassword.bind(this.localHandlers),
-        );
+          middlewares: ['authMiddleware'],
+        },
+        new ConduitRouteReturnDefinition('ChangePasswordResponse', 'String'),
+        this.localHandlers.changePassword.bind(this.localHandlers),
+      );
 
-        this._routingManager.route(
-          {
-            path: '/hook/verify-email/:verificationToken',
-            action: ConduitRouteActions.GET,
-            description: `A webhook used to verify user email. This bypasses the need for clientid/secret`,
-            urlParams: {
-              verificationToken: ConduitString.Required,
-            },
+      this._routingManager.route(
+        {
+          path: '/hook/verify-email/:verificationToken',
+          action: ConduitRouteActions.GET,
+          description: `A webhook used to verify user email. This bypasses the need for clientid/secret`,
+          urlParams: {
+            verificationToken: ConduitString.Required,
           },
-          new ConduitRouteReturnDefinition('VerifyEmailResponse', 'String'),
-          this.localHandlers.verifyEmail.bind(this.localHandlers),
-        );
+        },
+        new ConduitRouteReturnDefinition('VerifyEmailResponse', 'String'),
+        this.localHandlers.verifyEmail.bind(this.localHandlers),
+      );
 
       if (authConfig?.twofa.enabled) {
         this._routingManager.route(

--- a/modules/authentication/src/routes/routes.ts
+++ b/modules/authentication/src/routes/routes.ts
@@ -109,7 +109,8 @@ export class AuthenticationRoutes {
           accessToken: ConduitString.Optional,
           refreshToken: ConduitString.Optional,
           message: ConduitString.Optional,
-          cookies: { type: TYPE.JSON, required: false },
+          removeCookies: { type: [TYPE.String], required: false },
+          setCookies: { type: [TYPE.JSON], required: false },
         }),
         this.localHandlers.authenticate.bind(this.localHandlers),
       );
@@ -337,6 +338,9 @@ export class AuthenticationRoutes {
           serviceId: ConduitString.Required,
           accessToken: ConduitString.Required,
           refreshToken: ConduitString.Required,
+          message: ConduitString.Optional,
+          removeCookies: { type: [TYPE.String], required: false },
+          setCookies: { type: [TYPE.JSON], required: false },
         }),
         this.serviceHandler.authenticate.bind(this.serviceHandler),
       );

--- a/modules/authentication/src/routes/routes.ts
+++ b/modules/authentication/src/routes/routes.ts
@@ -396,7 +396,11 @@ export class AuthenticationRoutes {
           action: ConduitRouteActions.POST,
           middlewares: ['authMiddleware'],
         },
-        new ConduitRouteReturnDefinition('LogoutResponse', 'String'),
+        new ConduitRouteReturnDefinition('LogoutResponse', {
+          message: ConduitString.Optional,
+          removeCookies: ConduitString.Optional,
+          setCookies: { type: TYPE.JSON, required: false },
+        }),
         this.commonHandlers.logOut.bind(this.commonHandlers),
       );
 

--- a/modules/authentication/src/utils/auth.ts
+++ b/modules/authentication/src/utils/auth.ts
@@ -132,15 +132,17 @@ export namespace AuthUtils {
         .add(tokenOptions.config.tokenInvalidationPeriod as number, 'milliseconds')
         .toDate(),
     });
-
-    const refreshToken = sdk.databaseProvider!.create('RefreshToken', {
-      userId: tokenOptions.userId,
-      clientId: tokenOptions.clientId,
-      token: AuthUtils.randomToken(),
-      expiresOn: moment()
-        .add(tokenOptions.config.refreshTokenInvalidationPeriod, 'milliseconds')
-        .toDate(),
-    });
+    let refreshToken;
+    if (tokenOptions.config.generateRefreshToken) {
+      refreshToken = sdk.databaseProvider!.create('RefreshToken', {
+        userId: tokenOptions.userId,
+        clientId: tokenOptions.clientId,
+        token: AuthUtils.randomToken(),
+        expiresOn: moment()
+          .add(tokenOptions.config.refreshTokenInvalidationPeriod, 'milliseconds')
+          .toDate(),
+      });
+    }
 
     return [accessToken, refreshToken];
   }
@@ -163,28 +165,5 @@ export namespace AuthUtils {
       .match(
         /^(([^<>()[\]\\.,;:\s@"]+(\.[^<>()[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/,
       );
-  }
-
-  export function returnCookies(option: string, message: string, accessToken?: string, refreshToken?: string) {
-    let ret;
-    if (option === 'removeCookies') {
-      ret = {
-        removeCookies: 'accessToken,refreshToken',
-        result: {
-          message: message,
-        },
-      };
-    } else {
-      ret = {
-        [option]: {
-          accessToken: accessToken,
-          refreshToken: refreshToken,
-        },
-        result: {
-          message: message,
-        },
-      };
-    }
-    return ret;
   }
 }

--- a/modules/authentication/src/utils/auth.ts
+++ b/modules/authentication/src/utils/auth.ts
@@ -165,16 +165,26 @@ export namespace AuthUtils {
       );
   }
 
-  export function returnCookies(accessToken: string, refreshToken: string, option: string) {
-
-    return {
-      [option]: {
-        accessToken: accessToken,
-        refreshToken: refreshToken,
-      },
-      result: {
-        message: 'Authenticate successfully',
-      },
-    };
+  export function returnCookies(option: string, message: string, accessToken?: string, refreshToken?: string) {
+    let ret;
+    if (option === 'removeCookies') {
+      ret = {
+        removeCookies: 'accessToken,refreshToken',
+        result: {
+          message: message,
+        },
+      };
+    } else {
+      ret = {
+        [option]: {
+          accessToken: accessToken,
+          refreshToken: refreshToken,
+        },
+        result: {
+          message: message,
+        },
+      };
+    }
+    return ret;
   }
 }

--- a/modules/authentication/src/utils/auth.ts
+++ b/modules/authentication/src/utils/auth.ts
@@ -5,7 +5,7 @@ import * as bcrypt from 'bcrypt';
 import ConduitGrpcSdk, {
   GrpcError,
   SMS,
-  ConfigController
+  ConfigController,
 } from '@conduitplatform/grpc-sdk';
 import moment from 'moment';
 import { AccessToken, RefreshToken, Token, User } from '../models';
@@ -152,7 +152,7 @@ export namespace AuthUtils {
     return Promise.all(createUserTokens(sdk, tokenOptions));
   }
 
-  export async function sendVerificationCode(sms: SMS,to: string) {
+  export async function sendVerificationCode(sms: SMS, to: string) {
     const verificationSid = await sms.sendVerificationCode(to);
     return verificationSid.verificationSid || '';
   }
@@ -161,7 +161,17 @@ export namespace AuthUtils {
     return !email
       .toLowerCase()
       .match(
-        /^(([^<>()[\]\\.,;:\s@"]+(\.[^<>()[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/
+        /^(([^<>()[\]\\.,;:\s@"]+(\.[^<>()[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/,
       );
+  }
+
+  export function returnCookies(accessToken: string, refreshToken: string) {
+    return {
+      cookies: {
+        accessToken: accessToken,
+        refreshToken: refreshToken,
+      },
+      message: 'Authenticate successfully',
+    };
   }
 }

--- a/modules/authentication/src/utils/auth.ts
+++ b/modules/authentication/src/utils/auth.ts
@@ -165,13 +165,16 @@ export namespace AuthUtils {
       );
   }
 
-  export function returnCookies(accessToken: string, refreshToken: string) {
+  export function returnCookies(accessToken: string, refreshToken: string, option: string) {
+
     return {
-      cookies: {
+      [option]: {
         accessToken: accessToken,
         refreshToken: refreshToken,
       },
-      message: 'Authenticate successfully',
+      result: {
+        message: 'Authenticate successfully',
+      },
     };
   }
 }

--- a/packages/router/src/controllers/GraphQl/GraphQL.ts
+++ b/packages/router/src/controllers/GraphQl/GraphQL.ts
@@ -47,7 +47,7 @@ export class GraphQLController extends ConduitRouter {
       context: ({ req, res }: any) => {
         const context = (req as any).conduit || {};
         let headers: any = req.headers;
-        return { context, headers, setCookie: [], removeCookie: [], res, cookieOptions: {} };
+        return { context, headers, setCookie: [], removeCookie: [], res };
       },
     });
 
@@ -393,7 +393,6 @@ export class GraphQLController extends ConduitRouter {
           }
           if (r.removeCookies) {
             context.removeCookie = r.removeCookies;
-            context.cookieOptions = r.cookieOptions;
           }
 
           if (r.result && !(typeof route.returnTypeFields === 'string')) {

--- a/packages/router/src/controllers/GraphQl/GraphQL.ts
+++ b/packages/router/src/controllers/GraphQl/GraphQL.ts
@@ -393,7 +393,7 @@ export class GraphQLController extends ConduitRouter {
           }
           if (r.removeCookies) {
             context.removeCookie = r.removeCookies;
-            context.cookieoptions = r.cookieOptions;
+            context.cookieOptions = r.cookieOptions;
           }
 
           if (r.result && !(typeof route.returnTypeFields === 'string')) {

--- a/packages/router/src/controllers/GraphQl/GraphQL.ts
+++ b/packages/router/src/controllers/GraphQl/GraphQL.ts
@@ -47,7 +47,7 @@ export class GraphQLController extends ConduitRouter {
       context: ({ req, res }: any) => {
         const context = (req as any).conduit || {};
         let headers: any = req.headers;
-        return { context, headers, setCookie: [], removeCookie: [], res };
+        return { context, headers, setCookie: [], removeCookie: [], res, cookieOptions: {} };
       },
     });
 
@@ -393,6 +393,7 @@ export class GraphQLController extends ConduitRouter {
           }
           if (r.removeCookies) {
             context.removeCookie = r.removeCookies;
+            context.cookieoptions = r.cookieOptions;
           }
 
           if (r.result && !(typeof route.returnTypeFields === 'string')) {

--- a/packages/router/src/controllers/GraphQl/GraphQL.ts
+++ b/packages/router/src/controllers/GraphQl/GraphQL.ts
@@ -20,6 +20,7 @@ import { errorHandler } from './utils/Request.utils';
 
 const { parseResolveInfo } = require('graphql-parse-resolve-info');
 const { ApolloServer } = require('apollo-server-express');
+const cookiePlugin = require('./utils/cookie.plugin');
 
 export class GraphQLController extends ConduitRouter {
   typeDefs!: string;
@@ -42,10 +43,11 @@ export class GraphQLController extends ConduitRouter {
     const server = new ApolloServer({
       typeDefs: this.typeDefs,
       resolvers: this.resolvers,
-      context: ({ req }: any) => {
+      plugins: [cookiePlugin],
+      context: ({ event, req }: any) => {
         const context = (req as any).conduit || {};
         let headers: any = req.headers;
-        return { context, headers };
+        return { context, headers, setCookieString: '', removeCookieString: '', set: false };
       },
     });
 
@@ -119,7 +121,7 @@ export class GraphQLController extends ConduitRouter {
         let parseResult: ParseResult = this._parser.extractTypes(
           name + 'Request',
           input.bodyParams,
-          true
+          true,
         );
         this.types += parseResult.typeString;
         params += (params.length > 1 ? ',' : '') + 'params' + ':';
@@ -300,11 +302,11 @@ export class GraphQLController extends ConduitRouter {
       parent: any,
       args: any,
       context: any,
-      info: any
+      info: any,
     ) => {
       let { caching, cacheAge, scope } = extractCachingGql(
         route,
-        context.headers['Cache-Control']
+        context.headers['Cache-Control'],
       );
       if (caching) {
         info.cacheControl.setCacheHint({ maxAge: cacheAge, scope });
@@ -372,7 +374,7 @@ export class GraphQLController extends ConduitRouter {
       parent: any,
       args: any,
       context: any,
-      info: any
+      info: any,
     ) => {
       args = self.shouldPopulate(args, info);
       context.path = route.input.path;
@@ -386,6 +388,17 @@ export class GraphQLController extends ConduitRouter {
         })
         .then((r) => {
           let result = r.result ? r.result : r;
+          if (r.setCookies) {
+            const cookies = JSON.parse(r.setCookies);
+            let cookieString = Object.keys(cookies).map((key) => {
+              return `${key}=${cookies[key]}`;
+            }).join(';');
+            context.setCookieString = cookieString;
+          }
+          if (r.removeCookies) {
+            context.removeCookieString = r.removeCookies;
+          }
+
           if (r.result && !(typeof route.returnTypeFields === 'string')) {
             result = JSON.parse(result);
           } else {
@@ -397,6 +410,10 @@ export class GraphQLController extends ConduitRouter {
         })
         .catch(errorHandler);
     };
+  }
+
+  willSendResponse(context: any) {
+
   }
 
   private addConduitRoute(route: ConduitRoute) {

--- a/packages/router/src/controllers/GraphQl/GraphQL.ts
+++ b/packages/router/src/controllers/GraphQl/GraphQL.ts
@@ -47,7 +47,7 @@ export class GraphQLController extends ConduitRouter {
       context: ({ req, res }: any) => {
         const context = (req as any).conduit || {};
         let headers: any = req.headers;
-        return { context, headers, setCookie: {}, removeCookie: '', res };
+        return { context, headers, setCookie: [], removeCookie: [], res };
       },
     });
 
@@ -389,11 +389,9 @@ export class GraphQLController extends ConduitRouter {
         .then((r) => {
           let result = r.result ? r.result : r;
           if (r.setCookies) {
-            const cookies = JSON.parse(r.setCookies);
-            context.setCookie = cookies;
+            context.setCookie = r.setCookies;
           }
           if (r.removeCookies) {
-
             context.removeCookie = r.removeCookies;
           }
 

--- a/packages/router/src/controllers/GraphQl/GraphQL.ts
+++ b/packages/router/src/controllers/GraphQl/GraphQL.ts
@@ -44,10 +44,10 @@ export class GraphQLController extends ConduitRouter {
       typeDefs: this.typeDefs,
       resolvers: this.resolvers,
       plugins: [cookiePlugin],
-      context: ({ event, req }: any) => {
+      context: ({ req, res }: any) => {
         const context = (req as any).conduit || {};
         let headers: any = req.headers;
-        return { context, headers, setCookieString: '', removeCookieString: '', set: false };
+        return { context, headers, setCookie: {}, removeCookie: '', res };
       },
     });
 
@@ -390,13 +390,11 @@ export class GraphQLController extends ConduitRouter {
           let result = r.result ? r.result : r;
           if (r.setCookies) {
             const cookies = JSON.parse(r.setCookies);
-            let cookieString = Object.keys(cookies).map((key) => {
-              return `${key}=${cookies[key]}`;
-            }).join(';');
-            context.setCookieString = cookieString;
+            context.setCookie = cookies;
           }
           if (r.removeCookies) {
-            context.removeCookieString = r.removeCookies;
+
+            context.removeCookie = r.removeCookies;
           }
 
           if (r.result && !(typeof route.returnTypeFields === 'string')) {

--- a/packages/router/src/controllers/GraphQl/utils/cookie.plugin.ts
+++ b/packages/router/src/controllers/GraphQl/utils/cookie.plugin.ts
@@ -14,7 +14,7 @@ module.exports = {
 
         if (removeCookie) {
           removeCookie.forEach((cookie: any) => {
-            res.clearCookie(cookie.name, { domain: cookie.options.domain, path: cookie.options.path });
+            res.clearCookie(cookie.name, cookie.options);
           });
         }
         return requestContext;

--- a/packages/router/src/controllers/GraphQl/utils/cookie.plugin.ts
+++ b/packages/router/src/controllers/GraphQl/utils/cookie.plugin.ts
@@ -7,6 +7,8 @@ module.exports = {
         const { res } = requestContext.context;
 
         setCookie.forEach((cookie: any) => {
+          if (cookie.options.path === '')
+            delete cookie.options.path
           res.cookie(cookie.name, cookie.value, cookie.options);
         });
 

--- a/packages/router/src/controllers/GraphQl/utils/cookie.plugin.ts
+++ b/packages/router/src/controllers/GraphQl/utils/cookie.plugin.ts
@@ -1,13 +1,9 @@
-import { remove } from 'lodash';
-
-const cookie = require('cookie');
-
 module.exports = {
   requestDidStart() {
     return {
       willSendResponse(requestContext: any) {
 
-        const { setCookie, removeCookie, cookieOptions } = requestContext.context;
+        const { setCookie, removeCookie } = requestContext.context;
         const { res } = requestContext.context;
 
         setCookie.forEach((cookie: any) => {
@@ -15,8 +11,8 @@ module.exports = {
         });
 
         if (removeCookie) {
-          removeCookie.forEach((cookie: string) => {
-            res.clearCookie(cookie, { domain: cookieOptions.domain, path: cookieOptions.path });
+          removeCookie.forEach((cookie: any) => {
+            res.clearCookie(cookie.name, { domain: cookie.options.domain, path: cookie.options.path });
           });
         }
         return requestContext;

--- a/packages/router/src/controllers/GraphQl/utils/cookie.plugin.ts
+++ b/packages/router/src/controllers/GraphQl/utils/cookie.plugin.ts
@@ -4,16 +4,19 @@ module.exports = {
   requestDidStart() {
     return {
       willSendResponse(requestContext: any) {
-        const { setCookieString } = requestContext.context;
-        let cookieArray = setCookieString.split(';');
-        let cookiesObject: any = [];
-        cookieArray.forEach((cookie: string) => {
-          cookiesObject.push({
-            'Set-Cookie': cookie,
-          });
+
+        const { setCookie, removeCookie } = requestContext.context;
+        const { res } = requestContext.context;
+
+        Object.keys(setCookie).forEach((cookie) => {
+          res.cookie(cookie, setCookie[cookie]);
         });
-        const map = new Map(cookiesObject);
-        requestContext.http.headers = map;
+
+        if (removeCookie) {
+          removeCookie.split(',').forEach((cookie: string) => {
+            res.clearCookie(cookie);
+          });
+        }
         return requestContext;
       },
 

--- a/packages/router/src/controllers/GraphQl/utils/cookie.plugin.ts
+++ b/packages/router/src/controllers/GraphQl/utils/cookie.plugin.ts
@@ -7,7 +7,7 @@ module.exports = {
     return {
       willSendResponse(requestContext: any) {
 
-        const { setCookie, removeCookie } = requestContext.context;
+        const { setCookie, removeCookie, cookieOptions } = requestContext.context;
         const { res } = requestContext.context;
 
         setCookie.forEach((cookie: any) => {
@@ -16,7 +16,7 @@ module.exports = {
 
         if (removeCookie) {
           removeCookie.forEach((cookie: string) => {
-            res.clearCookie(cookie);
+            res.clearCookie(cookie, { domain: cookieOptions.domain, path: cookieOptions.path });
           });
         }
         return requestContext;

--- a/packages/router/src/controllers/GraphQl/utils/cookie.plugin.ts
+++ b/packages/router/src/controllers/GraphQl/utils/cookie.plugin.ts
@@ -1,0 +1,22 @@
+const cookie = require('cookie');
+
+module.exports = {
+  requestDidStart() {
+    return {
+      willSendResponse(requestContext: any) {
+        const { setCookieString } = requestContext.context;
+        let cookieArray = setCookieString.split(';');
+        let cookiesObject: any = [];
+        cookieArray.forEach((cookie: string) => {
+          cookiesObject.push({
+            'Set-Cookie': cookie,
+          });
+        });
+        const map = new Map(cookiesObject);
+        requestContext.http.headers = map;
+        return requestContext;
+      },
+
+    };
+  },
+};

--- a/packages/router/src/controllers/GraphQl/utils/cookie.plugin.ts
+++ b/packages/router/src/controllers/GraphQl/utils/cookie.plugin.ts
@@ -1,3 +1,5 @@
+import { remove } from 'lodash';
+
 const cookie = require('cookie');
 
 module.exports = {
@@ -8,12 +10,12 @@ module.exports = {
         const { setCookie, removeCookie } = requestContext.context;
         const { res } = requestContext.context;
 
-        Object.keys(setCookie).forEach((cookie) => {
-          res.cookie(cookie, setCookie[cookie]);
+        setCookie.forEach((cookie: any) => {
+          res.cookie(cookie.name, cookie.value, cookie.options);
         });
 
         if (removeCookie) {
-          removeCookie.split(',').forEach((cookie: string) => {
+          removeCookie.forEach((cookie: string) => {
             res.clearCookie(cookie);
           });
         }

--- a/packages/router/src/controllers/Rest/Rest.ts
+++ b/packages/router/src/controllers/Rest/Rest.ts
@@ -168,14 +168,13 @@ export class RestController extends ConduitRouter {
                 result: this.extractResult(route.returnTypeFields as string, result),
               };
             }
-            if (r.setCookies) {
-              const cookies = JSON.parse(r.setCookies);
-              Object.keys(cookies).forEach((key) => {
-                res.cookie(key, cookies[key]);
+            if (r.setCookies && r.setCookies.length) {
+              r.setCookies.forEach((cookie: any) => {
+                res.cookie(cookie.name, cookie.value,cookie.options);
               });
             }
-            if (r.removeCookies && r.removeCookies !== '') {
-              (r.removeCookies.split(',')).forEach((key: string) => {
+            if (r.removeCookies && r.removeCookies.length) {
+              (r.removeCookies).forEach((key: string) => {
                 res.clearCookie(key);
               });
             }

--- a/packages/router/src/controllers/Rest/Rest.ts
+++ b/packages/router/src/controllers/Rest/Rest.ts
@@ -174,8 +174,8 @@ export class RestController extends ConduitRouter {
               });
             }
             if (r.removeCookies && r.removeCookies.length) {
-              (r.removeCookies).forEach((key: string) => {
-                res.clearCookie(key, { domain: r.cookieOptions.domain, path: r.cookieOptions.path });
+              (r.removeCookies).forEach((cookie: any) => {
+                res.clearCookie(cookie.name, { domain: r.removeCookies.options.domain, path: r.removeCookies.options.path });
               });
             }
             if (route.input.action === ConduitRouteActions.GET && caching) {

--- a/packages/router/src/controllers/Rest/Rest.ts
+++ b/packages/router/src/controllers/Rest/Rest.ts
@@ -170,6 +170,8 @@ export class RestController extends ConduitRouter {
             }
             if (r.setCookies && r.setCookies.length) {
               r.setCookies.forEach((cookie: any) => {
+                if (cookie.options.path === '')
+                  delete cookie.options.path
                 res.cookie(cookie.name, cookie.value,cookie.options);
               });
             }

--- a/packages/router/src/controllers/Rest/Rest.ts
+++ b/packages/router/src/controllers/Rest/Rest.ts
@@ -175,7 +175,7 @@ export class RestController extends ConduitRouter {
             }
             if (r.removeCookies && r.removeCookies.length) {
               (r.removeCookies).forEach((key: string) => {
-                res.clearCookie(key);
+                res.clearCookie(key, { domain: r.cookieOptions.domain, path: r.cookieOptions.path });
               });
             }
             if (route.input.action === ConduitRouteActions.GET && caching) {
@@ -185,6 +185,7 @@ export class RestController extends ConduitRouter {
               res.setHeader('Cache-Control', 'no-store');
             }
             res.status(200).json(result);
+            res.end()
           }
         })
         .catch((err: Error | ConduitError | any) => {

--- a/packages/router/src/controllers/Rest/Rest.ts
+++ b/packages/router/src/controllers/Rest/Rest.ts
@@ -174,9 +174,8 @@ export class RestController extends ConduitRouter {
                 res.cookie(key, cookies[key]);
               });
             }
-            if (r.removeCookies) {
-              const cookies = JSON.parse(r.setCookies);
-              Object.keys(cookies).forEach((key) => {
+            if (r.removeCookies && r.removeCookies !== '') {
+              (r.removeCookies.split(',')).forEach((key: string) => {
                 res.clearCookie(key);
               });
             }

--- a/packages/router/src/controllers/Rest/Rest.ts
+++ b/packages/router/src/controllers/Rest/Rest.ts
@@ -168,21 +168,23 @@ export class RestController extends ConduitRouter {
                 result: this.extractResult(route.returnTypeFields as string, result),
               };
             }
-            if (result.cookies) {
-              const cookies = result.cookies;
-              Object.keys(cookies).forEach((key: string) => {
+            if (r.setCookies) {
+              const cookies = JSON.parse(r.setCookies);
+              Object.keys(cookies).forEach((key) => {
                 res.cookie(key, cookies[key]);
               });
             }
-
+            if (r.removeCookies) {
+              const cookies = JSON.parse(r.setCookies);
+              Object.keys(cookies).forEach((key) => {
+                res.clearCookie(key);
+              });
+            }
             if (route.input.action === ConduitRouteActions.GET && caching) {
               this.storeInCache(hashKey, result, cacheAge!);
               res.setHeader('Cache-Control', `${scope}, max-age=${cacheAge}`);
             } else {
               res.setHeader('Cache-Control', 'no-store');
-            }
-            if (result.cookies) {
-              delete result.cookies;
             }
             res.status(200).json(result);
           }

--- a/packages/router/src/controllers/Rest/util.ts
+++ b/packages/router/src/controllers/Rest/util.ts
@@ -6,17 +6,6 @@ export function extractRequestData(req: Request) {
   const context = (req as any).conduit || {};
   let params: any = {};
   let headers: any = req.headers;
-  if (req.headers.hasOwnProperty('cookie')) {
-    let actualCookies: any = {};
-    let cookies = (req.headers.cookie!).split(';');
-    cookies.forEach((cookie: string) => {
-      const temp = cookie.split('=');
-      const key = temp[0];
-      const value = temp[1];
-      actualCookies[key] = value;
-    });
-    context['cookies'] = actualCookies;
-  }
   if (req.query) {
     let newObj = {};
     Object.keys(req.query).forEach((k: string) => {

--- a/packages/router/src/controllers/Rest/util.ts
+++ b/packages/router/src/controllers/Rest/util.ts
@@ -6,6 +6,17 @@ export function extractRequestData(req: Request) {
   const context = (req as any).conduit || {};
   let params: any = {};
   let headers: any = req.headers;
+  if (req.headers.hasOwnProperty('cookie')) {
+    let actualCookies: any = {};
+    let cookies = (req.headers.cookie!).split(';');
+    cookies.forEach((cookie: string) => {
+      const temp = cookie.split('=');
+      const key = temp[0];
+      const value = temp[1];
+      actualCookies[key] = value;
+    });
+    context['cookies'] = actualCookies;
+  }
   if (req.query) {
     let newObj = {};
     Object.keys(req.query).forEach((k: string) => {


### PR DESCRIPTION
- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other (please describe)

**Does this PR introduce a breaking change?** <!-- (check one) -->

- [ ] Yes
- [x] No

If adding a **new feature**, the PR's description includes:

Many applications use cookies for their authentication tokens, and conduit should have an option to set cookies instead of providing creds in response.

- Cookie functionality is configurable through `setCookies.enabled` config option.
- When cookies are returned from authentication module, router wraps them in the response object.
- When a request arrives, cookies are accessible through `call.request.context.cookies` object.
