### PR TITLE
fix(security): security client aliases are not unique

### DIFF
--- a/packages/security/src/admin/routes/CreateSecurityClient.route.ts
+++ b/packages/security/src/admin/routes/CreateSecurityClient.route.ts
@@ -39,6 +39,23 @@ export function getCreateSecurityClientRoute() {
       if (!Object.values(PlatformTypesEnum).includes(platform)) {
         throw new ConduitError('INVALID_ARGUMENTS', 400, 'Platform not supported');
       }
+      if (alias) {
+        const existingClient = await Client.getInstance().findOne({ alias });
+        if (existingClient) {
+          throw new ConduitError(
+            'ALREADY_EXISTS',
+            409,
+            `A security client with an alias of '${alias}' already exists`,
+          );
+        }
+      }
+      if (alias === '') {
+        throw new ConduitError(
+          'INVALID_ARGUMENTS',
+          400,
+          'Non-null alias field should not be an empty string',
+        );
+      }
       const clientId = randomBytes(15).toString('hex');
       const clientSecret = randomBytes(64).toString('hex');
       const hash = await bcrypt.hash(clientSecret, 10);

--- a/packages/security/src/admin/routes/CreateSecurityClient.route.ts
+++ b/packages/security/src/admin/routes/CreateSecurityClient.route.ts
@@ -90,7 +90,7 @@ export function getCreateSecurityClientRoute() {
         notes,
       });
       return {
-        result: client,
+        result: { ...client, clientSecret },
       }; // unnested from result in Rest.addConduitRoute, grpc routes avoid this using wrapRouterGrpcFunction
     },
   );

--- a/packages/security/src/admin/routes/CreateSecurityClient.route.ts
+++ b/packages/security/src/admin/routes/CreateSecurityClient.route.ts
@@ -25,19 +25,19 @@ export function getCreateSecurityClientRoute() {
         notes: ConduitString.Optional,
       },
     },
-    new ConduitRouteReturnDefinition('CreateSecurityClient', {
-      id: ConduitString.Required,
-      clientId: ConduitString.Required,
-      clientSecret: ConduitString.Required,
-      platform: ConduitString.Required,
-      domain: ConduitString.Optional,
-      alias: ConduitString.Optional,
-      notes: ConduitString.Optional,
-    }),
+    new ConduitRouteReturnDefinition('CreateSecurityClient', Client.getInstance().fields),
     async (params: ConduitRouteParameters) => {
-      const { platform, domain, alias, notes } = params.params!;
+      const { platform, domain, notes } = params.params!;
+      let { alias } = params.params!;
       if (!Object.values(PlatformTypesEnum).includes(platform)) {
         throw new ConduitError('INVALID_ARGUMENTS', 400, 'Platform not supported');
+      }
+      if (alias === '') {
+        throw new ConduitError(
+          'INVALID_ARGUMENTS',
+          400,
+          'Non-null alias field should not be an empty string',
+        );
       }
       if (alias) {
         const existingClient = await Client.getInstance().findOne({ alias });
@@ -49,16 +49,6 @@ export function getCreateSecurityClientRoute() {
           );
         }
       }
-      if (alias === '') {
-        throw new ConduitError(
-          'INVALID_ARGUMENTS',
-          400,
-          'Non-null alias field should not be an empty string',
-        );
-      }
-      const clientId = randomBytes(15).toString('hex');
-      const clientSecret = randomBytes(64).toString('hex');
-      const hash = await bcrypt.hash(clientSecret, 10);
       if (platform === PlatformTypesEnum.WEB) {
         if (!domain || domain === '')
           throw new ConduitError(
@@ -83,6 +73,14 @@ export function getCreateSecurityClientRoute() {
         if (!domainPattern.test(comparedDomain) && domain !== '*')
           throw new ConduitError('INVALID_ARGUMENTS', 400, 'Invalid domain argument');
       }
+      const clientId = randomBytes(15).toString('hex');
+      const clientSecret = randomBytes(64).toString('hex');
+      const hash = await bcrypt.hash(clientSecret, 10);
+      if (!alias) {
+        alias = `${platform.toLowerCase()}:${
+          platform === 'WEB' ? `${domain}:${clientId}` : clientId
+        }`;
+      }
       const client = await Client.getInstance().create({
         clientId,
         clientSecret: hash,
@@ -92,15 +90,7 @@ export function getCreateSecurityClientRoute() {
         notes,
       });
       return {
-        result: {
-          id: client._id,
-          clientId,
-          clientSecret,
-          platform,
-          domain,
-          alias,
-          notes,
-        },
+        result: client,
       }; // unnested from result in Rest.addConduitRoute, grpc routes avoid this using wrapRouterGrpcFunction
     },
   );

--- a/packages/security/src/admin/routes/GetSecurityClients.route.ts
+++ b/packages/security/src/admin/routes/GetSecurityClients.route.ts
@@ -3,13 +3,14 @@ import { Client } from '../../models';
 import { ConduitRouteActions, ConduitRouteParameters } from '@conduitplatform/grpc-sdk';
 
 export function getGetSecurityClientsRoute() {
+  const { clientSecret, ...returnTypeFields } = Client.getInstance().fields;
   return new ConduitRoute(
     {
       path: '/security/client',
       action: ConduitRouteActions.GET,
     },
     new ConduitRouteReturnDefinition('GetSecurityClient', {
-      clients: [Client.getInstance().fields],
+      clients: [returnTypeFields],
     }),
     async (params: ConduitRouteParameters) => {
       const clients = await Client.getInstance().findMany({});

--- a/packages/security/src/admin/routes/UpdateSecurityClient.route.ts
+++ b/packages/security/src/admin/routes/UpdateSecurityClient.route.ts
@@ -43,6 +43,23 @@ export function getUpdateSecurityClientRoute() {
       if (isNil(client)) {
         throw new ConduitError('INVALID_PARAMS', 400, 'Security client not found');
       }
+      if (alias) {
+        const existingClient = await Client.getInstance().findOne({ alias });
+        if (existingClient) {
+          throw new ConduitError(
+            'ALREADY_EXISTS',
+            409,
+            `A security client with an alias of '${alias}' already exists`,
+          );
+        }
+      }
+      if (alias === '') {
+        throw new ConduitError(
+          'INVALID_ARGUMENTS',
+          400,
+          'Non-null alias field should not be an empty string',
+        );
+      }
       if (client.platform === PlatformTypesEnum.WEB) {
         if (!domain || domain === '')
           throw new ConduitError(

--- a/packages/security/src/admin/routes/UpdateSecurityClient.route.ts
+++ b/packages/security/src/admin/routes/UpdateSecurityClient.route.ts
@@ -13,6 +13,7 @@ import { Client } from '../../models';
 import { isNil } from 'lodash';
 
 export function getUpdateSecurityClientRoute() {
+  const { clientSecret, ...returnTypeFields } = Client.getInstance().fields;
   return new ConduitRoute(
     {
       path: '/security/client/:id',
@@ -26,7 +27,7 @@ export function getUpdateSecurityClientRoute() {
         notes: ConduitString.Optional,
       },
     },
-    new ConduitRouteReturnDefinition('UpdateSecurityClient', Client.getInstance().fields),
+    new ConduitRouteReturnDefinition('UpdateSecurityClient', returnTypeFields),
     async (params: ConduitRouteParameters) => {
       const { domain, alias, notes } = params.params!;
       let client = await Client.getInstance().findOne({

--- a/packages/security/src/interfaces/ValidationInterface.ts
+++ b/packages/security/src/interfaces/ValidationInterface.ts
@@ -2,7 +2,7 @@ export interface ValidationInterface {
   validated?: boolean;
   client?: {
     platform: string;
-    domain: string;
+    domain?: string;
     clientSecret: string;
   };
 }

--- a/packages/security/src/models/Client.schema.ts
+++ b/packages/security/src/models/Client.schema.ts
@@ -15,6 +15,7 @@ const schema = {
   },
   alias: {
     type: TYPE.String,
+    unique: true,
     required: false,
   },
   notes: {

--- a/packages/security/src/models/Client.schema.ts
+++ b/packages/security/src/models/Client.schema.ts
@@ -52,7 +52,9 @@ export class Client extends ConduitActiveSchema<Client> {
   _id!: string;
   clientId!: string;
   clientSecret!: string;
-  domain!: string;
+  alias?: string;
+  notes?: string;
+  domain?: string;
   platform!: string;
   createdAt!: Date;
   updatedAt!: Date;

--- a/packages/security/src/models/Client.schema.ts
+++ b/packages/security/src/models/Client.schema.ts
@@ -16,7 +16,7 @@ const schema = {
   alias: {
     type: TYPE.String,
     unique: true,
-    required: false,
+    required: true,
   },
   notes: {
     type: TYPE.String,

--- a/packages/security/src/utils/security.ts
+++ b/packages/security/src/utils/security.ts
@@ -6,7 +6,7 @@ export async function validateClient(
   req: Request,
   client: {
     platform: string;
-    domain: string;
+    domain?: string;
     clientSecret: string;
   },
   fromRedis: boolean,


### PR DESCRIPTION
This PR enforces uniqueness across security client aliases.
We already have a notes field for non-unique descriptions anyway.

Security clients now have a db-level uniqueness constraint, and as such, they are also required on a db-level.
Explicitly passing in an alias on security client creation is still optional as it is otherwise implicitly generated based on the platform type, client id and, in case of web clients, the domain used.

~~This is not a breaking change as the feature is not formally released in a tagged non-release-candidate version.~~
This PR **does** introduce a breaking change related to `createClient` and `updateClient` admin route return types.
Basically, we now return `_id` instead of `id` (plus the remaining missing model fields) as we generally do everywhere else.
I am not marking the commit itself as a Breaking Change as we're already in a release candidate for v0.13, but we should include this in the final release notes.

**What kind of change does this PR introduce?** <!--(check at least one)-->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other (please describe)

**Does this PR introduce a breaking change?**

- [X] Yes
- [ ] No

**The PR fulfills these requirements:**

- [X] It's submitted to the `main` branch
- [ ] When resolving a specific issue, it's referenced in the PR's description  (e.g. `fix #xxx`, where "xxx" is the issue number)