### PR TITLE
fix(database): fix casing for mongo ObjectId types in type extraction

### DIFF
--- a/modules/database/src/introspection/mongoose/utils.ts
+++ b/modules/database/src/introspection/mongoose/utils.ts
@@ -36,5 +36,9 @@ function extractType(field: Indexable) {
   if (conduitField.type === 'Document') {
     conduitField.type = TYPE.JSON; //workaround for Document types
   }
+  if (conduitField.type === 'ObjectID') {
+    conduitField.type = TYPE.ObjectId; // fix casing for ObjectID
+  }
+
   return conduitField;
 }


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/ConduitPlatform/Conduit/blob/main/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** <!--(check at least one)-->
This PR fixes the casing for ObjectId types in mongo type extraction.
- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other (please describe)

**Does this PR introduce a breaking change?** <!-- (check one) -->

- [ ] Yes
- [x] No

<!-- If yes, please describe the impact and migration path for existing applications. -->

**The PR fulfills these requirements:**

- [x] It's submitted to the `main` branch
