### PR TITLE
feat(config): DEBUG__DISABLE_INACTIVE_MODULE_REMOVAL env var

### DIFF
--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -61,10 +61,13 @@ export default class ConfigManager implements IConfigManager {
       },
     );
     this.highAvailability();
-    const self = this;
-    setInterval(() => {
-      self.monitorModuleHealth();
-    }, 5000);
+    const disableModuleRemoval = process.env.DEBUG__DISABLE_INACTIVE_MODULE_REMOVAL === 'true';
+    if (!disableModuleRemoval) {
+      const self = this;
+      setInterval(() => {
+        self.monitorModuleHealth();
+      }, 5000);
+    }
   }
 
   async highAvailability() {


### PR DESCRIPTION
Setting `DEBUG__DISABLE_INACTIVE_MODULE_REMOVAL` to `true` prevents `Config` from kicking out inactive modules.
This was needed as debugging modules proved to be needlessly annoying for most typical debug sessions ever since fixing Config's inactive module kicking.

I opted for a verbose and descriptive env var instead of something like `DEBUG_MODE` as the modified behavior may still be unsuitable for certain debug sessions, plus we may wish to specifically enable/disable certain operations for debugging going forward.
Either way, it's not meant to be used by end users.

**What kind of change does this PR introduce?** <!--(check at least one)-->

- [ ] Bugfix
- [X] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other (please describe)

**Does this PR introduce a breaking change?** <!-- (check one) -->

- [ ] Yes
- [X] No

<!-- If yes, please describe the impact and migration path for existing applications. -->

**The PR fulfills these requirements:**

- [X] It's submitted to the `main` branch
- [ ] When resolving a specific issue, it's referenced in the PR's description  (e.g. `fix #xxx`, where "xxx" is the issue number)

If adding a **new feature**, the PR's description includes:

- [X] A convincing reason for adding this feature <!-- to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it -->
