### PR TITLE
fix(router,grpc-sdk): swagger generation

### DIFF
--- a/libraries/grpc-sdk/src/classes/ConduitParser.ts
+++ b/libraries/grpc-sdk/src/classes/ConduitParser.ts
@@ -22,6 +22,7 @@ export abstract class ConduitParser<ParseResult, ProcessingObject> {
     | string
     | {
         type?: string;
+        $ref?: string;
         format?: string;
         properties?: object;
       };

--- a/modules/authentication/src/admin/admin.ts
+++ b/modules/authentication/src/admin/admin.ts
@@ -88,7 +88,7 @@ export class AdminHandlers {
             password: ConduitString.Required,
           },
         },
-        new ConduitRouteReturnDefinition('CreateUser', userFields),
+        new ConduitRouteReturnDefinition('User', userFields),
         'createUser',
       ),
       constructConduitRoute(

--- a/modules/chat/src/admin/admin.ts
+++ b/modules/chat/src/admin/admin.ts
@@ -70,7 +70,7 @@ export class AdminHandlers {
             participants: { type: [TYPE.String], required: true }, // handler array check is still required
           },
         },
-        new ConduitRouteReturnDefinition('CreateRoom', ChatRoom.getInstance().fields),
+        new ConduitRouteReturnDefinition('ChatRoom', ChatRoom.getInstance().fields),
         'createRoom',
       ),
       constructConduitRoute(

--- a/modules/database/src/admin/admin.ts
+++ b/modules/database/src/admin/admin.ts
@@ -247,7 +247,8 @@ export class AdminHandlers {
           path: '/schemas',
           action: ConduitRouteActions.DELETE,
           queryParams: {
-            ids: { type: [TYPE.JSON], required: true }, // handler array check is still required
+            ids: [ConduitJson.Required], // handler array check is still required
+            deleteData: ConduitBoolean.Required,
           },
         },
         new ConduitRouteReturnDefinition('DeleteSchemas', 'String'),
@@ -260,7 +261,7 @@ export class AdminHandlers {
           urlParams: {
             id: { type: RouteOptionType.String, required: true },
           },
-          bodyParams: {
+          queryParams: {
             deleteData: ConduitBoolean.Required,
           },
         },

--- a/modules/forms/src/admin/admin.ts
+++ b/modules/forms/src/admin/admin.ts
@@ -77,7 +77,7 @@ export class AdminHandlers {
             enabled: ConduitBoolean.Required,
           },
         },
-        new ConduitRouteReturnDefinition('CreateForm', 'String'),
+        new ConduitRouteReturnDefinition('Forms', 'String'),
         'createForm',
       ),
       constructConduitRoute(

--- a/packages/router/src/controllers/Rest/Swagger.ts
+++ b/packages/router/src/controllers/Rest/Swagger.ts
@@ -65,6 +65,7 @@ export class SwaggerGenerator {
       parameters: [],
       responses: {
         200: {
+          description: 'Successful Operation',
           content: {
             'application/json': {
               schema: {},
@@ -80,33 +81,11 @@ export class SwaggerGenerator {
       ((route.input.urlParams as unknown) as string) !== ''
     ) {
       for (const name in route.input.urlParams) {
-        let type = '';
-        if (typeof route.input.urlParams[name] === 'object') {
-          // @ts-ignore
-          if (
-            route.input.urlParams[name] &&
-            // @ts-ignore
-            route.input.urlParams[name].type &&
-            // @ts-ignore
-            typeof route.input.urlParams[name].type !== 'object'
-          ) {
-            // @ts-ignore
-            type = route.input.urlParams[name].type.toLowerCase();
-          } else {
-            type = 'object';
-          }
-
-          if (!['string', 'number', 'boolean', 'array', 'object'].includes(type)) {
-            type = 'string';
-          }
-        } else {
-          type = route.input.urlParams[name].toString().toLowerCase();
-        }
         routeDoc.parameters.push({
           name,
           in: 'path',
           required: true,
-          type: route.input.urlParams[name],
+          schema: this._parser.extractTypes('url', route.input.urlParams, true),
         });
       }
     }
@@ -116,32 +95,10 @@ export class SwaggerGenerator {
       ((route.input.queryParams as unknown) as string) !== ''
     ) {
       for (const name in route.input.queryParams) {
-        let type = '';
-        if (typeof route.input.queryParams[name] === 'object') {
-          // @ts-ignore
-          if (
-            route.input.queryParams[name] &&
-            // @ts-ignore
-            route.input.queryParams[name].type &&
-            // @ts-ignore
-            typeof route.input.queryParams[name].type !== 'object'
-          ) {
-            // @ts-ignore
-            type = route.input.queryParams[name].type.toLowerCase();
-          } else {
-            type = 'object';
-          }
-
-          if (!['string', 'number', 'boolean', 'array', 'object'].includes(type)) {
-            type = 'string';
-          }
-        } else {
-          type = route.input.queryParams[name].toString().toLowerCase();
-        }
         routeDoc.parameters.push({
           name,
           in: 'query',
-          type: type,
+          schema: this._parser.extractTypes('query', route.input.queryParams, true),
         });
       }
     }
@@ -182,7 +139,6 @@ export class SwaggerGenerator {
       this._swaggerDoc.paths[path] = {};
       this._swaggerDoc.paths[path][method] = routeDoc;
     }
-    this._swaggerDoc.paths[path] = { ...this._swaggerDoc.paths[path], method };
   }
 
   private _extractMethod(action: string) {

--- a/packages/router/src/controllers/Rest/SwaggerParser.ts
+++ b/packages/router/src/controllers/Rest/SwaggerParser.ts
@@ -55,6 +55,7 @@ export class SwaggerParser extends ConduitParser<ParseResult, ProcessingObject> 
   protected getType(conduitType: TYPE) {
     const res: {
       type?: string;
+      $ref?: string;
       format?: string;
       properties?: object;
     } = {};
@@ -72,8 +73,13 @@ export class SwaggerParser extends ConduitParser<ParseResult, ProcessingObject> 
         res.type = 'string';
         res.format = 'uuid';
         break;
-      default:
+      case 'String':
+      case 'Number':
+      case 'Boolean':
         res.type = conduitType.toLowerCase();
+        break;
+      default:
+        res.$ref = `#/components/schemas/${conduitType}`;
     }
     return res;
   }


### PR DESCRIPTION
This PR fixes Swagger doc generation, removing any existing schema errors and warnings.
Validation tested with [Swagger Editor](https://editor.swagger.io/).

Also fixes:
- `deleteData` param passed as a body parameter in `Database` module`s `deleteSchema` admin route.
- `deleteData` missing entirely from `deleteSchemas` admin route declaration.

Additionally, a few module route return types have been renamed so as to appease Swagger component ref mappings.
This shouldn't be an issue once Swagger generation automatically registers these based on availlable db models.

Limitations: `query` and `url` params are still not advertised as required by Swagger as of right now.

**What kind of change does this PR introduce?** <!--(check at least one)-->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other (please describe)

**Does this PR introduce a breaking change?** <!-- (check one) -->

- [ ] Yes
- [X] No

<!-- If yes, please describe the impact and migration path for existing applications. -->

**The PR fulfills these requirements:**

- [X] It's submitted to the `main` branch
- [ ] When resolving a specific issue, it's referenced in the PR's description  (e.g. `fix #xxx`, where "xxx" is the issue number)
