### PR TITLE
fix(database): get pending query params not parsed, add search param

### DIFF
--- a/modules/database/src/admin/admin.ts
+++ b/modules/database/src/admin/admin.ts
@@ -288,6 +288,12 @@ export class AdminHandlers {
       constructConduitRoute({
         path: '/introspection/schemas',
         action: ConduitRouteActions.GET,
+        queryParams: {
+          skip: ConduitNumber.Optional,
+          limit: ConduitNumber.Optional,
+          sort: ConduitString.Optional,
+          search: ConduitString.Optional,
+        }
       },
       new ConduitRouteReturnDefinition('GetPendingSchemas', { schemas: [PendingSchemas.fields] }),
       'getPendingSchemas'

--- a/modules/database/src/admin/schema.admin.ts
+++ b/modules/database/src/admin/schema.admin.ts
@@ -501,8 +501,8 @@ export class SchemaAdmin {
     const limit = call.request.params.limit ?? 25;
     let query = {};
     if (!isNil(search)) {
-      let identifier = escapeStringRegexp(search);
-      query ={ name : { $regex: `.*${identifier}.*`, $options: 'i' }};
+      const identifier = escapeStringRegexp(search);
+      query = { name : { $regex: `.*${identifier}.*`, $options: 'i' }};
     }
     const schemas = await this.database.getSchemaModel('_PendingSchemas').model.findMany(
       query,

--- a/modules/database/src/admin/schema.admin.ts
+++ b/modules/database/src/admin/schema.admin.ts
@@ -499,17 +499,13 @@ export class SchemaAdmin {
     const { search, sort } = call.request.params;
     const skip = call.request.params.skip ?? 0;
     const limit = call.request.params.limit ?? 25;
-    let query;
+    let query = {};
     if (!isNil(search)) {
       let identifier = escapeStringRegexp(search);
-      query = { $regex: `.*${identifier}.*`, $options: 'i' };
+      query ={ name : { $regex: `.*${identifier}.*`, $options: 'i' }};
     }
     const schemas = await this.database.getSchemaModel('_PendingSchemas').model.findMany(
-      query
-        ? {
-            name: query,
-          }
-        : {},
+      query,
       skip,
       limit,
       undefined,

--- a/modules/database/src/admin/schema.admin.ts
+++ b/modules/database/src/admin/schema.admin.ts
@@ -496,12 +496,25 @@ export class SchemaAdmin {
   }
 
   async getPendingSchemas(call: ParsedRouterRequest): Promise<UnparsedRouterResponse> {
-    const { sort } = call.request.params;
+    const { search, sort } = call.request.params;
     const skip = call.request.params.skip ?? 0;
     const limit = call.request.params.limit ?? 25;
-    const schemas = await this.database
-      .getSchemaModel('_PendingSchemas')
-      .model.findMany({}, skip, limit, undefined, sort);
+    let query;
+    if (!isNil(search)) {
+      let identifier = escapeStringRegexp(search);
+      query = { $regex: `.*${identifier}.*`, $options: 'i' };
+    }
+    const schemas = await this.database.getSchemaModel('_PendingSchemas').model.findMany(
+      query
+        ? {
+            name: query,
+          }
+        : {},
+      skip,
+      limit,
+      undefined,
+      sort
+    );
     return { schemas };
   }
 


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/ConduitPlatform/Conduit/blob/main/.github/CONTRIBUTING.md#pull-request-guidelines
-->
This PR fixes the query params not being parsed from the get pending schemas endpoint and adds support for search param.
<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** <!--(check at least one)-->

- [x] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other (please describe)

**Does this PR introduce a breaking change?** <!-- (check one) -->

- [ ] Yes
- [x] No

<!-- If yes, please describe the impact and migration path for existing applications. -->

**The PR fulfills these requirements:**

- [x] It's submitted to the `main` branch
