### PR TITLE
fix(database): database module triggers introspection on unpopulated dbs

### DIFF
--- a/modules/database/src/Database.ts
+++ b/modules/database/src/Database.ts
@@ -87,7 +87,7 @@ export default class DatabaseModule extends ManagedModule<void> {
 
   async onServerStart() {
     await this._activeAdapter.createSchemaFromAdapter(models.DeclaredSchema);
-    if(await this._activeAdapter.isPopulated()) {
+    if (await this._activeAdapter.isPopulated()) {
       const isConduitDb = await this._activeAdapter.isConduitDb();
       if (!isConduitDb) {
         await this.introspectDb();
@@ -558,7 +558,7 @@ export default class DatabaseModule extends ManagedModule<void> {
 
     await Promise.all(
       introspectedSchemas.map(async (schema: ConduitSchema) => {
-        if(isEmpty(schema.fields))
+        if (isEmpty(schema.fields))
           return null;
         await this._activeAdapter.getSchemaModel('_PendingSchemas').model.create(
           JSON.stringify({

--- a/modules/database/src/Database.ts
+++ b/modules/database/src/Database.ts
@@ -87,9 +87,11 @@ export default class DatabaseModule extends ManagedModule<void> {
 
   async onServerStart() {
     await this._activeAdapter.createSchemaFromAdapter(models.DeclaredSchema);
-    const isConduitDb = await this._activeAdapter.isConduitDb();
-    if (!isConduitDb) {
-      await this.introspectDb();
+    if(await this._activeAdapter.isPopulated()) {
+      const isConduitDb = await this._activeAdapter.isConduitDb();
+      if (!isConduitDb) {
+        await this.introspectDb();
+      }
     }
     this.updateHealth(HealthCheckStatus.SERVING);
     const modelPromises = Object.values(models).flatMap((model: any) => {

--- a/modules/database/src/adapters/DatabaseAdapter.ts
+++ b/modules/database/src/adapters/DatabaseAdapter.ts
@@ -8,7 +8,10 @@ import { ConduitDatabaseSchema } from '../interfaces/ConduitDatabaseSchema';
 export abstract class DatabaseAdapter<T extends SchemaAdapter<any>> {
   registeredSchemas: Map<string, ConduitSchema>;
   models?: { [name: string]: T };
-
+  /**
+   * Checks if the database has been populated with user defined schemas
+   */
+  abstract isPopulated(): Promise<boolean>;
   /**
    * Checks if the database has already been connected with Conduit
    */

--- a/modules/database/src/adapters/DatabaseAdapter.ts
+++ b/modules/database/src/adapters/DatabaseAdapter.ts
@@ -9,11 +9,11 @@ export abstract class DatabaseAdapter<T extends SchemaAdapter<any>> {
   registeredSchemas: Map<string, ConduitSchema>;
   models?: { [name: string]: T };
   /**
-   * Checks if the database has been populated with user defined schemas
+   * Checks whether the database has been populated with user defined schemas
    */
   abstract isPopulated(): Promise<boolean>;
   /**
-   * Checks if the database has already been connected with Conduit
+   * Checks whether the database has already been connected with Conduit
    */
   abstract isConduitDb(): Promise<boolean>;
 

--- a/modules/database/src/adapters/sequelize-adapter/index.ts
+++ b/modules/database/src/adapters/sequelize-adapter/index.ts
@@ -31,6 +31,17 @@ export class SequelizeAdapter extends DatabaseAdapter<SequelizeSchema> {
     this.sequelize = new Sequelize(this.connectionUri, { logging: false });
   }
 
+  async isPopulated(): Promise<boolean> {
+    return this.sequelize
+    .query(`SELECT COUNT(*)
+    FROM INFORMATION_SCHEMA.TABLES
+    WHERE TABLE_SCHEMA = 'public' AND TABLE_NAME <> '_DeclaredSchema';`)
+    .then((res) => parseInt((res as any)[0][0].count) > 0)
+    .catch((e) => {
+      console.log(e);
+      return false;
+    });
+  }
 
   async isConduitDb() {
     return this.sequelize


### PR DESCRIPTION
This PR addresses the issue where the database module would begin the introspection process even on unpopulated dbs. An additional check has been added to both database adapters where it first checks whether the db contains any user populated collections/tables before proceeding to introspection.
Fixes #167.
<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** <!--(check at least one)-->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other (please describe)

**Does this PR introduce a breaking change?** <!-- (check one) -->

- [ ] Yes
- [x] No

<!-- If yes, please describe the impact and migration path for existing applications. -->

**The PR fulfills these requirements:**

- [x] It's submitted to the `main` branch
- [x] When resolving a specific issue, it's referenced in the PR's description  (e.g. `fix #xxx`, where "xxx" is the issue number)
