### PR TITLE
Disable Database Introspection on Startup

### DIFF
--- a/libraries/grpc-sdk/src/classes/ConduitSchema.ts
+++ b/libraries/grpc-sdk/src/classes/ConduitSchema.ts
@@ -3,7 +3,7 @@ import { ConduitModel, ConduitModelOptions } from '../interfaces';
 export class ConduitSchema {
   readonly name: string;
   readonly fields: ConduitModel;
-  readonly collectionName?: string;
+  readonly collectionName: string | ''; // '' on implicit name, updated in createSchemaFromAdapter()
   readonly schemaOptions: ConduitModelOptions;
   ownerModule: string = 'unknown';
 
@@ -16,9 +16,7 @@ export class ConduitSchema {
     this.name = name;
     this.fields = fields;
     this.schemaOptions = schemaOptions ?? {};
-    if (collectionName && collectionName !== '') {
-      this.collectionName = collectionName;
-    }
+    this.collectionName = (collectionName && collectionName !== '') ? collectionName : '';
   }
 
   get modelSchema(): ConduitModel {

--- a/modules/database/src/adapters/utils/collectionName.ts
+++ b/modules/database/src/adapters/utils/collectionName.ts
@@ -1,8 +1,0 @@
-export function generateUniqueCollectionName(collectionName: string, length = 6) {
-  const validCharacters = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
-  let idSuffix = '';
-  for (let i = 0; i < length; i++) {
-    idSuffix += validCharacters.charAt(Math.floor(Math.random() * validCharacters.length));
-  }
-  return `${collectionName}_${idSuffix}`;
-}

--- a/modules/database/src/adapters/utils/collectionName.ts
+++ b/modules/database/src/adapters/utils/collectionName.ts
@@ -1,0 +1,8 @@
+export function generateUniqueCollectionName(collectionName: string, length = 6) {
+  const validCharacters = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+  let idSuffix = '';
+  for (let i = 0; i < length; i++) {
+    idSuffix += validCharacters.charAt(Math.floor(Math.random() * validCharacters.length));
+  }
+  return `${collectionName}_${idSuffix}`;
+}

--- a/modules/database/src/admin/admin.ts
+++ b/modules/database/src/admin/admin.ts
@@ -66,6 +66,7 @@ export class AdminHandlers {
         getSchemaOwners: this.schemaAdmin.getSchemaOwners.bind(this.schemaAdmin),
         getIntrospectionStatus: this.schemaAdmin.getIntrospectionStatus.bind(this.schemaAdmin),
         introspectDatabase: this.schemaAdmin.introspectDatabase.bind(this.schemaAdmin),
+        getPendingSchema: this.schemaAdmin.getPendingSchema.bind(this.schemaAdmin),
         getPendingSchemas: this.schemaAdmin.getPendingSchemas.bind(this.schemaAdmin),
         finalizeSchemas: this.schemaAdmin.finalizeSchemas.bind(this.schemaAdmin),
         // Documents
@@ -329,6 +330,17 @@ export class AdminHandlers {
       },
       new ConduitRouteReturnDefinition('IntrospectDatabase', 'String'),
       'introspectDatabase'
+      ),
+      constructConduitRoute(
+        {
+          path: '/introspection/schemas/:id',
+          action: ConduitRouteActions.GET,
+          urlParams: {
+            id: { type: RouteOptionType.String, required: true },
+          },
+        },
+        new ConduitRouteReturnDefinition('GetSPendingSchema', PendingSchemas.fields),
+        'getPendingSchema',
       ),
       constructConduitRoute({
         path: '/introspection/schemas',

--- a/modules/database/src/admin/admin.ts
+++ b/modules/database/src/admin/admin.ts
@@ -64,6 +64,7 @@ export class AdminHandlers {
         setSchemaExtension: this.schemaAdmin.setSchemaExtension.bind(this.schemaAdmin),
         setSchemaPerms: this.schemaAdmin.setSchemaPerms.bind(this.schemaAdmin),
         getSchemaOwners: this.schemaAdmin.getSchemaOwners.bind(this.schemaAdmin),
+        getIntrospectionStatus: this.schemaAdmin.getIntrospectionStatus.bind(this.schemaAdmin),
         introspectDatabase: this.schemaAdmin.introspectDatabase.bind(this.schemaAdmin),
         getPendingSchemas: this.schemaAdmin.getPendingSchemas.bind(this.schemaAdmin),
         finalizeSchemas: this.schemaAdmin.finalizeSchemas.bind(this.schemaAdmin),
@@ -309,6 +310,18 @@ export class AdminHandlers {
         },
         new ConduitRouteReturnDefinition('SetSchemaPermissions', 'String'),
         'setSchemaPerms',
+      ),
+      constructConduitRoute({
+          path: '/introspection',
+          action: ConduitRouteActions.GET,
+        },
+        new ConduitRouteReturnDefinition('GetIntrospectionStatus', {
+          foreignSchemas: [ConduitString.Required],
+          foreignSchemaCount: ConduitNumber.Required,
+          importedSchemas: [ConduitString.Required],
+          importedSchemaCount: ConduitNumber.Required,
+        }),
+        'getIntrospectionStatus'
       ),
       constructConduitRoute({
         path: '/introspection',

--- a/modules/database/src/admin/schema.admin.ts
+++ b/modules/database/src/admin/schema.admin.ts
@@ -506,6 +506,15 @@ export class SchemaAdmin {
     return 'Schemas successfully introspected';
   }
 
+  async getPendingSchema(call: ParsedRouterRequest): Promise<UnparsedRouterResponse> {
+    const query: ParsedQuery = { _id: call.request.params.id };
+    const requestedSchema = await this.database.getSchemaModel('_PendingSchemas').model.findOne(query);
+    if (isNil(requestedSchema)) {
+      throw new GrpcError(status.NOT_FOUND, 'Pending schema does not exist');
+    }
+    return requestedSchema;
+  }
+
   async getPendingSchemas(call: ParsedRouterRequest): Promise<UnparsedRouterResponse> {
     const { search, sort } = call.request.params;
     const skip = call.request.params.skip ?? 0;

--- a/modules/database/src/introspection/mongoose/utils.ts
+++ b/modules/database/src/introspection/mongoose/utils.ts
@@ -5,12 +5,6 @@ import {
   TYPE,
 } from '@conduitplatform/grpc-sdk';
 
-export const INITIAL_DB_SCHEMAS = [
-  '_declaredschemas',
-  'customendpoints',
-  '_pendingschemas',
-];
-
 /**
  * This function should take as an input a mongo-schema object and convert it to a conduit schema
  */

--- a/modules/database/src/introspection/sequelize/utils.ts
+++ b/modules/database/src/introspection/sequelize/utils.ts
@@ -2,13 +2,11 @@ import { TYPE } from "@conduitplatform/grpc-sdk";
 import { isNil } from "lodash";
 import { Sequelize } from "sequelize";
 
-export const INITIAL_DB_SCHEMAS = ['_DeclaredSchema','CustomEndpoints','_PendingSchemas']; // Check schema entries for cms metadata
-
 /**
  * This function should take as an input a sequelize-auto object and convert it to a conduit schema
  */
 export function sqlSchemaConverter(sqlSchema: any) {
-  for(const fieldName of Object.keys(sqlSchema)) {
+  for (const fieldName of Object.keys(sqlSchema)) {
     let field = sqlSchema[fieldName];
     field.type = extractType(field.type);
     extractProperties(field);

--- a/modules/database/src/models/DeclaredSchema.schema.ts
+++ b/modules/database/src/models/DeclaredSchema.schema.ts
@@ -35,6 +35,10 @@ export const DeclaredSchema = new ConduitSchema(
       type: TYPE.String,
       required: true,
     },
+    collectionName: {
+      type: TYPE.String,
+      required: true,
+    },
     createdAt: TYPE.Date,
     updatedAt: TYPE.Date,
   },


### PR DESCRIPTION
Disables automatic database introspection on `Database` startup.
A simple collection name check is now performed by default, comparing available db schemas with whatever, if anything, is already available in `DeclaredSchemas`, storing foreign schema collection names in the adapter for later use.

`DeclaredSchemas` is now aware of schemas' collection names.
Any Conduit module schemas attempting to be registered using a used collection name now get their actual collection name prefixed by `cnd_`.

Introspection can still be triggered through a `POST` @ `/admin/database/introspection`.
Added a new admin route (`GET` @ `/admin/database/introspection`) for retrieving information on current introspection state:
- foreignSchemas (schemas that have never been imported)
- foreignSchemaCount
- importedSchemas (schemas that have previously been imported and may be reimported at will)
- importedSchemaCount

Added `getPendingSchema` (by id) admin route as requested by UI team.

Fixed `finalizeSchemas` admin route not throwing on empty schemas array input.

Note: Building this after updating node_modules post #184 depends on #185 getting merged as node build types have been messed up.

**What kind of change does this PR introduce?** <!--(check at least one)-->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other (please describe)

**Does this PR introduce a breaking change?** <!-- (check one) -->

- [ ] Yes
- [X] No

<!-- If yes, please describe the impact and migration path for existing applications. -->

**The PR fulfills these requirements:**

- [X] It's submitted to the `main` branch
- [ ] When resolving a specific issue, it's referenced in the PR's description  (e.g. `fix #xxx`, where "xxx" is the issue number)

If adding a **new feature**, the PR's description includes:

- [X] A convincing reason for adding this feature <!-- to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it -->
