### PR TITLE
fix(authentication): wrong param types in OAuth2 requests

### DIFF
--- a/modules/authentication/src/handlers/oauth2/OAuth2.ts
+++ b/modules/authentication/src/handlers/oauth2/OAuth2.ts
@@ -246,7 +246,7 @@ export abstract class OAuth2<T, S extends OAuth2Settings>
         path: `/init/${this.providerName}`,
         description: `Begins ${this.capitalizeProvider()} authentication.`,
         action: ConduitRouteActions.GET,
-        bodyParams: {
+        queryParams: {
           scopes: [ConduitString.Optional],
         },
       },
@@ -262,7 +262,7 @@ export abstract class OAuth2<T, S extends OAuth2Settings>
         path: `/hook/${this.providerName}`,
         action: ConduitRouteActions.GET,
         description: `Login/register with ${this.capitalizeProvider()} using redirect.`,
-        urlParams: {
+        queryParams: {
           code: ConduitString.Required,
           state: [ConduitString.Required],
         },


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/ConduitPlatform/Conduit/blob/main/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** <!--(check at least one)-->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other (please describe)

**Does this PR introduce a breaking change?** <!-- (check one) -->

- [ ] Yes
- [x] No

<!-- If yes, please describe the impact and migration path for existing applications. -->

**The PR fulfills these requirements:**

- [x] It's submitted to the `main` branch
- [x] When resolving a specific issue, it's referenced in the PR's description  (e.g. `fix #xxx`, where "xxx" is the issue number)

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature <!-- to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it -->

**Other information:**
