### PR TITLE
Crud granularity

### DIFF
--- a/libraries/grpc-sdk/src/classes/Routing/RouteBuilder.ts
+++ b/libraries/grpc-sdk/src/classes/Routing/RouteBuilder.ts
@@ -36,7 +36,7 @@ export class RouteBuilder {
     if (!Array.isArray(middleware)) {
       middleware = [middleware];
     }
-    if (this._options.middlewares?.length !== 0) {
+    if (this._options.middlewares !== undefined && this._options.middlewares?.length !== 0) {
       if (allowDuplicates) {
         this._options.middlewares?.concat(middleware);
       } else {

--- a/modules/database/src/admin/admin.ts
+++ b/modules/database/src/admin/admin.ts
@@ -155,7 +155,7 @@ export class AdminHandlers {
             fields: ConduitJson.Required,
             modelOptions: ConduitJson.Optional,
             enabled: ConduitBoolean.Optional, // move inside modelOptions (frontend-compat)
-            authentication: {
+            crudOperations: {
               create: {
                 enabled: ConduitBoolean.Optional,
                 authenticated: ConduitBoolean.Required,
@@ -196,7 +196,7 @@ export class AdminHandlers {
             fields: ConduitJson.Optional,
             modelOptions: ConduitJson.Optional,
             enabled: ConduitBoolean.Optional, // move inside modelOptions (frontend-compat)
-            authentication: {
+            crudOperations: {
               create: {
                 enabled: ConduitBoolean.Optional,
                 authenticated: ConduitBoolean.Optional,

--- a/modules/database/src/admin/admin.ts
+++ b/modules/database/src/admin/admin.ts
@@ -155,24 +155,25 @@ export class AdminHandlers {
             fields: ConduitJson.Required,
             modelOptions: ConduitJson.Optional,
             enabled: ConduitBoolean.Optional, // move inside modelOptions (frontend-compat)
-            crudOperations: {
+            authentication: {
               create: {
-                enabled: ConduitBoolean.Required,
-                authentication: ConduitBoolean.Required,
+                enabled: ConduitBoolean.Optional,
+                authenticated: ConduitBoolean.Required,
               },
               read: {
-                enabled: ConduitBoolean.Required,
-                authentication: ConduitBoolean.Required,
+                enabled: ConduitBoolean.Optional,
+                authenticated: ConduitBoolean.Required,
               },
               update: {
-                enabled: ConduitBoolean.Required,
-                authentication: ConduitBoolean.Required,
+                enabled: ConduitBoolean.Optional,
+                authenticated: ConduitBoolean.Required,
               },
               delete: {
-                enabled: ConduitBoolean.Required,
-                authentication: ConduitBoolean.Required,
+                enabled: ConduitBoolean.Optional,
+                authenticated: ConduitBoolean.Required,
               },
             },
+            crudOperations: ConduitBoolean.Optional,
             permissions: {
               extendable: ConduitBoolean.Optional,
               canCreate: ConduitBoolean.Optional,

--- a/modules/database/src/admin/admin.ts
+++ b/modules/database/src/admin/admin.ts
@@ -155,8 +155,24 @@ export class AdminHandlers {
             fields: ConduitJson.Required,
             modelOptions: ConduitJson.Optional,
             enabled: ConduitBoolean.Optional, // move inside modelOptions (frontend-compat)
-            authentication: ConduitBoolean.Optional, // move inside modelOptions (frontend-compat)
-            crudOperations: ConduitBoolean.Optional, // move inside modelOptions (frontend-compat)
+            crudOperations: {
+              create: {
+                enabled: ConduitBoolean.Required,
+                authentication: ConduitBoolean.Required,
+              },
+              read: {
+                enabled: ConduitBoolean.Required,
+                authentication: ConduitBoolean.Required,
+              },
+              update: {
+                enabled: ConduitBoolean.Required,
+                authentication: ConduitBoolean.Required,
+              },
+              delete: {
+                enabled: ConduitBoolean.Required,
+                authentication: ConduitBoolean.Required,
+              },
+            },
             permissions: {
               extendable: ConduitBoolean.Optional,
               canCreate: ConduitBoolean.Optional,

--- a/modules/database/src/admin/admin.ts
+++ b/modules/database/src/admin/admin.ts
@@ -173,7 +173,6 @@ export class AdminHandlers {
                 authenticated: ConduitBoolean.Required,
               },
             },
-            crudOperations: ConduitBoolean.Optional,
             permissions: {
               extendable: ConduitBoolean.Optional,
               canCreate: ConduitBoolean.Optional,
@@ -197,8 +196,24 @@ export class AdminHandlers {
             fields: ConduitJson.Optional,
             modelOptions: ConduitJson.Optional,
             enabled: ConduitBoolean.Optional, // move inside modelOptions (frontend-compat)
-            authentication: ConduitBoolean.Optional, // move inside modelOptions (frontend-compat)
-            crudOperations: ConduitBoolean.Optional, // move inside modelOptions (frontend-compat)
+            authentication: {
+              create: {
+                enabled: ConduitBoolean.Optional,
+                authenticated: ConduitBoolean.Optional,
+              },
+              read: {
+                enabled: ConduitBoolean.Optional,
+                authenticated: ConduitBoolean.Optional,
+              },
+              update: {
+                enabled: ConduitBoolean.Optional,
+                authenticated: ConduitBoolean.Optional,
+              },
+              delete: {
+                enabled: ConduitBoolean.Optional,
+                authenticated: ConduitBoolean.Optional,
+              },
+            },
             permissions: {
               extendable: ConduitBoolean.Optional,
               canCreate: ConduitBoolean.Optional,

--- a/modules/database/src/admin/documents.admin.ts
+++ b/modules/database/src/admin/documents.admin.ts
@@ -44,7 +44,6 @@ export class DocumentsAdmin {
     if (isNil(schema)) {
       throw new GrpcError(status.NOT_FOUND, 'Schema does not exist');
     }
-
     if (!query || query.length === '') {
       query = {};
     }

--- a/modules/database/src/admin/schema.admin.ts
+++ b/modules/database/src/admin/schema.admin.ts
@@ -122,6 +122,7 @@ export class SchemaAdmin {
     } = call.request.params;
     const enabled = call.request.params.enabled ?? true;
     const crudOperations = call.request.params.crudOperations;
+    const authentication = call.request.params.authentication;
 
     if (name.indexOf('-') >= 0 || name.indexOf(' ') >= 0) {
       throw new GrpcError(
@@ -152,8 +153,8 @@ export class SchemaAdmin {
     });
 
     const schemaOptions = isNil(modelOptions)
-      ? { conduit: { cms: { enabled, crudOperations } } }
-      : { ...modelOptions, conduit: { cms: { enabled, crudOperations } } };
+      ? { conduit: { cms: { enabled, crudOperations, authentication } } }
+      : { ...modelOptions, conduit: { cms: { enabled, crudOperations, authentication } } };
     schemaOptions.conduit.permissions = permissions; // database sets missing perms to defaults
 
     return this.schemaController
@@ -205,7 +206,7 @@ export class SchemaAdmin {
     requestedSchema.modelOptions = merge(
       requestedSchema.modelOptions,
       modelOptions,
-      { conduit: { cms: { enabled, authentication, crudOperations } } },
+      { conduit: { cms: { enabled, authentication, crudOperations} } },
     );
 
 

--- a/modules/database/src/admin/schema.admin.ts
+++ b/modules/database/src/admin/schema.admin.ts
@@ -121,7 +121,7 @@ export class SchemaAdmin {
       permissions,
     } = call.request.params;
     const enabled = call.request.params.enabled ?? true;
-    const authentication = call.request.params.authentication;
+    const crudOperations = call.request.params.crudOperations;
 
     if (name.indexOf('-') >= 0 || name.indexOf(' ') >= 0) {
       throw new GrpcError(
@@ -152,8 +152,8 @@ export class SchemaAdmin {
     });
 
     const schemaOptions = isNil(modelOptions)
-      ? { conduit: { cms: { enabled, authentication } } }
-      : { ...modelOptions, conduit: { cms: { enabled, authentication } } };
+      ? { conduit: { cms: { enabled, crudOperations } } }
+      : { ...modelOptions, conduit: { cms: { enabled, crudOperations } } };
     schemaOptions.conduit.permissions = permissions; // database sets missing perms to defaults
 
     return this.schemaController
@@ -173,7 +173,7 @@ export class SchemaAdmin {
       fields,
       modelOptions,
       permissions,
-      authentication
+      crudOperations
     } = call.request.params;
 
     if (!isNil(name) && name !== '') {
@@ -201,11 +201,11 @@ export class SchemaAdmin {
     requestedSchema.fields = fields ? fields : requestedSchema.fields;
     const enabled = call.request.params.enabled ?? requestedSchema.modelOptions.conduit.cms.enabled;
 
-    authentication = call.request.params.authentication ?? requestedSchema.modelOptions.conduit.cms.authentication;
+    crudOperations = call.request.params.crudOperations ?? requestedSchema.modelOptions.conduit.cms.crudOperations;
     requestedSchema.modelOptions = merge(
       requestedSchema.modelOptions,
       modelOptions,
-      { conduit: { cms: { enabled, authentication } } },
+      { conduit: { cms: { enabled, crudOperations } } },
     );
 
 

--- a/modules/database/src/admin/schema.admin.ts
+++ b/modules/database/src/admin/schema.admin.ts
@@ -121,8 +121,7 @@ export class SchemaAdmin {
       permissions,
     } = call.request.params;
     const enabled = call.request.params.enabled ?? true;
-    const authentication = call.request.params.authentication ?? false;
-    const crudOperations = call.request.params.crudOperations ?? true;
+    const crudOperations = call.request.params.crudOperations;
 
     if (name.indexOf('-') >= 0 || name.indexOf(' ') >= 0) {
       throw new GrpcError(
@@ -153,8 +152,8 @@ export class SchemaAdmin {
     });
 
     const schemaOptions = isNil(modelOptions)
-      ? { conduit: { cms: { enabled, authentication, crudOperations } } }
-      : { ...modelOptions, conduit: { cms: { enabled, authentication, crudOperations } } };
+      ? { conduit: { cms: { enabled, crudOperations } } }
+      : { ...modelOptions, conduit: { cms: { enabled, crudOperations } } };
     schemaOptions.conduit.permissions = permissions; // database sets missing perms to defaults
 
     return this.schemaController

--- a/modules/database/src/admin/schema.admin.ts
+++ b/modules/database/src/admin/schema.admin.ts
@@ -121,7 +121,6 @@ export class SchemaAdmin {
       permissions,
     } = call.request.params;
     const enabled = call.request.params.enabled ?? true;
-    const crudOperations = call.request.params.crudOperations;
     const authentication = call.request.params.authentication;
 
     if (name.indexOf('-') >= 0 || name.indexOf(' ') >= 0) {
@@ -153,8 +152,8 @@ export class SchemaAdmin {
     });
 
     const schemaOptions = isNil(modelOptions)
-      ? { conduit: { cms: { enabled, crudOperations, authentication } } }
-      : { ...modelOptions, conduit: { cms: { enabled, crudOperations, authentication } } };
+      ? { conduit: { cms: { enabled, authentication } } }
+      : { ...modelOptions, conduit: { cms: { enabled, authentication } } };
     schemaOptions.conduit.permissions = permissions; // database sets missing perms to defaults
 
     return this.schemaController
@@ -168,12 +167,13 @@ export class SchemaAdmin {
   }
 
   async patchSchema(call: ParsedRouterRequest): Promise<UnparsedRouterResponse> {
-    const {
+    let {
       id,
       name,
       fields,
       modelOptions,
       permissions,
+      authentication
     } = call.request.params;
 
     if (!isNil(name) && name !== '') {
@@ -201,12 +201,11 @@ export class SchemaAdmin {
     requestedSchema.fields = fields ? fields : requestedSchema.fields;
     const enabled = call.request.params.enabled ?? requestedSchema.modelOptions.conduit.cms.enabled;
 
-    const authentication = call.request.params.authentication ?? requestedSchema.modelOptions.conduit.cms.authentication;
-    const crudOperations = call.request.params.crudOperations ?? requestedSchema.modelOptions.conduit.cms.crudOperations;
+    authentication = call.request.params.authentication ?? requestedSchema.modelOptions.conduit.cms.authentication;
     requestedSchema.modelOptions = merge(
       requestedSchema.modelOptions,
       modelOptions,
-      { conduit: { cms: { enabled, authentication, crudOperations} } },
+      { conduit: { cms: { enabled, authentication } } },
     );
 
 

--- a/modules/database/src/controllers/cms/utils.ts
+++ b/modules/database/src/controllers/cms/utils.ts
@@ -64,8 +64,8 @@ function removeRequiredFields(fields: any) {
 
 export function getOps(schemaName: string, actualSchema: any, handlers: CmsHandlers) {
   let routesArray: any = [];
-  const authenticatedRead = actualSchema.modelOptions.conduit.cms.authentication.read.authenticated;
-  const readIsEnabled = actualSchema.modelOptions.conduit.cms.authentication.read.enabled;
+  const authenticatedRead = actualSchema.modelOptions.conduit.cms.crudOperations.read.authenticated;
+  const readIsEnabled = actualSchema.modelOptions.conduit.cms.crudOperations.read.enabled;
   let route = new RouteBuilder()
     .path(`/${schemaName}/:id`)
     .method(ConduitRouteActions.GET)
@@ -113,8 +113,8 @@ export function getOps(schemaName: string, actualSchema: any, handlers: CmsHandl
     .bodyParams(assignableFields)
     .return(`create${schemaName}`, actualSchema.fields)
     .handler(handlers.createDocument.bind(handlers));
-  const authenticatedCreate = actualSchema.modelOptions.conduit.cms.authentication.create.authenticated;
-  const createIsEnabled = actualSchema.modelOptions.conduit.cms.authentication.create.enabled;
+  const authenticatedCreate = actualSchema.modelOptions.conduit.cms.crudOperations.create.authenticated;
+  const createIsEnabled = actualSchema.modelOptions.conduit.cms.crudOperations.create.enabled;
   if (authenticatedCreate) {
     route.middleware('authMiddleware');
   }
@@ -148,8 +148,8 @@ export function getOps(schemaName: string, actualSchema: any, handlers: CmsHandl
       docs: [actualSchema.fields],
     })
     .handler(handlers.updateManyDocuments.bind(handlers));
-  const authenticatedUpdate = actualSchema.modelOptions.conduit.cms.authentication.update.authenticated;
-  const updateIsEnabled = actualSchema.modelOptions.conduit.cms.authentication.update.enabled;
+  const authenticatedUpdate = actualSchema.modelOptions.conduit.cms.crudOperations.update.authenticated;
+  const updateIsEnabled = actualSchema.modelOptions.conduit.cms.crudOperations.update.enabled;
   if (authenticatedUpdate) {
     route.middleware('authMiddleware');
   }
@@ -216,8 +216,8 @@ export function getOps(schemaName: string, actualSchema: any, handlers: CmsHandl
     })
     .return(`delete${schemaName}`, TYPE.String)
     .handler(handlers.deleteDocument.bind(handlers));
-  const authenticatedDelete = actualSchema.modelOptions.conduit.cms.authentication.delete.authenticated;
-  const deleteIsEnabled = actualSchema.modelOptions.conduit.cms.authentication.delete.enabled;
+  const authenticatedDelete = actualSchema.modelOptions.conduit.cms.crudOperations.delete.authenticated;
+  const deleteIsEnabled = actualSchema.modelOptions.conduit.cms.crudOperations.delete.enabled;
   if (authenticatedDelete) {
     route.middleware('authMiddleware');
   }

--- a/modules/database/src/controllers/cms/utils.ts
+++ b/modules/database/src/controllers/cms/utils.ts
@@ -74,9 +74,9 @@ export function getOps(schemaName: string, actualSchema: any, handlers: CmsHandl
       : 'public, max-age=10')
     .return(`${schemaName}`, actualSchema.fields)
     .handler(handlers.getDocumentById.bind(handlers));
-  if (actualSchema.authentication) {
+  const authenticatedRead = actualSchema.modelOptions.conduit.cms.crudOperations.read;
+  if (authenticatedRead)
     route.middleware('authMiddleware');
-  }
   routesArray.push(route.build());
 
   route = new RouteBuilder()
@@ -95,7 +95,7 @@ export function getOps(schemaName: string, actualSchema: any, handlers: CmsHandl
       count: TYPE.Number,
     })
     .handler(handlers.getDocuments.bind(handlers));
-  if (actualSchema.authentication) {
+  if (authenticatedRead) {
     route.middleware('authMiddleware');
   }
   routesArray.push(route.build());
@@ -110,7 +110,8 @@ export function getOps(schemaName: string, actualSchema: any, handlers: CmsHandl
     .bodyParams(assignableFields)
     .return(`create${schemaName}`, actualSchema.fields)
     .handler(handlers.createDocument.bind(handlers));
-  if (actualSchema.authentication) {
+  const authenticatedCreate = actualSchema.modelOptions.conduit.cms.crudOperations.create;
+  if (authenticatedCreate) {
     route.middleware('authMiddleware');
   }
   routesArray.push(route.build());
@@ -123,7 +124,7 @@ export function getOps(schemaName: string, actualSchema: any, handlers: CmsHandl
       docs: [actualSchema.fields],
     })
     .handler(handlers.createManyDocuments.bind(handlers));
-  if (actualSchema.authentication) {
+  if (authenticatedCreate) {
     route.middleware('authMiddleware');
   }
   routesArray.push(route.build());
@@ -141,7 +142,8 @@ export function getOps(schemaName: string, actualSchema: any, handlers: CmsHandl
       docs: [actualSchema.fields],
     })
     .handler(handlers.updateManyDocuments.bind(handlers));
-  if (actualSchema.authentication) {
+  const authenticatedUpdate = actualSchema.modelOptions.conduit.cms.crudOperations.update;
+  if (authenticatedUpdate) {
     route.middleware('authMiddleware');
   }
   routesArray.push(route.build());
@@ -164,7 +166,7 @@ export function getOps(schemaName: string, actualSchema: any, handlers: CmsHandl
       docs: [actualSchema.fields],
     })
     .handler(handlers.patchManyDocuments.bind(handlers));
-  if (actualSchema.authentication) {
+  if (authenticatedUpdate) {
     route.middleware('authMiddleware');
   }
   routesArray.push(route.build());
@@ -178,7 +180,7 @@ export function getOps(schemaName: string, actualSchema: any, handlers: CmsHandl
     .bodyParams(assignableFields)
     .return(`update${schemaName}`, actualSchema.fields)
     .handler(handlers.updateDocument.bind(handlers));
-  if (actualSchema.authentication) {
+  if (authenticatedUpdate) {
     route.middleware('authMiddleware');
   }
   routesArray.push(route.build());
@@ -192,7 +194,7 @@ export function getOps(schemaName: string, actualSchema: any, handlers: CmsHandl
     .bodyParams(removeRequiredFields(Object.assign({}, assignableFields)))
     .return(`patch${schemaName}`, actualSchema.fields)
     .handler(handlers.patchDocument.bind(handlers));
-  if (actualSchema.authentication) {
+  if (authenticatedUpdate) {
     route.middleware('authMiddleware');
   }
   routesArray.push(route.build());
@@ -204,7 +206,8 @@ export function getOps(schemaName: string, actualSchema: any, handlers: CmsHandl
     })
     .return(`delete${schemaName}`, TYPE.String)
     .handler(handlers.deleteDocument.bind(handlers));
-  if (actualSchema.authentication) {
+  const authenticatedDelete = actualSchema.modelOptions.conduit.cms.crudOperations.delete;
+  if (authenticatedDelete) {
     route.middleware('authMiddleware');
   }
   routesArray.push(route.build());

--- a/modules/database/src/controllers/cms/utils.ts
+++ b/modules/database/src/controllers/cms/utils.ts
@@ -65,6 +65,7 @@ function removeRequiredFields(fields: any) {
 export function getOps(schemaName: string, actualSchema: any, handlers: CmsHandlers) {
   let routesArray: any = [];
   const authenticatedRead = actualSchema.modelOptions.conduit.cms.authentication.read.authenticated;
+  const readIsEnabled = actualSchema.modelOptions.conduit.cms.authentication.read.enabled;
   let route = new RouteBuilder()
     .path(`/${schemaName}/:id`)
     .method(ConduitRouteActions.GET)
@@ -77,7 +78,8 @@ export function getOps(schemaName: string, actualSchema: any, handlers: CmsHandl
     .handler(handlers.getDocumentById.bind(handlers));
   if (authenticatedRead)
     route.middleware('authMiddleware');
-  routesArray.push(route.build());
+  if (readIsEnabled)
+    routesArray.push(route.build());
 
   route = new RouteBuilder()
     .path(`/${schemaName}`)
@@ -98,7 +100,8 @@ export function getOps(schemaName: string, actualSchema: any, handlers: CmsHandl
   if (authenticatedRead) {
     route.middleware('authMiddleware');
   }
-  routesArray.push(route.build());
+  if (readIsEnabled)
+    routesArray.push(route.build());
 
   let assignableFields = Object.assign({}, actualSchema.fields);
   delete assignableFields._id;
@@ -111,10 +114,12 @@ export function getOps(schemaName: string, actualSchema: any, handlers: CmsHandl
     .return(`create${schemaName}`, actualSchema.fields)
     .handler(handlers.createDocument.bind(handlers));
   const authenticatedCreate = actualSchema.modelOptions.conduit.cms.authentication.create.authenticated;
+  const createIsEnabled = actualSchema.modelOptions.conduit.cms.authentication.create.enabled;
   if (authenticatedCreate) {
     route.middleware('authMiddleware');
   }
-  routesArray.push(route.build());
+  if (createIsEnabled)
+    routesArray.push(route.build());
 
   route = new RouteBuilder()
     .path(`/${schemaName}/many`)
@@ -127,7 +132,8 @@ export function getOps(schemaName: string, actualSchema: any, handlers: CmsHandl
   if (authenticatedCreate) {
     route.middleware('authMiddleware');
   }
-  routesArray.push(route.build());
+  if (createIsEnabled)
+    routesArray.push(route.build());
 
   route = new RouteBuilder()
     .path(`/${schemaName}/many`)
@@ -143,10 +149,12 @@ export function getOps(schemaName: string, actualSchema: any, handlers: CmsHandl
     })
     .handler(handlers.updateManyDocuments.bind(handlers));
   const authenticatedUpdate = actualSchema.modelOptions.conduit.cms.authentication.update.authenticated;
+  const updateIsEnabled = actualSchema.modelOptions.conduit.cms.authentication.update.enabled;
   if (authenticatedUpdate) {
     route.middleware('authMiddleware');
   }
-  routesArray.push(route.build());
+  if (updateIsEnabled)
+    routesArray.push(route.build());
 
   route = new RouteBuilder()
     .path(`/${schemaName}/many`)
@@ -169,7 +177,8 @@ export function getOps(schemaName: string, actualSchema: any, handlers: CmsHandl
   if (authenticatedUpdate) {
     route.middleware('authMiddleware');
   }
-  routesArray.push(route.build());
+  if (updateIsEnabled)
+    routesArray.push(route.build());
 
   route = new RouteBuilder()
     .path(`/${schemaName}/:id`)
@@ -197,7 +206,8 @@ export function getOps(schemaName: string, actualSchema: any, handlers: CmsHandl
   if (authenticatedUpdate) {
     route.middleware('authMiddleware');
   }
-  routesArray.push(route.build());
+  if (updateIsEnabled)
+    routesArray.push(route.build());
   route = new RouteBuilder()
     .path(`/${schemaName}/:id`)
     .method(ConduitRouteActions.DELETE)
@@ -207,10 +217,12 @@ export function getOps(schemaName: string, actualSchema: any, handlers: CmsHandl
     .return(`delete${schemaName}`, TYPE.String)
     .handler(handlers.deleteDocument.bind(handlers));
   const authenticatedDelete = actualSchema.modelOptions.conduit.cms.authentication.delete.authenticated;
+  const deleteIsEnabled = actualSchema.modelOptions.conduit.cms.authentication.delete.enabled;
   if (authenticatedDelete) {
     route.middleware('authMiddleware');
   }
-  routesArray.push(route.build());
+  if (deleteIsEnabled)
+    routesArray.push(route.build());
 
   return routesArray;
 }

--- a/modules/database/src/controllers/cms/utils.ts
+++ b/modules/database/src/controllers/cms/utils.ts
@@ -64,17 +64,17 @@ function removeRequiredFields(fields: any) {
 
 export function getOps(schemaName: string, actualSchema: any, handlers: CmsHandlers) {
   let routesArray: any = [];
+  const authenticatedRead = actualSchema.modelOptions.conduit.cms.authentication.read.authenticated;
   let route = new RouteBuilder()
     .path(`/${schemaName}/:id`)
     .method(ConduitRouteActions.GET)
     .urlParams({
       id: { type: TYPE.String, required: true },
-    }).cacheControl(actualSchema.authentication
+    }).cacheControl(authenticatedRead
       ? 'private, max-age=10'
       : 'public, max-age=10')
     .return(`${schemaName}`, actualSchema.fields)
     .handler(handlers.getDocumentById.bind(handlers));
-  const authenticatedRead = actualSchema.modelOptions.conduit.cms.crudOperations.read;
   if (authenticatedRead)
     route.middleware('authMiddleware');
   routesArray.push(route.build());
@@ -87,7 +87,7 @@ export function getOps(schemaName: string, actualSchema: any, handlers: CmsHandl
       limit: TYPE.Number,
       sort: [TYPE.String],
     })
-    .cacheControl(actualSchema.authentication
+    .cacheControl(authenticatedRead
       ? 'private, max-age=10'
       : 'public, max-age=10')
     .return(`get${schemaName}`, {
@@ -110,7 +110,7 @@ export function getOps(schemaName: string, actualSchema: any, handlers: CmsHandl
     .bodyParams(assignableFields)
     .return(`create${schemaName}`, actualSchema.fields)
     .handler(handlers.createDocument.bind(handlers));
-  const authenticatedCreate = actualSchema.modelOptions.conduit.cms.crudOperations.create;
+  const authenticatedCreate = actualSchema.modelOptions.conduit.cms.authentication.create.authenticated;
   if (authenticatedCreate) {
     route.middleware('authMiddleware');
   }
@@ -142,7 +142,7 @@ export function getOps(schemaName: string, actualSchema: any, handlers: CmsHandl
       docs: [actualSchema.fields],
     })
     .handler(handlers.updateManyDocuments.bind(handlers));
-  const authenticatedUpdate = actualSchema.modelOptions.conduit.cms.crudOperations.update;
+  const authenticatedUpdate = actualSchema.modelOptions.conduit.cms.authentication.update.authenticated;
   if (authenticatedUpdate) {
     route.middleware('authMiddleware');
   }
@@ -206,7 +206,7 @@ export function getOps(schemaName: string, actualSchema: any, handlers: CmsHandl
     })
     .return(`delete${schemaName}`, TYPE.String)
     .handler(handlers.deleteDocument.bind(handlers));
-  const authenticatedDelete = actualSchema.modelOptions.conduit.cms.crudOperations.delete;
+  const authenticatedDelete = actualSchema.modelOptions.conduit.cms.authentication.delete.authenticated;
   if (authenticatedDelete) {
     route.middleware('authMiddleware');
   }

--- a/modules/database/src/migrations/crudOperations.migration.ts
+++ b/modules/database/src/migrations/crudOperations.migration.ts
@@ -1,0 +1,36 @@
+import { DatabaseAdapter } from '../adapters/DatabaseAdapter';
+import { MongooseSchema } from '../adapters/mongoose-adapter/MongooseSchema';
+import { SequelizeSchema } from '../adapters/sequelize-adapter/SequelizeSchema';
+
+export async function migrateCrudOperations(adapter: DatabaseAdapter<MongooseSchema | SequelizeSchema>) {
+  const model = adapter.getSchemaModel('_DeclaredSchema').model;
+  const cmsSchemas = await model
+    .findMany({ 'modelOptions.conduit.cms.enabled': { $exists: true } });
+
+  for (const schema of cmsSchemas) {
+    const { crudOperations, authentication } = schema.modelOptions.conduit.cms;
+    const cms = {
+      crudOperations: {
+        create: {
+          enabled: crudOperations,
+          authenticated: authentication,
+        },
+        read: {
+          enabled: crudOperations,
+          authenticated: authentication,
+        },
+        update: {
+          enabled: crudOperations,
+          authenticated: authentication,
+        },
+        delete: {
+          enabled: crudOperations,
+          authenticated: authentication,
+        },
+      },
+    };
+    await model.findByIdAndUpdate(schema._id, {
+      conduit: { cms },
+    });
+  }
+}

--- a/modules/database/src/migrations/crudOperations.migration.ts
+++ b/modules/database/src/migrations/crudOperations.migration.ts
@@ -8,8 +8,9 @@ export async function migrateCrudOperations(adapter: DatabaseAdapter<MongooseSch
     .findMany({ 'modelOptions.conduit.cms.enabled': { $exists: true } });
 
   for (const schema of cmsSchemas) {
-    const { crudOperations, authentication } = schema.modelOptions.conduit.cms;
+    const { crudOperations, authentication, enabled } = schema.modelOptions.conduit.cms;
     const cms = {
+      enabled: enabled,
       crudOperations: {
         create: {
           enabled: crudOperations,
@@ -29,8 +30,11 @@ export async function migrateCrudOperations(adapter: DatabaseAdapter<MongooseSch
         },
       },
     };
-    await model.findByIdAndUpdate(schema._id, {
-      conduit: { cms },
+    const id = (schema._id).toString()
+    await model.findByIdAndUpdate(id,{
+      modelOptions: {
+        conduit: { cms }
+      },
     });
   }
 }

--- a/modules/database/src/migrations/index.ts
+++ b/modules/database/src/migrations/index.ts
@@ -1,7 +1,8 @@
 import { DatabaseAdapter } from '../adapters/DatabaseAdapter';
 import { MongooseSchema } from '../adapters/mongoose-adapter/MongooseSchema';
 import { SequelizeSchema } from '../adapters/sequelize-adapter/SequelizeSchema';
+import { migrateCrudOperations } from './crudOperations.migration';
 
 export async function runMigrations(adapter: DatabaseAdapter<MongooseSchema | SequelizeSchema>){
-  // ...
+  await migrateCrudOperations(adapter);
 }

--- a/modules/database/src/routes/routes.ts
+++ b/modules/database/src/routes/routes.ts
@@ -35,7 +35,6 @@ export class DatabaseRoutes {
     handler: RequestHandlers
   }[], crud: boolean = true) {
     if (crud) {
-
       this.crudRoutes = routes;
     } else {
       this.customRoutes = routes;

--- a/modules/database/src/routes/routes.ts
+++ b/modules/database/src/routes/routes.ts
@@ -35,6 +35,7 @@ export class DatabaseRoutes {
     handler: RequestHandlers
   }[], crud: boolean = true) {
     if (crud) {
+
       this.crudRoutes = routes;
     } else {
       this.customRoutes = routes;


### PR DESCRIPTION
Options for required authentication in differ crud operations provided.
Admin can decide whenever a CRUD operation can be done from an authenticated user.
Also , admin can decide if a CRUD route is disabled or enabled. 

**What kind of change does this PR introduce?** <!--(check at least one)-->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other (please describe)

**Other information:**

modelOptions migrated to 
```
  "modelOptions": {
    "conduit": {
      "cms": {
        "enabled": true,
        "crudOperations": {
          "create": {
            "enabled": true,
            "authenticated": false
          },
          "read": {
            "enabled": true,
            "authenticated": false
          },
          "update": {
            "enabled": true,
            "authenticated": false
          },
          "delete": {
            "enabled": true,
            "authenticated": false
          }
        }
      },
      "permissions": {
        "extendable": true,
        "canCreate": true,
        "canModify": "Everything",
        "canDelete": true
      }
    }
  },
```
**Usage Example**

```
modelOptions.conduit.cms.create.enabled = true  -> POST routes are accessible
modelOptions.conduit.cms.create.authenticated = true  ->POST routes are accessible only by authenticated users
```
