### PR TITLE
chore(commons,sms,email,database,chat,authentication,storage): use grpc-tools instead of protoc

### DIFF
--- a/libraries/grpc-sdk/package.json
+++ b/libraries/grpc-sdk/package.json
@@ -42,7 +42,6 @@
     "directory": "libraries/grpc-sdk"
   },
   "devDependencies": {
-    "@grpc/proto-loader": "^0.6.9",
     "@types/convict": "^4.2.1",
     "@types/google-protobuf": "^3.15.5",
     "@types/ioredis": "^4.28.7",

--- a/modules/authentication/build.sh
+++ b/modules/authentication/build.sh
@@ -2,7 +2,8 @@ rm -rf ./src/protoTypes
 mkdir ./src/protoTypes
 
 echo "Generating typescript code"
-protoc --plugin=./node_modules/.bin/protoc-gen-ts_proto\
+./node_modules/.bin/grpc_tools_node_protoc \
+  --plugin=./node_modules/.bin/protoc-gen-ts_proto\
   --ts_proto_out=./src/protoTypes\
   --ts_proto_opt=onlyTypes=true\
   ./src/authentication.proto

--- a/modules/authentication/package.json
+++ b/modules/authentication/package.json
@@ -39,6 +39,7 @@
     "uuid": "^7.0.2"
   },
   "devDependencies": {
+    "grpc-tools": "^1.11.2",
     "@types/bcrypt": "^3.0.0",
     "@types/convict": "^4.2.1",
     "@types/jsonwebtoken": "^8.3.9",

--- a/modules/chat/build.sh
+++ b/modules/chat/build.sh
@@ -2,7 +2,8 @@ rm -rf ./src/protoTypes
 mkdir ./src/protoTypes
 
 echo "Generating typescript code"
-protoc --plugin=./node_modules/.bin/protoc-gen-ts_proto\
+./node_modules/.bin/grpc_tools_node_protoc \
+  --plugin=./node_modules/.bin/protoc-gen-ts_proto\
   --ts_proto_out=./src/protoTypes\
   --ts_proto_opt=onlyTypes=true\
   ./src/chat.proto

--- a/modules/chat/package.json
+++ b/modules/chat/package.json
@@ -35,6 +35,7 @@
   },
   "devDependencies": {
     "rimraf": "^3.0.2",
+    "grpc-tools": "^1.11.2",
     "copyfiles": "^2.2.0",
     "typescript": "~4.2.0",
     "@types/uuid": "^7.0.2",

--- a/modules/database/build.sh
+++ b/modules/database/build.sh
@@ -2,7 +2,8 @@ rm -rf ./src/protoTypes
 mkdir ./src/protoTypes
 
 echo "Generating typescript code"
-protoc --plugin=./node_modules/.bin/protoc-gen-ts_proto\
+./node_modules/.bin/grpc_tools_node_protoc \
+  --plugin=./node_modules/.bin/protoc-gen-ts_proto\
   --ts_proto_out=./src/protoTypes\
   --ts_proto_opt=onlyTypes=true\
   ./src/database.proto

--- a/modules/database/package.json
+++ b/modules/database/package.json
@@ -48,6 +48,7 @@
     "registry": "https://npm.pkg.github.com/"
   },
   "devDependencies": {
+    "grpc-tools": "^1.11.2",
     "@types/lodash": "^4.14.149",
     "copyfiles": "^2.2.0",
     "rimraf": "^3.0.2",

--- a/modules/email/build.sh
+++ b/modules/email/build.sh
@@ -2,7 +2,8 @@ rm -rf ./src/protoTypes
 mkdir ./src/protoTypes
 
 echo "Generating typescript code"
-protoc --plugin=./node_modules/.bin/protoc-gen-ts_proto\
+./node_modules/.bin/grpc_tools_node_protoc \
+  --plugin=./node_modules/.bin/protoc-gen-ts_proto\
   --ts_proto_out=./src/protoTypes\
   --ts_proto_opt=onlyTypes=true\
   ./src/email.proto

--- a/modules/email/package.json
+++ b/modules/email/package.json
@@ -50,6 +50,7 @@
     "copyfiles": "^2.2.0",
     "rimraf": "^3.0.2",
     "smtp-server": "^3.6.0",
+    "grpc-tools": "^1.11.2",
     "typescript": "~4.2.0",
     "@types/mailgun-js": "^0.22.12",
     "@types/mandrill-api": "^1.0.30",

--- a/modules/sms/build.sh
+++ b/modules/sms/build.sh
@@ -2,7 +2,8 @@ rm -rf ./src/protoTypes
 mkdir ./src/protoTypes
 
 echo "Generating typescript code"
-protoc --plugin=./node_modules/.bin/protoc-gen-ts_proto\
+./node_modules/.bin/grpc_tools_node_protoc \
+  --plugin=./node_modules/.bin/protoc-gen-ts_proto\
   --ts_proto_out=./src/protoTypes\
   --ts_proto_opt=onlyTypes=true\
   ./src/sms.proto

--- a/modules/sms/package.json
+++ b/modules/sms/package.json
@@ -31,6 +31,7 @@
     "twilio": "3.54.2"
   },
   "devDependencies": {
+    "grpc-tools": "^1.11.2",
     "@types/convict": "^4.2.1",
     "@types/lodash": "^4.14.149",
     "copyfiles": "^2.2.0",

--- a/modules/storage/build.sh
+++ b/modules/storage/build.sh
@@ -2,7 +2,8 @@ rm -rf ./src/protoTypes
 mkdir ./src/protoTypes
 
 echo "Generating typescript code"
-protoc --plugin=./node_modules/.bin/protoc-gen-ts_proto\
+./node_modules/.bin/grpc_tools_node_protoc \
+  --plugin=./node_modules/.bin/protoc-gen-ts_proto\
   --ts_proto_out=./src/protoTypes\
   --ts_proto_opt=onlyTypes=true\
   ./src/storage.proto

--- a/modules/storage/package.json
+++ b/modules/storage/package.json
@@ -44,6 +44,7 @@
     "uuid": "^7.0.3"
   },
   "devDependencies": {
+    "grpc-tools": "^1.11.2",
     "@types/convict": "^4.2.1",
     "@types/lodash": "^4.14.149",
     "@types/uuid": "^7.0.2",

--- a/packages/commons/build.sh
+++ b/packages/commons/build.sh
@@ -5,7 +5,8 @@ cp ../core/src/core.proto ./src/
 
 
 echo "Generating typescript code"
-protoc --plugin=./node_modules/.bin/protoc-gen-ts_proto\
+./node_modules/.bin/grpc_tools_node_protoc \
+  --plugin=./node_modules/.bin/protoc-gen-ts_proto\
   --ts_proto_out=./src/protoTypes\
   --ts_proto_opt=onlyTypes=true\
   ./src/core.proto

--- a/packages/commons/package.json
+++ b/packages/commons/package.json
@@ -34,6 +34,7 @@
     "directory": "packages/commons"
   },
   "devDependencies": {
+    "grpc-tools": "^1.11.2",
     "@types/convict": "^4.2.1",
     "@types/express": "~4.16.1",
     "@types/ioredis": "^4.22.0",


### PR DESCRIPTION
fix(grpc-sdk): duplicate import of proto-loader
chore(commons,sms,email,database,chat,authentication): use grpc-tools instead of protoc

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/ConduitPlatform/Conduit/blob/main/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** <!--(check at least one)-->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [x] Build-related changes
- [ ] Other (please describe)

**Does this PR introduce a breaking change?** <!-- (check one) -->

- [ ] Yes
- [x] No

<!-- If yes, please describe the impact and migration path for existing applications. -->

**The PR fulfills these requirements:**

- [x] It's submitted to the `main` branch
- [x] When resolving a specific issue, it's referenced in the PR's description  (e.g. `fix #xxx`, where "xxx" is the issue number)

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature <!-- to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it -->

**Other information:**
