### PR TITLE
fix(commons,config,core,router,admin,security): config update

### DIFF
--- a/packages/admin/src/index.ts
+++ b/packages/admin/src/index.ts
@@ -44,7 +44,6 @@ const swaggerRouterMetadata: SwaggerRouterMetadata = {
 };
 
 export default class AdminModule extends IConduitAdmin {
-  commons: ConduitCommons;
   grpcSdk: ConduitGrpcSdk;
   private _restRouter: RestController;
   private _sdkRoutes: ConduitRoute[];
@@ -56,8 +55,7 @@ export default class AdminModule extends IConduitAdmin {
     packageDefinition: any,
     server: Server,
   ) {
-    super();
-    this.commons = commons;
+    super(commons);
     this.grpcSdk = grpcSdk;
     this._restRouter = new RestController(this.commons, swaggerRouterMetadata);
 

--- a/packages/commons/src/index.ts
+++ b/packages/commons/src/index.ts
@@ -1,6 +1,9 @@
-import { IConduitRouter } from './modules';
-import { IConduitAdmin } from './modules';
-import { IConduitSecurity } from './modules';
+import {
+  IConduitCore,
+  IConduitAdmin,
+  IConduitRouter,
+  IConduitSecurity,
+} from './modules';
 import { isNil, isPlainObject } from 'lodash';
 import validator from 'validator';
 import isNaturalNumber from 'is-natural-number';
@@ -8,10 +11,10 @@ import { IConfigManager } from './modules';
 import { StateManager } from './utilities/StateManager';
 import { RedisManager } from './utilities/RedisManager';
 import { EventBus } from './utilities/EventBus';
-import Crypto from 'crypto';
 
 export class ConduitCommons {
   private static _instance: ConduitCommons;
+  private _core?: IConduitCore;
   private _router?: IConduitRouter;
   private _admin?: IConduitAdmin;
   private _security?: IConduitSecurity;
@@ -20,12 +23,8 @@ export class ConduitCommons {
   private readonly _stateManager: StateManager;
   private readonly name: string;
 
-  private constructor(name?: string) {
-    if (!name) {
-      this.name = 'corepackage_' + Crypto.randomBytes(16).toString('hex');
-    } else {
-      this.name = name;
-    }
+  private constructor(name: string) {
+    this.name = name;
     if (process.env.REDIS_HOST && process.env.REDIS_PORT) {
       let redisManager = new RedisManager(process.env.REDIS_HOST, process.env.REDIS_PORT);
       this._eventBus = new EventBus(redisManager);
@@ -34,6 +33,16 @@ export class ConduitCommons {
       console.error('Redis IP not defined');
       process.exit(-1);
     }
+  }
+
+  registerCore(core: IConduitCore) {
+    if (this._core) throw new Error('Cannot register a second core!');
+    this._core = core;
+  }
+
+  getCore() {
+    if (this._core) return this._core;
+    throw new Error('Core not assigned yet!');
   }
 
   registerRouter(router: IConduitRouter) {

--- a/packages/commons/src/modules/Admin/ConduitAdmin.ts
+++ b/packages/commons/src/modules/Admin/ConduitAdmin.ts
@@ -1,6 +1,12 @@
-import { ConduitRoute } from '../../index';
+import { ConduitCommons, ConduitRoute } from '../..';
 
 export abstract class IConduitAdmin {
+  protected constructor(protected readonly commons: ConduitCommons) {}
+
   abstract initialize(): void;
   abstract registerRoute(route: ConduitRoute): void;
+
+  setConfig(moduleConfig: any) {
+    this.commons.getBus().publish('config:update:admin', JSON.stringify(moduleConfig));
+  };
 }

--- a/packages/commons/src/modules/Core/index.ts
+++ b/packages/commons/src/modules/Core/index.ts
@@ -1,0 +1,9 @@
+import { ConduitCommons } from '../..';
+
+export abstract class IConduitCore {
+  protected constructor(protected readonly commons: ConduitCommons) {}
+
+  setConfig(moduleConfig: any) {
+    this.commons.getBus().publish('config:update:core', JSON.stringify(moduleConfig));
+  };
+}

--- a/packages/commons/src/modules/Router/interfaces/Router.ts
+++ b/packages/commons/src/modules/Router/interfaces/Router.ts
@@ -3,7 +3,6 @@ import { ConduitRouterBuilder } from '../classes';
 import {
   ConduitMiddleware,
   ConduitRoute,
-  ConduitRouteParameters,
 } from '../../../interfaces';
 
 export interface IConduitRouter {
@@ -27,4 +26,6 @@ export interface IConduitRouter {
   ): void;
 
   getRegisteredRoutes(): any;
+
+  setConfig(moduleConfig: any): void;
 }

--- a/packages/commons/src/modules/Security/ConduitSecurity.ts
+++ b/packages/commons/src/modules/Security/ConduitSecurity.ts
@@ -1,5 +1,10 @@
-import { ConduitCommons } from '../../index';
+import { ConduitCommons } from '../..';
 
 export abstract class IConduitSecurity {
-  constructor(conduit: ConduitCommons) {}
+  protected constructor(protected readonly commons: ConduitCommons) {}
+
+  setConfig(moduleConfig: any) {
+    // TODO: Re-register routes etc
+    this.commons.getBus().publish('config:update:security', JSON.stringify(moduleConfig));
+  };
 }

--- a/packages/commons/src/modules/index.ts
+++ b/packages/commons/src/modules/index.ts
@@ -1,3 +1,4 @@
+export * from './Core';
 export * from './Router';
 export * from './Admin';
 export * from './Security';

--- a/packages/config/src/admin/routes/GetConfig.route.ts
+++ b/packages/config/src/admin/routes/GetConfig.route.ts
@@ -82,6 +82,15 @@ export function getGetConfigRoute(
         case 'core':
           finalConfig = dbConfig.moduleConfigs.core;
           break;
+        case 'router':
+          finalConfig = dbConfig.moduleConfigs.router;
+          break;
+        case 'admin':
+          finalConfig = dbConfig.moduleConfigs.admin;
+          break;
+        case 'security':
+          finalConfig = dbConfig.moduleConfigs.security;
+          break;
         default:
           throw new ConduitError('NOT_FOUND', 404, 'Resource not found');
       }

--- a/packages/config/src/admin/routes/UpdateConfig.route.ts
+++ b/packages/config/src/admin/routes/UpdateConfig.route.ts
@@ -89,6 +89,15 @@ export function getUpdateConfigRoute(
         case 'core':
           updatedConfig = await conduit.getConfigManager().set('core', newConfig);
           break;
+        case 'router':
+          updatedConfig = await conduit.getConfigManager().set('router', newConfig);
+          break;
+        case 'admin':
+          updatedConfig = await conduit.getConfigManager().set('admin', newConfig);
+          break;
+        case 'security':
+          updatedConfig = await conduit.getConfigManager().set('security', newConfig);
+          break;
         default:
           throw new ConduitError('NOT_FOUND', 404, 'Resource not found');
       }

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -199,6 +199,22 @@ export default class ConfigManager implements IConfigManager {
         this.configDocId!,
         { $set: { [`moduleConfigs.${moduleName}`]: moduleConfig } },
       );
+      switch (moduleName) {
+        case 'core':
+          this.sdk.getCore().setConfig(moduleConfig);
+          break;
+        case 'admin':
+          this.sdk.getAdmin().setConfig(moduleConfig);
+          break;
+        case 'router':
+          this.sdk.getRouter().setConfig(moduleConfig);
+          break;
+        case 'security':
+          this.sdk.getSecurity().setConfig(moduleConfig);
+          break;
+        default:
+          break;
+      }
       return moduleConfig;
     } catch {
       console.error(`Could not update "${moduleName}" configuration`);

--- a/packages/core/src/Core.ts
+++ b/packages/core/src/Core.ts
@@ -1,11 +1,10 @@
-import { ConduitCommons } from '@conduitplatform/commons';
+import { ConduitCommons, IConduitCore } from '@conduitplatform/commons';
 import { HttpServer} from './HttpServer';
 import { GrpcServer } from './GrpcServer';
 import { isNil } from 'lodash';
 
-export class Core {
+export class Core extends IConduitCore {
   private static _instance: Core;
-  private readonly commons: ConduitCommons;
   private readonly _httpServer: HttpServer;
   private readonly _grpcServer: GrpcServer;
 
@@ -14,7 +13,8 @@ export class Core {
   get initialized() { return this._httpServer.initialized && this._grpcServer.initialized; }
 
   private constructor(httpPort: number | string, grpcPort: number) {
-    this.commons = ConduitCommons.getInstance('core');
+    super(ConduitCommons.getInstance('core'));
+    this.commons.registerCore(this);
     this._grpcServer = new GrpcServer(this.commons, grpcPort);
     this._httpServer = new HttpServer(httpPort, this.commons);
   }

--- a/packages/router/src/index.ts
+++ b/packages/router/src/index.ts
@@ -321,6 +321,10 @@ export class ConduitDefaultRouter implements IConduitRouter {
     this._commons.getAdmin().registerRoute(adminRoutes.getRoutes(this));
     this._commons.getAdmin().registerRoute(adminRoutes.getMiddlewares(this));
   }
+
+  setConfig(moduleConfig: any) {
+    this._commons.getBus().publish('config:update:router', JSON.stringify(moduleConfig));
+  }
 }
 
 export * from './builders';

--- a/packages/security/src/index.ts
+++ b/packages/security/src/index.ts
@@ -9,7 +9,7 @@ import * as models from './models';
 
 class SecurityModule extends IConduitSecurity {
   constructor(
-    private readonly commons: ConduitCommons,
+    commons: ConduitCommons,
     private readonly grpcSdk: ConduitGrpcSdk
   ) {
     super(commons);


### PR DESCRIPTION
Adds `setConfig()` to configurable core module abstract classes and interfaces in `commons` sdk.
Fixes `set/getConfig()` not working for `admin`, `router`.
Adds `set/getConfig()` for `security`.

**What kind of change does this PR introduce?** <!--(check at least one)-->

- [X] Bugfix
- [X] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other (please describe)

**Does this PR introduce a breaking change?** <!-- (check one) -->

- [ ] Yes
- [X] No

**The PR fulfills these requirements:**

- [X] It's submitted to the `main` branch
- [ ] When resolving a specific issue, it's referenced in the PR's description  (e.g. `fix #xxx`, where "xxx" is the issue number)

If adding a **new feature**, the PR's description includes:

- [X] A convincing reason for adding this feature <!-- to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it -->
