### PR TITLE
fix(config,grpc-sdk): updateModuleHealth() not reregistering removed modules

### DIFF
--- a/libraries/grpc-sdk/src/modules/config/index.ts
+++ b/libraries/grpc-sdk/src/modules/config/index.ts
@@ -103,14 +103,15 @@ export class Config extends ConduitModule<typeof ConfigDefinition> {
         return res.result;
       })
       .then((r) => {
-        setInterval(() => self.moduleHealthProbe.bind(self)(name), 2000);
+        setInterval(() => self.moduleHealthProbe.bind(self)(name, url), 2000);
         return r;
       });
   }
 
-  moduleHealthProbe(name: string) {
+  moduleHealthProbe(name: string, url: string) {
     const request: ModuleHealthRequest = {
       moduleName: name.toString(),
+      url,
       status: this._serviceHealthStatusGetter(),
     };
     const self = this;

--- a/packages/core/src/core.proto
+++ b/packages/core/src/core.proto
@@ -100,7 +100,8 @@ message Empty {
 
 message ModuleHealthRequest {
     string moduleName = 1;
-    int32 status = 2; // [0, 1, 2]
+    string url = 2;
+    int32 status = 3; // [0, 1, 2]
 }
 
 message ModuleByNameRequest {


### PR DESCRIPTION
Modules attempting to `moduleHealthProbe()` after being removed from `Config.registeredModules` due to inactivity are now successfully reregistered.

**What kind of change does this PR introduce?** <!--(check at least one)-->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other (please describe)

**Does this PR introduce a breaking change?** <!-- (check one) -->

- [ ] Yes
- [X] No

<!-- If yes, please describe the impact and migration path for existing applications. -->

**The PR fulfills these requirements:**

- [X] It's submitted to the `main` branch
- [ ] When resolving a specific issue, it's referenced in the PR's description  (e.g. `fix #xxx`, where "xxx" is the issue number)