### PR TITLE
ci: ESlint CodeFactor defaults, @typescript-eslint/no-unused-vars ignoreRestSiblings

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,95 @@
+{
+  "env": {
+    "es6": true,
+    "node": true,
+    "browser": true,
+    "jquery": true,
+    "jasmine": true,
+    "mocha": true,
+    "qunit": true
+  },
+  "overrides": [
+    {
+      "files": [ "**/*.js", "**/*.jsx", "**/*.es6", "**/*.mjs", "**/*.mdx" ],
+      "extends": "eslint:recommended",
+      "parserOptions": {
+        "ecmaFeatures": {
+          "jsx": true,
+          "globalReturn": true
+        },
+        "sourceType": "script"
+      },
+      "rules": {
+        "no-undef": "off",
+        "no-fallthrough": "off",
+        "no-mixed-spaces-and-tabs": "off",
+        "no-redeclare": "off",
+        "no-with": "off",
+        "no-prototype-builtins": "off",
+        "no-misleading-character-class": "off",
+        "no-async-promise-executor": "off",
+        "no-import-assign": "off",
+        "no-empty": [
+          "error",
+          { "allowEmptyCatch": true }
+        ],
+        "no-unused-vars": [
+          "warn",
+          {
+            "vars": "local",
+            "args": "after-used",
+            "ignoreRestSiblings": false
+          }
+        ]
+      }
+    },
+    {
+      "files": [ "**/*.ts", "**/*.tsx" ],
+      "parser": "@typescript-eslint/parser",
+      "plugins": [ "@typescript-eslint" ],
+      "extends": [ "eslint:recommended", "plugin:@typescript-eslint/recommended" ],
+      "rules": {
+        "no-undef": "off",
+        "no-fallthrough": "off",
+        "no-mixed-spaces-and-tabs": "off",
+        "no-redeclare": "off",
+        "no-with": "off",
+        "no-prototype-builtins": "off",
+        "no-misleading-character-class": "off",
+        "no-async-promise-executor": "off",
+        "no-import-assign": "off",
+        "no-empty": [
+          "error",
+          { "allowEmptyCatch": true }
+        ],
+        "@typescript-eslint/no-unused-vars": [
+          "warn",
+          {
+            "vars": "local",
+            "args": "after-used",
+            "ignoreRestSiblings": true
+          }
+        ],
+        "@typescript-eslint/prefer-as-const": "off",
+        "@typescript-eslint/no-empty-function": "off",
+        "@typescript-eslint/no-empty-interface": "off",
+        "@typescript-eslint/no-inferrable-types": "off",
+        "@typescript-eslint/no-namespace": "off",
+        "@typescript-eslint/no-non-null-assertion": "off",
+        "@typescript-eslint/no-this-alias": "off",
+        "@typescript-eslint/no-unnecessary-type-constraint": "off",
+        "@typescript-eslint/no-var-requires": "off",
+        "@typescript-eslint/triple-slash-reference": "off",
+        "@typescript-eslint/prefer-namespace-keyword": "off"
+      }
+    }
+  ],
+  "globals": {
+    "ActiveXObject": true,
+    "XDomainRequest": true,
+    "ScriptEngine": true,
+    "WSH": true,
+    "WScript": true,
+    "DocumentTouch": true
+  }
+}


### PR DESCRIPTION
This PR introduces an ESlint configuration file to be used by CodeFactor.
I kept all of the [options CodeFactor defaults to](https://github.com/codefactor-io/default-configs/blob/master/.eslintrc.json), except for a `no-unused-vars.ignoreRestSiblings` that would otherwise complain over unused args in ...rest syntax object destructuring that allows getting rid of object fields in a clean and concise way.

I did not include any fancy pre-commit hooks or anything, just a config file to be used by CodeFactor CI tests.

[Tested in a repo fork.](https://github.com/kon14/Conduit/pull/1)

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** <!--(check at least one)-->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [X] Other (please describe)

ESlint rule for CodeFactor CI

**Does this PR introduce a breaking change?** <!-- (check one) -->

- [ ] Yes
- [X] No

**The PR fulfills these requirements:**

- [X] It's submitted to the `main` branch
- [ ] When resolving a specific issue, it's referenced in the PR's description  (e.g. `fix #xxx`, where "xxx" is the issue number)
