### PR TITLE
Architecture Change Bugfixes and Additions

### DIFF
--- a/libraries/grpc-sdk/src/index.ts
+++ b/libraries/grpc-sdk/src/index.ts
@@ -152,7 +152,7 @@ export default class ConduitGrpcSdk {
     if (this._eventBus) {
       return this._eventBus;
     } else {
-      console.warn('Event bus not initialized');
+      ConduitGrpcSdk.Logger.warn('Event bus not initialized');
       return null;
     }
   }
@@ -161,7 +161,7 @@ export default class ConduitGrpcSdk {
     if (this._stateManager) {
       return this._stateManager;
     } else {
-      console.warn('State Manager not initialized');
+      ConduitGrpcSdk.Logger.warn('State Manager not initialized');
       return null;
     }
   }
@@ -182,7 +182,7 @@ export default class ConduitGrpcSdk {
     if (this._modules['router']) {
       return this._modules['router'] as Router;
     } else {
-      console.warn('Router not up yet!');
+      ConduitGrpcSdk.Logger.warn('Router not up yet!');
       return null;
     }
   }
@@ -191,7 +191,7 @@ export default class ConduitGrpcSdk {
     if (this._modules['database']) {
       return this._modules['database'] as DatabaseProvider;
     } else {
-      console.warn('Database provider not up yet!');
+      ConduitGrpcSdk.Logger.warn('Database provider not up yet!');
       return null;
     }
   }
@@ -204,7 +204,7 @@ export default class ConduitGrpcSdk {
     if (this._modules['storage']) {
       return this._modules['storage'] as Storage;
     } else {
-      console.warn('Storage module not up yet!');
+      ConduitGrpcSdk.Logger.warn('Storage module not up yet!');
       return null;
     }
   }
@@ -213,7 +213,7 @@ export default class ConduitGrpcSdk {
     if (this._modules['forms']) {
       return this._modules['forms'] as Forms;
     } else {
-      console.warn('Forms module not up yet!');
+      ConduitGrpcSdk.Logger.warn('Forms module not up yet!');
       return null;
     }
   }
@@ -222,7 +222,7 @@ export default class ConduitGrpcSdk {
     if (this._modules['email']) {
       return this._modules['email'] as Email;
     } else {
-      console.warn('Email provider not up yet!');
+      ConduitGrpcSdk.Logger.warn('Email provider not up yet!');
       return null;
     }
   }
@@ -231,7 +231,7 @@ export default class ConduitGrpcSdk {
     if (this._modules['pushNotifications']) {
       return this._modules['pushNotifications'] as PushNotifications;
     } else {
-      console.warn('Push notifications module not up yet!');
+      ConduitGrpcSdk.Logger.warn('Push notifications module not up yet!');
       return null;
     }
   }
@@ -240,7 +240,7 @@ export default class ConduitGrpcSdk {
     if (this._modules['authentication']) {
       return this._modules['authentication'] as Authentication;
     } else {
-      console.warn('Authentication module not up yet!');
+      ConduitGrpcSdk.Logger.warn('Authentication module not up yet!');
       return null;
     }
   }
@@ -249,7 +249,7 @@ export default class ConduitGrpcSdk {
     if (this._modules['sms']) {
       return this._modules['sms'] as SMS;
     } else {
-      console.warn('SMS module not up yet!');
+      ConduitGrpcSdk.Logger.warn('SMS module not up yet!');
       return null;
     }
   }
@@ -258,7 +258,7 @@ export default class ConduitGrpcSdk {
     if (this._modules['chat']) {
       return this._modules['chat'] as Chat;
     } else {
-      console.warn('Chat module not up yet!');
+      ConduitGrpcSdk.Logger.warn('Chat module not up yet!');
       return null;
     }
   }

--- a/libraries/grpc-sdk/src/modules/authentication/index.ts
+++ b/libraries/grpc-sdk/src/modules/authentication/index.ts
@@ -1,7 +1,6 @@
 import { ConduitModule } from '../../classes/ConduitModule';
 import {
   AuthenticationDefinition,
-  SetConfigResponse,
   UserCreateResponse,
   UserDeleteResponse,
   UserLoginResponse,
@@ -11,12 +10,6 @@ export class Authentication extends ConduitModule<typeof AuthenticationDefinitio
   constructor(private readonly moduleName: string, url: string, grpcToken?: string) {
     super(moduleName, 'authentication', url, grpcToken);
     this.initializeClient(AuthenticationDefinition);
-  }
-
-  setConfig(newConfig: any): Promise<SetConfigResponse> {
-    return this.client!.setConfig({ newConfig: JSON.stringify(newConfig) }).then(res => {
-      return JSON.parse(res.updatedConfig);
-    });
   }
 
   userLogin(userId: string, clientId: string): Promise<UserLoginResponse> {

--- a/libraries/grpc-sdk/src/modules/chat/index.ts
+++ b/libraries/grpc-sdk/src/modules/chat/index.ts
@@ -7,12 +7,6 @@ export class Chat extends ConduitModule<typeof ChatDefinition> {
     this.initializeClient(ChatDefinition);
   }
 
-  setConfig(newConfig: any) {
-    return this.client!.setConfig({ newConfig: JSON.stringify(newConfig) }).then(res => {
-      return JSON.parse(res.updatedConfig);
-    });
-  }
-
   sendMessage(messageData: SendMessageRequest): Promise<any> {
     return this.client!.sendMessage(messageData);
   }

--- a/libraries/grpc-sdk/src/modules/email/index.ts
+++ b/libraries/grpc-sdk/src/modules/email/index.ts
@@ -7,12 +7,6 @@ export class Email extends ConduitModule<typeof EmailDefinition> {
     this.initializeClient(EmailDefinition);
   }
 
-  setConfig(newConfig: any) {
-    return this.client!.setConfig({ newConfig: JSON.stringify(newConfig) }).then(res => {
-      return JSON.parse(res.updatedConfig);
-    });
-  }
-
   registerTemplate(template: {
     name: string;
     subject: string;

--- a/libraries/grpc-sdk/src/modules/forms/index.ts
+++ b/libraries/grpc-sdk/src/modules/forms/index.ts
@@ -6,10 +6,4 @@ export class Forms extends ConduitModule<typeof FormsDefinition> {
     super(moduleName, 'forms', url, grpcToken);
     this.initializeClient(FormsDefinition);
   }
-
-  setConfig(newConfig: any) {
-    return this.client!.setConfig({ newConfig: JSON.stringify(newConfig) }).then(res => {
-      return JSON.parse(res.updatedConfig);
-    });
-  }
 }

--- a/libraries/grpc-sdk/src/modules/pushNotifications/index.ts
+++ b/libraries/grpc-sdk/src/modules/pushNotifications/index.ts
@@ -7,12 +7,6 @@ export class PushNotifications extends ConduitModule<typeof PushNotificationsDef
     this.initializeClient(PushNotificationsDefinition);
   }
 
-  setConfig(newConfig: any) {
-    return this.client!.setConfig({ newConfig: JSON.stringify(newConfig) }).then(res => {
-      return JSON.parse(res.updatedConfig);
-    });
-  }
-
   sendNotificationToken(token: string, platform: string, userId: string) {
     return this.client!.setNotificationToken({
       token,

--- a/libraries/grpc-sdk/src/modules/sms/index.ts
+++ b/libraries/grpc-sdk/src/modules/sms/index.ts
@@ -12,12 +12,6 @@ export class SMS extends ConduitModule<typeof SmsDefinition> {
     this.initializeClient(SmsDefinition);
   }
 
-  setConfig(newConfig: any): Promise<any> {
-    return this.client!.setConfig({ newConfig: JSON.stringify(newConfig) }).then(res => {
-      return JSON.parse(res.updatedConfig);
-    });
-  }
-
   sendSms(to: string, message: string): Promise<SendSmsResponse> {
     return this.client!.sendSms({ to, message });
   }

--- a/libraries/grpc-sdk/src/modules/storage/index.ts
+++ b/libraries/grpc-sdk/src/modules/storage/index.ts
@@ -2,7 +2,6 @@ import { ConduitModule } from '../../classes/ConduitModule';
 import {
   FileResponse,
   GetFileDataResponse,
-  SetConfigResponse,
   StorageDefinition,
 } from '../../protoUtils/storage';
 
@@ -10,12 +9,6 @@ export class Storage extends ConduitModule<typeof StorageDefinition> {
   constructor(private readonly moduleName: string, url: string, grpcToken?: string) {
     super(moduleName, 'storage', url, grpcToken);
     this.initializeClient(StorageDefinition);
-  }
-
-  setConfig(newConfig: any): Promise<SetConfigResponse> {
-    return this.client!.setConfig({ newConfig: JSON.stringify(newConfig) }).then(res => {
-      return JSON.parse(res.updatedConfig);
-    });
   }
 
   getFile(id: string): Promise<FileResponse> {

--- a/libraries/hermes/src/GraphQl/GraphQL.ts
+++ b/libraries/hermes/src/GraphQl/GraphQL.ts
@@ -41,6 +41,7 @@ export class GraphQLController extends ConduitRouter {
   }
 
   refreshGQLServer() {
+    if (!this.typeDefs || this.typeDefs === ' ' || !this.resolvers) return;
     const server = new ApolloServer({
       typeDefs: this.typeDefs,
       resolvers: this.resolvers,
@@ -348,7 +349,10 @@ export class GraphQLController extends ConduitRouter {
           }
 
           if (r.result && !(typeof route.returnTypeFields === 'string')) {
-            result = JSON.parse(result);
+            if (typeof r.result === 'string') {
+              // only grpc route data is stringified
+              result = JSON.parse(result);
+            }
           } else {
             result = {
               result: self.extractResult(route.returnTypeFields as string, result),

--- a/libraries/hermes/src/GraphQl/utils/SimpleTypeParamUtils.ts
+++ b/libraries/hermes/src/GraphQl/utils/SimpleTypeParamUtils.ts
@@ -17,7 +17,7 @@ function extractArrayParam(
   required: boolean = false,
   originalParam?: any,
 ) {
-  if (GQL_PRIMITIVES.indexOf(param)) {
+  if (GQL_PRIMITIVES.indexOf(param) !== -1) {
     return `[${param}]` + (required ? '!' : '');
   } else if (param === 'ObjectId') {
     return '[ID]' + (required ? '!' : '');

--- a/libraries/hermes/src/Rest/Rest.ts
+++ b/libraries/hermes/src/Rest/Rest.ts
@@ -1,4 +1,3 @@
-// todo Create the controller that creates REST-specific endpoints
 import {
   Handler,
   IRouterMatcher,

--- a/libraries/hermes/src/Socket/Socket.ts
+++ b/libraries/hermes/src/Socket/Socket.ts
@@ -29,6 +29,7 @@ export class SocketController extends ConduitRouter {
   ) => void)[];
 
   constructor(
+    private readonly port: number,
     grpcSdk: ConduitGrpcSdk,
     expressApp: Application,
     redisDetails: { host: string; port: number },
@@ -51,7 +52,7 @@ export class SocketController extends ConduitRouter {
     this.io.adapter(
       createAdapter({ pubClient: this.pubClient, subClient: this.subClient }),
     );
-    this.httpServer.listen(process.env.SOCKET_PORT || 3001);
+    this.httpServer.listen(process.env.SOCKET_PORT || this.port);
     this._registeredNamespaces = new Map();
     this.globalMiddlewares = [];
   }

--- a/libraries/hermes/src/index.ts
+++ b/libraries/hermes/src/index.ts
@@ -5,7 +5,12 @@ import { SocketController } from './Socket/Socket';
 import ConduitGrpcSdk, { ConduitError, Indexable } from '@conduitplatform/grpc-sdk';
 import { ConduitLogger } from './utils/logger';
 import http from 'http';
-import { ConduitMiddleware, ConduitSocket, SocketPush } from './interfaces';
+import {
+  ConduitRequest,
+  ConduitMiddleware,
+  ConduitSocket,
+  SocketPush,
+} from './interfaces';
 import { SwaggerRouterMetadata } from './types';
 import cors from 'cors';
 import cookieParser from 'cookie-parser';
@@ -148,7 +153,7 @@ export class ConduitRoutingController {
   }
 
   registerMiddleware(
-    middleware: (req: Request, res: Response, next: NextFunction) => void,
+    middleware: (req: ConduitRequest, res: Response, next: NextFunction) => void,
     socketMiddleware: boolean,
   ) {
     this._middlewareRouter.use(middleware);

--- a/libraries/hermes/src/index.ts
+++ b/libraries/hermes/src/index.ts
@@ -94,12 +94,14 @@ export class ConduitRoutingController {
     );
 
     this.expressApp.use(baseUrl, (req, res, next) => {
-      if (req.url.startsWith(`${baseUrl}/graphql`) && this._graphQLRouter) {
+      if (req.url.startsWith('/graphql')) {
         if (!this._graphQLRouter) {
-          res.status(500).json({ message: 'GraphQL is not enabled on this server!' });
+          return res
+            .status(500)
+            .json({ message: 'GraphQL is not enabled on this server!' });
         }
         this._graphQLRouter?.handleRequest(req, res, next);
-      } else if (!req.url.startsWith(`${baseUrl}/graphql`)) {
+      } else if (!req.url.startsWith('/graphql')) {
         // this needs to be a function to hook on whatever the current router is
         self._restRouter?.handleRequest(req, res, next);
       }

--- a/libraries/hermes/src/index.ts
+++ b/libraries/hermes/src/index.ts
@@ -202,15 +202,17 @@ export class ConduitRoutingController {
   ) {
     processedRoutes.forEach(r => {
       if (r instanceof ConduitMiddleware) {
-        console.log(
+        ConduitGrpcSdk.Logger.log(
           'New middleware registered: ' + r.input.path + ' handler url: ' + url,
         );
         this.registerRouteMiddleware(r);
       } else if (r instanceof ConduitSocket) {
-        console.log('New socket registered: ' + r.input.path + ' handler url: ' + url);
+        ConduitGrpcSdk.Logger.log(
+          'New socket registered: ' + r.input.path + ' handler url: ' + url,
+        );
         this.registerConduitSocket(r);
       } else {
-        console.log(
+        ConduitGrpcSdk.Logger.log(
           'New route registered: ' +
             r.input.action +
             ' ' +
@@ -234,11 +236,11 @@ export class ConduitRoutingController {
     // handle specific listen errors with friendly messages
     switch (error.code) {
       case 'EACCES':
-        console.error(bind + ' requires elevated privileges');
+        ConduitGrpcSdk.Logger.error(bind + ' requires elevated privileges');
         process.exit(1);
         break;
       case 'EADDRINUSE':
-        console.error(bind + ' is already in use');
+        ConduitGrpcSdk.Logger.error(bind + ' is already in use');
         process.exit(1);
         break;
       default:
@@ -250,7 +252,7 @@ export class ConduitRoutingController {
     const address = this.server.address();
     const bind =
       typeof address === 'string' ? 'pipe ' + address : 'port ' + address?.port;
-    console.log(this.baseUrl.substr(1) + ' listening on ' + bind);
+    ConduitGrpcSdk.Logger.log(this.baseUrl.substr(1) + ' listening on ' + bind);
   }
 
   private registerGlobalMiddleware() {

--- a/modules/authentication/src/Authentication.ts
+++ b/modules/authentication/src/Authentication.ts
@@ -54,7 +54,8 @@ export default class Authentication extends ManagedModule<Config> {
   }
 
   async onServerStart() {
-    this.database = this.grpcSdk.databaseProvider!;
+    await this.grpcSdk.waitForExistence('database');
+    this.database = this.grpcSdk.database!;
     await runMigrations(this.grpcSdk);
   }
 

--- a/modules/authentication/src/Authentication.ts
+++ b/modules/authentication/src/Authentication.ts
@@ -203,8 +203,8 @@ export default class Authentication extends ManagedModule<Config> {
       });
 
       if (verify && this.sendEmail) {
-        const serverConfig = await this.grpcSdk.config.getServerConfig();
-        const url = serverConfig.url;
+        const serverConfig = await this.grpcSdk.config.get('router');
+        const url = serverConfig.hostUrl;
         const verificationToken: models.Token = await models.Token.getInstance().create({
           type: TokenType.VERIFICATION_TOKEN,
           userId: user._id,

--- a/modules/authentication/src/admin/index.ts
+++ b/modules/authentication/src/admin/index.ts
@@ -45,8 +45,8 @@ export class AdminHandlers {
         renewServiceToken: this.serviceAdmin.renewToken.bind(this),
       })
       .catch((err: Error) => {
-        console.log('Failed to register admin routes for module!');
-        console.error(err);
+        ConduitGrpcSdk.Logger.log('Failed to register admin routes for module!');
+        ConduitGrpcSdk.Logger.error(err);
       });
   }
 

--- a/modules/authentication/src/handlers/local.ts
+++ b/modules/authentication/src/handlers/local.ts
@@ -34,7 +34,7 @@ export class LocalHandlers implements IAuthenticationStrategy {
     private readonly sendEmail: boolean,
   ) {
     grpcSdk.config.get('router').then(config => {
-      this.clientValidation = config.security.clientValidation.enabled;
+      this.clientValidation = config.security.clientValidation;
     });
   }
 

--- a/modules/authentication/src/handlers/local.ts
+++ b/modules/authentication/src/handlers/local.ts
@@ -267,8 +267,8 @@ export class LocalHandlers implements IAuthenticationStrategy {
 
     this.grpcSdk.bus?.publish('authentication:register:user', JSON.stringify(user));
 
-    const serverConfig = await this.grpcSdk.config.getServerConfig();
-    const url = serverConfig.url;
+    const serverConfig = await this.grpcSdk.config.get('router');
+    const url = serverConfig.hostUrl;
 
     if (this.sendEmail) {
       const verificationToken: Token = await Token.getInstance().create({

--- a/modules/authentication/src/handlers/oauth2/OAuth2.ts
+++ b/modules/authentication/src/handlers/oauth2/OAuth2.ts
@@ -81,7 +81,7 @@ export abstract class OAuth2<T, S extends OAuth2Settings>
 
   async authorize(call: ParsedRouterRequest) {
     const params = call.request.params;
-    const conduitUrl = (await this.grpcSdk.config.getServerConfig()).url;
+    const conduitUrl = (await this.grpcSdk.config.get('router')).hostUrl;
     const myParams: AuthParams = {
       client_id: this.settings.clientId,
       client_secret: this.settings.clientSecret,

--- a/modules/authentication/src/handlers/oauth2/facebook/facebook.ts
+++ b/modules/authentication/src/handlers/oauth2/facebook/facebook.ts
@@ -20,12 +20,12 @@ export class FacebookHandlers extends OAuth2<FacebookUser, OAuth2Settings> {
   constructor(
     grpcSdk: ConduitGrpcSdk,
     config: { facebook: ProviderConfig },
-    serverConfig: { url: string },
+    serverConfig: { hostUrl: string },
   ) {
     super(
       grpcSdk,
       'facebook',
-      new OAuth2Settings(serverConfig.url, config.facebook, facebookParameters),
+      new OAuth2Settings(serverConfig.hostUrl, config.facebook, facebookParameters),
     );
     this.mapScopes = {
       email: 'email',

--- a/modules/authentication/src/handlers/oauth2/figma/figma.ts
+++ b/modules/authentication/src/handlers/oauth2/figma/figma.ts
@@ -14,12 +14,12 @@ export class FigmaHandlers extends OAuth2<FigmaUser, OAuth2Settings> {
   constructor(
     grpcSdk: ConduitGrpcSdk,
     config: { figma: ProviderConfig },
-    serverConfig: { url: string },
+    serverConfig: { hostUrl: string },
   ) {
     super(
       grpcSdk,
       'figma',
-      new OAuth2Settings(serverConfig.url, config.figma, figmaParameters),
+      new OAuth2Settings(serverConfig.hostUrl, config.figma, figmaParameters),
     );
     this.defaultScopes = ['users:profile:read'];
   }

--- a/modules/authentication/src/handlers/oauth2/github/github.ts
+++ b/modules/authentication/src/handlers/oauth2/github/github.ts
@@ -12,12 +12,12 @@ export class GithubHandlers extends OAuth2<GithubUser, OAuth2Settings> {
   constructor(
     grpcSdk: ConduitGrpcSdk,
     config: { github: ProviderConfig },
-    serverConfig: { url: string },
+    serverConfig: { hostUrl: string },
   ) {
     super(
       grpcSdk,
       'github',
-      new OAuth2Settings(serverConfig.url, config.github, githubParameters),
+      new OAuth2Settings(serverConfig.hostUrl, config.github, githubParameters),
     );
     this.defaultScopes = ['read:user', 'repo'];
   }

--- a/modules/authentication/src/handlers/oauth2/google/google.ts
+++ b/modules/authentication/src/handlers/oauth2/google/google.ts
@@ -19,12 +19,12 @@ export class GoogleHandlers extends OAuth2<GoogleUser, OAuth2Settings> {
   constructor(
     grpcSdk: ConduitGrpcSdk,
     config: { google: ProviderConfig },
-    serverConfig: { url: string },
+    serverConfig: { hostUrl: string },
   ) {
     super(
       grpcSdk,
       'google',
-      new OAuth2Settings(serverConfig.url, config.google, googleParameters),
+      new OAuth2Settings(serverConfig.hostUrl, config.google, googleParameters),
     );
     this.defaultScopes = [
       'https://www.googleapis.com/auth/userinfo.email',

--- a/modules/authentication/src/handlers/oauth2/microsoft/microsoft.ts
+++ b/modules/authentication/src/handlers/oauth2/microsoft/microsoft.ts
@@ -13,12 +13,12 @@ export class MicrosoftHandlers extends OAuth2<MicrosoftUser, MicrosoftSettings> 
   constructor(
     grpcSdk: ConduitGrpcSdk,
     config: { microsoft: ProviderConfig },
-    serverConfig: { url: string },
+    serverConfig: { hostUrl: string },
   ) {
     super(
       grpcSdk,
       'microsoft',
-      new MicrosoftSettings(serverConfig.url, config.microsoft, microsoftParameters),
+      new MicrosoftSettings(serverConfig.hostUrl, config.microsoft, microsoftParameters),
     );
     this.defaultScopes = ['openid'];
   }

--- a/modules/authentication/src/handlers/oauth2/slack/slack.ts
+++ b/modules/authentication/src/handlers/oauth2/slack/slack.ts
@@ -15,12 +15,12 @@ export class SlackHandlers extends OAuth2<SlackUser, OAuth2Settings> {
   constructor(
     grpcSdk: ConduitGrpcSdk,
     config: { slack: ProviderConfig },
-    serverConfig: { url: string },
+    serverConfig: { hostUrl: string },
   ) {
     super(
       grpcSdk,
       'slack',
-      new OAuth2Settings(serverConfig.url, config.slack, slackParameters),
+      new OAuth2Settings(serverConfig.hostUrl, config.slack, slackParameters),
     );
     this.defaultScopes = ['users:read'];
   }

--- a/modules/authentication/src/handlers/oauth2/twitch/twitch.ts
+++ b/modules/authentication/src/handlers/oauth2/twitch/twitch.ts
@@ -12,12 +12,12 @@ export class TwitchHandlers extends OAuth2<TwitchUser, OAuth2Settings> {
   constructor(
     grpcSdk: ConduitGrpcSdk,
     config: { twitch: ProviderConfig },
-    serverConfig: { url: string },
+    serverConfig: { hostUrl: string },
   ) {
     super(
       grpcSdk,
       'twitch',
-      new OAuth2Settings(serverConfig.url, config.twitch, twitchParameters),
+      new OAuth2Settings(serverConfig.hostUrl, config.twitch, twitchParameters),
     );
   }
 

--- a/modules/authentication/src/routes/index.ts
+++ b/modules/authentication/src/routes/index.ts
@@ -65,27 +65,25 @@ export class AuthenticationRoutes {
 
     serverConfig = await this.grpcSdk.config.get('router');
     await Promise.all(
-      (Object.keys(oauth2) as (keyof OAuthHandler)[]).map(
-        (key: keyof OAuthHandler, value) => {
-          const handler: OAuth2<unknown, OAuth2Settings> = new oauth2[key](
-            this.grpcSdk,
-            config,
-            serverConfig,
-          );
-          return handler
-            .validate()
-            .then((active: boolean) => {
-              if (active) {
-                handler.declareRoutes(this._routingManager);
-                enabled = true;
-              }
-              return;
-            })
-            .catch(e => {
-              ConduitGrpcSdk.Logger.error(e);
-            });
-        },
-      ),
+      (Object.keys(oauth2) as (keyof OAuthHandler)[]).map((key: keyof OAuthHandler) => {
+        const handler: OAuth2<unknown, OAuth2Settings> = new oauth2[key](
+          this.grpcSdk,
+          config,
+          { hostUrl: serverConfig.url },
+        );
+        return handler
+          .validate()
+          .then((active: boolean) => {
+            if (active) {
+              handler.declareRoutes(this._routingManager);
+              enabled = true;
+            }
+            return;
+          })
+          .catch(e => {
+            ConduitGrpcSdk.Logger.error(e);
+          });
+      }),
     );
 
     errorMessage = null;

--- a/modules/authentication/src/routes/index.ts
+++ b/modules/authentication/src/routes/index.ts
@@ -63,7 +63,7 @@ export class AuthenticationRoutes {
     }
     errorMessage = null;
 
-    serverConfig = await this.grpcSdk.config.getServerConfig();
+    serverConfig = await this.grpcSdk.config.get('router');
     await Promise.all(
       (Object.keys(oauth2) as (keyof OAuthHandler)[]).map(
         (key: keyof OAuthHandler, value) => {

--- a/modules/authentication/src/routes/index.ts
+++ b/modules/authentication/src/routes/index.ts
@@ -44,7 +44,7 @@ export class AuthenticationRoutes {
 
   async registerRoutes() {
     const config = ConfigController.getInstance().config;
-    let serverConfig: { url: string };
+    let serverConfig: { hostUrl: string };
     this._routingManager.clear();
     let enabled = false;
     let errorMessage = null;
@@ -69,7 +69,7 @@ export class AuthenticationRoutes {
         const handler: OAuth2<unknown, OAuth2Settings> = new oauth2[key](
           this.grpcSdk,
           config,
-          { hostUrl: serverConfig.url },
+          serverConfig,
         );
         return handler
           .validate()

--- a/modules/chat/src/Chat.ts
+++ b/modules/chat/src/Chat.ts
@@ -59,7 +59,8 @@ export default class Chat extends ManagedModule<Config> {
   }
 
   async onServerStart() {
-    this.database = this.grpcSdk.databaseProvider!;
+    await this.grpcSdk.waitForExistence('database');
+    this.database = this.grpcSdk.database!;
     await runMigrations(this.grpcSdk);
     await this.grpcSdk.monitorModule('authentication', serving => {
       this.updateHealth(

--- a/modules/chat/src/routes/index.ts
+++ b/modules/chat/src/routes/index.ts
@@ -83,12 +83,12 @@ export class ChatRoutes {
         .catch((e: Error) => {
           throw new GrpcError(status.INTERNAL, e.message);
         });
-      const serverConfig = await this.grpcSdk.config.getServerConfig();
+      const serverConfig = await this.grpcSdk.config.get('router');
       await sendInvitations(
         usersToBeAdded,
         user,
         room,
-        serverConfig.url,
+        serverConfig.hostUrl,
         this.sendEmail,
         this.sendPushNotification,
         this.grpcSdk,
@@ -150,12 +150,12 @@ export class ChatRoutes {
 
     const config = await this.grpcSdk.config.get('chat');
     if (config.explicit_room_joins.enabled) {
-      const serverConfig = await this.grpcSdk.config.getServerConfig();
+      const serverConfig = await this.grpcSdk.config.get('router');
       const ret = await sendInvitations(
         usersToBeAdded,
         user,
         room,
-        serverConfig.url,
+        serverConfig.hostUrl,
         this.sendEmail,
         this.sendPushNotification,
         this.grpcSdk,

--- a/modules/database/src/migrations/securityClients.migration.ts
+++ b/modules/database/src/migrations/securityClients.migration.ts
@@ -1,12 +1,10 @@
 import { DatabaseAdapter } from '../adapters/DatabaseAdapter';
 import { MongooseSchema } from '../adapters/mongoose-adapter/MongooseSchema';
 import { SequelizeSchema } from '../adapters/sequelize-adapter/SequelizeSchema';
-import { migrateCrudOperations } from './crudOperations.migration';
-import { migrateSecurityClients } from './securityClients.migration';
 
-export async function runMigrations(
+export async function migrateSecurityClients(
   adapter: DatabaseAdapter<MongooseSchema | SequelizeSchema>,
 ) {
-  await migrateCrudOperations(adapter);
-  await migrateSecurityClients(adapter);
+  const model = adapter.getSchemaModel('_DeclaredSchema').model;
+  await model.updateMany({ name: 'Client' }, { ownerModule: 'router' }, true);
 }

--- a/modules/email/src/Email.ts
+++ b/modules/email/src/Email.ts
@@ -46,7 +46,8 @@ export default class Email extends ManagedModule<Config> {
   }
 
   async onServerStart() {
-    this.database = this.grpcSdk.databaseProvider!;
+    await this.grpcSdk.waitForExistence('database');
+    this.database = this.grpcSdk.database!;
     await runMigrations(this.grpcSdk);
   }
 

--- a/modules/forms/src/Forms.ts
+++ b/modules/forms/src/Forms.ts
@@ -65,6 +65,7 @@ export default class Forms extends ManagedModule<Config> {
       this.updateHealth(HealthCheckStatus.NOT_SERVING);
     } else {
       if (!this.isRunning) {
+        if (!this.grpcSdk.isAvailable('email')) return;
         await this.registerSchemas();
         await this.grpcSdk.emailProvider!.registerTemplate(FormSubmissionTemplate);
         const self = this;

--- a/modules/forms/src/Forms.ts
+++ b/modules/forms/src/Forms.ts
@@ -34,7 +34,8 @@ export default class Forms extends ManagedModule<Config> {
   }
 
   async onServerStart() {
-    this.database = this.grpcSdk.databaseProvider!;
+    await this.grpcSdk.waitForExistence('database');
+    this.database = this.grpcSdk.database!;
     await runMigrations(this.grpcSdk);
     await this.grpcSdk.monitorModule('email', serving => {
       if (serving && ConfigController.getInstance().config.active) {

--- a/modules/push-notifications/src/PushNotifications.ts
+++ b/modules/push-notifications/src/PushNotifications.ts
@@ -49,7 +49,8 @@ export default class PushNotifications extends ManagedModule<Config> {
   }
 
   async onServerStart() {
-    this.database = this.grpcSdk.databaseProvider!;
+    await this.grpcSdk.waitForExistence('database');
+    this.database = this.grpcSdk.database!;
     await runMigrations(this.grpcSdk);
     await this.grpcSdk.monitorModule('authentication', serving => {
       if (serving && ConfigController.getInstance().config.active) {

--- a/modules/router/src/Router.ts
+++ b/modules/router/src/Router.ts
@@ -133,7 +133,7 @@ export default class ConduitDefaultRouter extends ManagedModule<Config> {
     const value = (process.env['PORT'] || process.env['CLIENT_PORT']) ?? '3000';
     const port = parseInt(value, 10);
     if (isNaN(port)) {
-      console.error(`Invalid HTTP port value: ${port}`);
+      ConduitGrpcSdk.Logger.error(`Invalid HTTP port value: ${port}`);
       process.exit(-1);
     }
     if (port >= 0) {

--- a/modules/router/src/Router.ts
+++ b/modules/router/src/Router.ts
@@ -24,7 +24,7 @@ import AppConfigSchema, { Config } from './config';
 import * as models from './models';
 import { runMigrations } from './migrations';
 import SecurityModule from './security';
-import { AdminHandlers } from './admin/admin';
+import { AdminHandlers } from './admin';
 import {
   RegisterConduitRouteRequest,
   RegisterConduitRouteRequest_PathDefinition,

--- a/modules/router/src/Router.ts
+++ b/modules/router/src/Router.ts
@@ -1,4 +1,4 @@
-import { Router } from 'express';
+import { Router, NextFunction } from 'express';
 import { status } from '@grpc/grpc-js';
 import ConduitGrpcSdk, {
   ConfigController,
@@ -67,12 +67,14 @@ export default class ConduitDefaultRouter extends ManagedModule<Config> {
       '',
       this.grpcSdk,
     );
-    this._internalRouter.registerRoute('*', [
-      (req, res, next) => {
-        (req as ConduitRequest)['conduit'] = {};
+    this.registerGlobalMiddleware(
+      'conduitRequestMiddleware',
+      (req: ConduitRequest, res: Response, next: NextFunction) => {
+        req['conduit'] = {};
         next();
       },
-    ]);
+      true,
+    );
   }
 
   async onRegister() {

--- a/modules/router/src/Router.ts
+++ b/modules/router/src/Router.ts
@@ -60,7 +60,10 @@ export default class ConduitDefaultRouter extends ManagedModule<Config> {
   }
 
   async onServerStart() {
-    this.database = this.grpcSdk.databaseProvider!;
+    if (!this.grpcSdk.database) {
+      await this.grpcSdk.waitForExistence('database');
+      this.database = this.grpcSdk.databaseProvider!;
+    }
     await runMigrations(this.grpcSdk);
     this._internalRouter = new ConduitRoutingController(
       this.getHttpPort()!,

--- a/modules/router/src/Router.ts
+++ b/modules/router/src/Router.ts
@@ -70,7 +70,7 @@ export default class ConduitDefaultRouter extends ManagedModule<Config> {
       this.getSocketPort()!,
       '',
       this.grpcSdk,
-      3000,
+      1000,
     );
     this.registerGlobalMiddleware(
       'conduitRequestMiddleware',

--- a/modules/router/src/Router.ts
+++ b/modules/router/src/Router.ts
@@ -70,6 +70,7 @@ export default class ConduitDefaultRouter extends ManagedModule<Config> {
       this.getSocketPort()!,
       '',
       this.grpcSdk,
+      3000,
     );
     this.registerGlobalMiddleware(
       'conduitRequestMiddleware',

--- a/modules/router/src/admin/index.ts
+++ b/modules/router/src/admin/index.ts
@@ -39,8 +39,8 @@ export class AdminHandlers {
         updateSecurityClient: this.securityAdmin.updateSecurityClient.bind(this),
       })
       .catch((err: Error) => {
-        console.log('Failed to register admin routes for module!');
-        console.error(err);
+        ConduitGrpcSdk.Logger.log('Failed to register admin routes for module!');
+        ConduitGrpcSdk.Logger.error(err);
       });
   }
 

--- a/modules/router/src/admin/router.ts
+++ b/modules/router/src/admin/router.ts
@@ -1,0 +1,43 @@
+import ConduitGrpcSdk, { UnparsedRouterResponse } from '@conduitplatform/grpc-sdk';
+import { isNil } from 'lodash';
+import ConduitDefaultRouter from '../Router';
+
+export class RouterAdmin {
+  constructor(
+    private readonly grpcSdk: ConduitGrpcSdk,
+    private readonly router: ConduitDefaultRouter,
+  ) {}
+
+  async getMiddlewares(): Promise<UnparsedRouterResponse> {
+    const response: string[] = [];
+    const module = this.router.getGrpcRoutes();
+    Object.keys(module).forEach((url: string) => {
+      module[url].forEach((item: any) => {
+        if (
+          item.returns == null &&
+          !isNil(item.grpcFunction) &&
+          item.grpcFunction !== ''
+        ) {
+          response.push(item.grpcFunction);
+        }
+      });
+    });
+    return Array.from(new Set(response));
+  }
+
+  async getRoutes(): Promise<UnparsedRouterResponse> {
+    const response: any[] = [];
+    const module = this.router.getGrpcRoutes();
+    console.log(module);
+    Object.keys(module).forEach((url: string) => {
+      module[url].forEach((item: any) => {
+        response.push({
+          name: item.grpcFunction,
+          action: item.options.action,
+          path: item.options.path,
+        });
+      });
+    });
+    return { result: response }; // unnested from result in Rest.addConduitRoute, grpc routes avoid this using wrapRouterGrpcFunction
+  }
+}

--- a/modules/router/src/admin/router.ts
+++ b/modules/router/src/admin/router.ts
@@ -28,7 +28,7 @@ export class RouterAdmin {
   async getRoutes(): Promise<UnparsedRouterResponse> {
     const response: any[] = [];
     const module = this.router.getGrpcRoutes();
-    console.log(module);
+    ConduitGrpcSdk.Logger.logObject(module);
     Object.keys(module).forEach((url: string) => {
       module[url].forEach((item: any) => {
         response.push({

--- a/modules/router/src/config/config.ts
+++ b/modules/router/src/config/config.ts
@@ -17,10 +17,6 @@ export default {
       default: true,
     },
   },
-  port: {
-    format: 'Number',
-    default: 8080,
-  },
   security: {
     clientValidation: {
       enabled: {

--- a/modules/router/src/config/config.ts
+++ b/modules/router/src/config/config.ts
@@ -19,10 +19,8 @@ export default {
   },
   security: {
     clientValidation: {
-      enabled: {
-        format: 'Boolean',
-        default: false,
-      },
+      format: 'Boolean',
+      default: false,
     },
   },
 };

--- a/modules/router/src/security/handlers/client-validation/index.ts
+++ b/modules/router/src/security/handlers/client-validation/index.ts
@@ -42,7 +42,7 @@ export class ClientValidator {
     }
 
     const securityConfig = ConfigController.getInstance().config.security;
-    if (!securityConfig.clientValidation.enabled) {
+    if (!securityConfig.clientValidation) {
       req.conduit!.clientId = 'anonymous-client';
       delete req.headers.clientsecret;
       delete req.headers.clientid;

--- a/modules/router/src/security/index.ts
+++ b/modules/router/src/security/index.ts
@@ -25,9 +25,7 @@ export default class SecurityModule {
       'helmetGqlFix',
       (req: Request, res: Response, next: NextFunction) => {
         if (
-          (req.url === '/graphql' ||
-            req.url.startsWith('/swagger') ||
-            req.url.startsWith('/admin/swagger')) &&
+          (req.url === '/graphql' || req.url.startsWith('/swagger')) &&
           req.method === 'GET'
         ) {
           res.removeHeader('Content-Security-Policy');

--- a/modules/storage/src/Storage.ts
+++ b/modules/storage/src/Storage.ts
@@ -48,6 +48,7 @@ export default class Storage extends ManagedModule<Config> {
   }
 
   async onServerStart() {
+    await this.grpcSdk.waitForExistence('database');
     this.database = this.grpcSdk.databaseProvider!;
     await runMigrations(this.grpcSdk);
     this.storageProvider = createStorageProvider('local', {} as Config);

--- a/packages/admin/src/config/config.ts
+++ b/packages/admin/src/config/config.ts
@@ -18,6 +18,10 @@ export default {
     default: 'http://localhost:3030',
   },
   transports: {
+    rest: {
+      type: 'Boolean',
+      default: true,
+    },
     graphql: {
       type: 'Boolean',
       default: false,

--- a/packages/admin/src/config/config.ts
+++ b/packages/admin/src/config/config.ts
@@ -1,16 +1,30 @@
 export default {
   auth: {
     tokenSecret: {
-      type: String,
+      type: 'String',
       default: 'fjeinqgwenf',
     },
     hashRounds: {
-      type: Number,
+      type: 'Number',
       default: 11,
     },
     tokenExpirationTime: {
-      type: Number,
+      type: 'Number',
       default: 72000,
+    },
+  },
+  hostUrl: {
+    type: 'String',
+    default: 'http://localhost:3030',
+  },
+  transports: {
+    graphql: {
+      type: 'Boolean',
+      default: false,
+    },
+    sockets: {
+      type: 'Boolean',
+      default: false,
     },
   },
 };

--- a/packages/admin/src/index.ts
+++ b/packages/admin/src/index.ts
@@ -86,6 +86,7 @@ export default class AdminModule extends IConduitAdmin {
       this.getSocketPort()!,
       '/admin',
       this.grpcSdk,
+      3000,
       swaggerRouterMetadata,
     );
     this._grpcRoutes = {};

--- a/packages/admin/src/index.ts
+++ b/packages/admin/src/index.ts
@@ -112,7 +112,7 @@ export default class AdminModule extends IConduitAdmin {
   async initialize(server: GrpcServer) {
     ConfigController.getInstance().config = await this.commons
       .getConfigManager()
-      .get('admin');
+      .configurePackage('admin', AdminConfigSchema.getProperties());
     await server.addService(
       path.resolve(__dirname, '../../core/src/core.proto'),
       'conduit.core.Admin',
@@ -120,9 +120,6 @@ export default class AdminModule extends IConduitAdmin {
         registerAdminRoute: this.registerAdminRoute.bind(this),
       },
     );
-    ConfigController.getInstance().config = await this.commons
-      .getConfigManager()
-      .registerModulesConfig('admin', AdminConfigSchema.getProperties());
     this.grpcSdk.on('database', async () => {
       await this.handleDatabase().catch(ConduitGrpcSdk.Logger.log);
     });

--- a/packages/admin/src/index.ts
+++ b/packages/admin/src/index.ts
@@ -76,6 +76,7 @@ export default class AdminModule extends IConduitAdmin {
     this.grpcSdk = grpcSdk;
     this._router = new ConduitRoutingController(
       this.getHttpPort()!,
+      this.getSocketPort()!,
       '/admin',
       this.grpcSdk,
       swaggerRouterMetadata,
@@ -97,11 +98,23 @@ export default class AdminModule extends IConduitAdmin {
     this._grpcRoutes = {};
   }
 
-  getHttpPort() {
-    const value = (process.env['PORT'] || process.env['ADMIN_PORT']) ?? '3030';
+  private getHttpPort() {
+    const value = (process.env['ADMIN_HTTP_PORT'] || process.env['PORT']) ?? '3030'; // <=v13 compat (PORT)
     const port = parseInt(value, 10);
     if (isNaN(port)) {
       ConduitGrpcSdk.Logger.error(`Invalid HTTP port value: ${port}`);
+      process.exit(-1);
+    }
+    if (port >= 0) {
+      return port;
+    }
+  }
+
+  private getSocketPort() {
+    const value = process.env['ADMIN_SOCKET_PORT'] ?? '3031';
+    const port = parseInt(value, 10);
+    if (isNaN(port)) {
+      ConduitGrpcSdk.Logger.error(`Invalid Socket port value: ${port}`);
       process.exit(-1);
     }
     if (port >= 0) {

--- a/packages/admin/src/index.ts
+++ b/packages/admin/src/index.ts
@@ -142,14 +142,16 @@ export default class AdminModule extends IConduitAdmin {
   }
 
   private registerAdminRoutes() {
-    this._sdkRoutes = [
-      adminRoutes.getLoginRoute(this.commons),
-      adminRoutes.getModulesRoute(this.commons),
-      adminRoutes.getCreateAdminRoute(this.commons),
-      adminRoutes.getAdminUsersRoute(),
-      adminRoutes.deleteAdminUserRoute(),
-      adminRoutes.changePasswordRoute(this.commons),
-    ];
+    this._sdkRoutes.push(
+      ...[
+        adminRoutes.getLoginRoute(this.commons),
+        adminRoutes.getModulesRoute(this.commons),
+        adminRoutes.getCreateAdminRoute(this.commons),
+        adminRoutes.getAdminUsersRoute(),
+        adminRoutes.deleteAdminUserRoute(),
+        adminRoutes.changePasswordRoute(this.commons),
+      ],
+    );
     this._sdkRoutes.forEach(route => {
       this._router.registerConduitRoute(route);
     }, this);

--- a/packages/admin/src/index.ts
+++ b/packages/admin/src/index.ts
@@ -100,7 +100,7 @@ export default class AdminModule extends IConduitAdmin {
     const value = (process.env['PORT'] || process.env['ADMIN_PORT']) ?? '3030';
     const port = parseInt(value, 10);
     if (isNaN(port)) {
-      console.error(`Invalid HTTP port value: ${port}`);
+      ConduitGrpcSdk.Logger.error(`Invalid HTTP port value: ${port}`);
       process.exit(-1);
     }
     if (port >= 0) {
@@ -120,7 +120,7 @@ export default class AdminModule extends IConduitAdmin {
       .getConfigManager()
       .registerModulesConfig('admin', AdminConfigSchema.getProperties());
     this.grpcSdk.on('database', async () => {
-      await this.handleDatabase().catch(console.log);
+      await this.handleDatabase().catch(ConduitGrpcSdk.Logger.log);
     });
 
     this._sdkRoutes = [

--- a/packages/admin/src/index.ts
+++ b/packages/admin/src/index.ts
@@ -30,6 +30,7 @@ import {
   SwaggerRouterMetadata,
 } from '@conduitplatform/hermes';
 import { RegisterAdminRouteRequest_PathDefinition } from '@conduitplatform/grpc-sdk/dist/protoUtils/core';
+import { Response, NextFunction } from 'express';
 
 const swaggerRouterMetadata: SwaggerRouterMetadata = {
   urlPrefix: '/admin',
@@ -80,16 +81,18 @@ export default class AdminModule extends IConduitAdmin {
     );
     this._router.initRest();
     // Register Middleware
-    // todo switch to global
-    this._router.registerRoute('*', [
-      (req, res, next) => {
-        (req as ConduitRequest)['conduit'] = {};
+    this._router.registerMiddleware(
+      (req: ConduitRequest, res: Response, next: NextFunction) => {
+        req['conduit'] = {};
         next();
       },
-      middleware.getAdminMiddleware(this.commons),
+      true,
+    );
+    this._router.registerMiddleware(middleware.getAdminMiddleware(this.commons), true);
+    this._router.registerMiddleware(
       middleware.getAuthMiddleware(this.grpcSdk, this.commons),
-    ]);
-
+      true,
+    );
     this._grpcRoutes = {};
   }
 

--- a/packages/admin/src/index.ts
+++ b/packages/admin/src/index.ts
@@ -86,7 +86,7 @@ export default class AdminModule extends IConduitAdmin {
       this.getSocketPort()!,
       '/admin',
       this.grpcSdk,
-      3000,
+      1000,
       swaggerRouterMetadata,
     );
     this._grpcRoutes = {};

--- a/packages/admin/src/index.ts
+++ b/packages/admin/src/index.ts
@@ -2,9 +2,10 @@ import { isNaN, isNil } from 'lodash';
 import { status } from '@grpc/grpc-js';
 import ConduitGrpcSdk, {
   ConduitRouteActions,
+  GrpcServer,
+  ConfigController,
   GrpcCallback,
   GrpcRequest,
-  GrpcServer,
   Indexable,
 } from '@conduitplatform/grpc-sdk';
 import {
@@ -109,6 +110,9 @@ export default class AdminModule extends IConduitAdmin {
   }
 
   async initialize(server: GrpcServer) {
+    ConfigController.getInstance().config = await this.commons
+      .getConfigManager()
+      .get('admin');
     await server.addService(
       path.resolve(__dirname, '../../core/src/core.proto'),
       'conduit.core.Admin',
@@ -284,8 +288,7 @@ export default class AdminModule extends IConduitAdmin {
       .findOne({ username: 'admin' })
       .then(async existing => {
         if (isNil(existing)) {
-          const adminConfig = await this.commons.getConfigManager().get('admin');
-          const hashRounds = adminConfig.auth.hashRounds;
+          const hashRounds = ConfigController.getInstance().config.auth.hashRounds;
           return hashPassword('admin', hashRounds);
         }
         return Promise.resolve(null);

--- a/packages/admin/src/index.ts
+++ b/packages/admin/src/index.ts
@@ -312,7 +312,6 @@ export default class AdminModule extends IConduitAdmin {
       | ConduitMiddleware
       | ConduitSocket
     )[] = grpcToConduitRoute(
-      // can go
       'Admin',
       {
         protoFile: protofile,

--- a/packages/admin/src/middleware/Admin.middleware.ts
+++ b/packages/admin/src/middleware/Admin.middleware.ts
@@ -11,9 +11,11 @@ export function getAdminMiddleware(conduit: ConduitCommons) {
     res: Response,
     next: NextFunction,
   ) {
+    const graphQlCheck =
+      req.originalUrl.indexOf('/admin/graphql') === 0 && req.method === 'GET';
     if (
       // Excluded routes
-      req.originalUrl.indexOf('/admin/swagger') === 0 &&
+      (req.originalUrl.indexOf('/admin/swagger') === 0 || graphQlCheck) &&
       (await isDev(conduit))
     ) {
       return next();

--- a/packages/admin/src/middleware/Admin.middleware.ts
+++ b/packages/admin/src/middleware/Admin.middleware.ts
@@ -3,6 +3,7 @@ import { isNil } from 'lodash';
 import { ConduitCommons } from '@conduitplatform/commons';
 import { isDev } from '../utils/middleware';
 import { ConduitRequest } from '@conduitplatform/hermes';
+import ConduitGrpcSdk from '@conduitplatform/grpc-sdk';
 
 export function getAdminMiddleware(conduit: ConduitCommons) {
   return async function adminMiddleware(
@@ -19,7 +20,9 @@ export function getAdminMiddleware(conduit: ConduitCommons) {
     }
     const masterKey = req.headers.masterkey;
     if (!process.env.masterkey || process.env.masterkey.length === 0) {
-      console.warn('!Security issue!: Master key not set, defaulting to insecure string');
+      ConduitGrpcSdk.Logger.warn(
+        '!Security issue!: Master key not set, defaulting to insecure string',
+      );
     }
     const master = process.env.MASTER_KEY ?? process.env.masterkey ?? 'M4ST3RK3Y'; // Compat (<=0.12.2): masterkey
     if (isNil(masterKey) || masterKey !== master)

--- a/packages/admin/src/middleware/Auth.middleware.ts
+++ b/packages/admin/src/middleware/Auth.middleware.ts
@@ -13,11 +13,14 @@ export function getAuthMiddleware(grpcSdk: ConduitGrpcSdk, conduit: ConduitCommo
     res: Response,
     next: NextFunction,
   ) {
+    const graphQlCheck =
+      req.originalUrl.indexOf('/admin/graphql') === 0 && req.method === 'GET';
     if (
       // Excluded routes
       req.originalUrl.indexOf('/admin/login') === 0 ||
       req.originalUrl.indexOf('/admin/modules') === 0 ||
-      (req.originalUrl.indexOf('/admin/swagger') === 0 && (await isDev(conduit)))
+      ((req.originalUrl.indexOf('/admin/swagger') === 0 || graphQlCheck) &&
+        (await isDev(conduit)))
     ) {
       return next();
     }

--- a/packages/admin/src/middleware/Auth.middleware.ts
+++ b/packages/admin/src/middleware/Auth.middleware.ts
@@ -1,6 +1,6 @@
 import { NextFunction, Response } from 'express';
 import { isNil } from 'lodash';
-import ConduitGrpcSdk from '@conduitplatform/grpc-sdk';
+import ConduitGrpcSdk, { ConfigController } from '@conduitplatform/grpc-sdk';
 import { ConduitCommons } from '@conduitplatform/commons';
 import { Admin } from '../models';
 import { verifyToken } from '../utils/auth';
@@ -21,7 +21,7 @@ export function getAuthMiddleware(grpcSdk: ConduitGrpcSdk, conduit: ConduitCommo
     ) {
       return next();
     }
-    const adminConfig = await conduit.getConfigManager().get('admin');
+    const adminConfig = ConfigController.getInstance().config;
 
     const tokenHeader = req.headers.authorization;
     if (isNil(tokenHeader)) {

--- a/packages/admin/src/routes/CreateAdmin.route.ts
+++ b/packages/admin/src/routes/CreateAdmin.route.ts
@@ -5,6 +5,7 @@ import { hashPassword } from '../utils/auth';
 import {
   ConduitError,
   ConduitRouteActions,
+  ConfigController,
   ConduitRouteParameters,
   ConduitString,
 } from '@conduitplatform/grpc-sdk';
@@ -37,7 +38,7 @@ export function getCreateAdminRoute(conduit: ConduitCommons) {
       if (!isNil(admin)) {
         throw new ConduitError('INVALID_ARGUMENTS', 400, 'Already exists');
       }
-      const adminConfig = await conduit.getConfigManager().get('admin');
+      const adminConfig = ConfigController.getInstance().config;
       const hashRounds = adminConfig.auth.hashRounds;
       const pass = await hashPassword(password, hashRounds);
       await Admin.getInstance().create({ username: username, password: pass });

--- a/packages/admin/src/utils/middleware.ts
+++ b/packages/admin/src/utils/middleware.ts
@@ -1,6 +1,7 @@
 import { ConduitCommons } from '@conduitplatform/commons';
 
 export async function isDev(conduit: ConduitCommons) {
+  // TODO: Optimize me
   return conduit
     .getConfigManager()
     .get('core')

--- a/packages/admin/src/utils/middleware.ts
+++ b/packages/admin/src/utils/middleware.ts
@@ -1,12 +1,10 @@
 import { ConduitCommons } from '@conduitplatform/commons';
 
 export async function isDev(conduit: ConduitCommons) {
-  let isDev = false;
-  conduit
+  return conduit
     .getConfigManager()
     .get('core')
     .then(res => {
-      isDev = res.env === 'development';
+      return res.env === 'development';
     });
-  return isDev;
 }

--- a/packages/commons/src/modules/Admin/ConduitAdmin.ts
+++ b/packages/commons/src/modules/Admin/ConduitAdmin.ts
@@ -1,4 +1,4 @@
-import { GrpcServer } from '@conduitplatform/grpc-sdk';
+import { GrpcServer, ConfigController } from '@conduitplatform/grpc-sdk';
 import { ConduitCommons } from '../../index';
 import { ConduitRoute } from '@conduitplatform/hermes';
 
@@ -6,9 +6,13 @@ export abstract class IConduitAdmin {
   protected constructor(protected readonly commons: ConduitCommons) {}
 
   abstract initialize(server: GrpcServer): Promise<void>;
+  abstract subscribeToBusEvents(): Promise<void>;
   abstract registerRoute(route: ConduitRoute): void;
 
   setConfig(moduleConfig: any) {
+    ConfigController.getInstance().config = moduleConfig;
     this.commons.getBus().publish('config:update:admin', JSON.stringify(moduleConfig));
   }
+
+  protected abstract onConfig(): void;
 }

--- a/packages/commons/src/modules/Config/index.ts
+++ b/packages/commons/src/modules/Config/index.ts
@@ -10,4 +10,5 @@ export abstract class IConfigManager {
   abstract addFieldsToModule(moduleName: string, moduleConfig: any): Promise<any>;
   abstract getModuleUrlByName(moduleName: string): string | undefined;
   abstract isModuleUp(moduleName: string): Promise<boolean>;
+  abstract configurePackage(moduleName: string, config: any): Promise<any>;
 }

--- a/packages/commons/src/modules/Config/index.ts
+++ b/packages/commons/src/modules/Config/index.ts
@@ -9,4 +9,5 @@ export abstract class IConfigManager {
   abstract set(moduleName: string, moduleConfig: any): Promise<any>;
   abstract addFieldsToModule(moduleName: string, moduleConfig: any): Promise<any>;
   abstract getModuleUrlByName(moduleName: string): string | undefined;
+  abstract isModuleUp(moduleName: string): Promise<boolean>;
 }

--- a/packages/core/src/GrpcServer.ts
+++ b/packages/core/src/GrpcServer.ts
@@ -81,16 +81,10 @@ export class GrpcServer {
       await this.commons.getConfigManager().registerAppConfig();
     });
 
-    const config = await this.commons.getConfigManager().get('core');
-    if (!config) {
-      await this.commons
-        .getConfigManager()
-        .registerModulesConfig('core', convict.getProperties());
-    } else {
-      await this.commons
-        .getConfigManager()
-        .addFieldsToModule('core', convict.getProperties());
-    }
+    await this.commons
+      .getConfigManager()
+      .configurePackage('core', convict.getProperties());
+
     await this.commons.getAdmin().initialize(this.server);
     this.commons.getConfigManager().initConfigAdminRoutes();
 

--- a/packages/core/src/GrpcServer.ts
+++ b/packages/core/src/GrpcServer.ts
@@ -58,6 +58,7 @@ export class GrpcServer {
           await this.bootstrapSdkComponents();
           this.server.start();
           await this._grpcSdk.initializeEventBus();
+          await this.commons.getAdmin().subscribeToBusEvents();
           ConduitGrpcSdk.Logger.log(`gRPC server listening on: ${_url}`);
         });
       })

--- a/packages/core/src/GrpcServer.ts
+++ b/packages/core/src/GrpcServer.ts
@@ -76,16 +76,13 @@ export class GrpcServer {
     this._grpcSdk.on('router', () => {
       Core.getInstance().httpServer.initialize(this.grpcSdk, this.server);
     });
+
     this._grpcSdk.on('database', async () => {
       await this.commons.getConfigManager().registerAppConfig();
     });
 
-    let error;
-    await this.commons
-      .getConfigManager()
-      .get('core')
-      .catch((err: Error) => (error = err));
-    if (error) {
+    const config = await this.commons.getConfigManager().get('core');
+    if (!config) {
       await this.commons
         .getConfigManager()
         .registerModulesConfig('core', convict.getProperties());

--- a/packages/core/src/GrpcServer.ts
+++ b/packages/core/src/GrpcServer.ts
@@ -57,6 +57,7 @@ export class GrpcServer {
           await this.commons.getConfigManager().initialize(this.server);
           await this.bootstrapSdkComponents();
           this.server.start();
+          await this._grpcSdk.initializeEventBus();
           ConduitGrpcSdk.Logger.log(`gRPC server listening on: ${_url}`);
         });
       })

--- a/packages/core/src/config-manager/admin/routes/GetConfig.route.ts
+++ b/packages/core/src/config-manager/admin/routes/GetConfig.route.ts
@@ -32,7 +32,7 @@ export function getGetConfigRoute(
         if (!registeredModules.has(module))
           throw new ConduitError('NOT_FOUND', 404, 'Resource not found');
       }
-      finalConfig = grpcSdk.state!.getKey(`moduleConfigs.${module}`);
+      finalConfig = await grpcSdk.state!.getKey(`moduleConfigs.${module}`);
       if (!finalConfig) {
         finalConfig = {};
       } else {

--- a/packages/core/src/config-manager/admin/routes/UpdateConfig.route.ts
+++ b/packages/core/src/config-manager/admin/routes/UpdateConfig.route.ts
@@ -6,8 +6,6 @@ import ConduitGrpcSdk, {
   RouteOptionType,
   TYPE,
 } from '@conduitplatform/grpc-sdk';
-import { cond, isNil } from 'lodash';
-import * as models from '../../models';
 import { ConduitRoute, ConduitRouteReturnDefinition } from '@conduitplatform/hermes';
 
 export function getUpdateConfigRoute(
@@ -38,12 +36,6 @@ export function getUpdateConfigRoute(
         throw new ConduitError('NOT_IMPLEMENTED', 501, 'Modules cannot be deactivated');
       }
       switch (moduleName) {
-        case 'email':
-          if (!registeredModules.has(moduleName) || isNil(grpcSdk.emailProvider))
-            throw new ConduitError('INVALID_PARAMS', 400, 'Module not available');
-          updatedConfig = await grpcSdk.emailProvider.setConfig(newConfig);
-          await conduit.getConfigManager().set(moduleName, updatedConfig);
-          break;
         case 'core':
           updatedConfig = await conduit.getConfigManager().set('core', newConfig);
           break;
@@ -53,7 +45,15 @@ export function getUpdateConfigRoute(
         default:
           if (!registeredModules.has(moduleName) || !grpcSdk.isAvailable(moduleName))
             throw new ConduitError('INVALID_PARAMS', 400, 'Module not available');
-          updatedConfig = await grpcSdk.getModule<any>(moduleName)!.setConfig(newConfig);
+          updatedConfig = JSON.parse(
+            // @ts-ignore
+            (
+              await grpcSdk
+                .getModule<any>(moduleName)!
+                // @ts-ignore
+                .setConfig({ newConfig: JSON.stringify(newConfig) })
+            ).updatedConfig,
+          );
           await conduit.getConfigManager().set(moduleName, updatedConfig);
       }
       return { result: { config: updatedConfig } };

--- a/packages/core/src/config-manager/admin/routes/UpdateConfig.route.ts
+++ b/packages/core/src/config-manager/admin/routes/UpdateConfig.route.ts
@@ -42,7 +42,7 @@ export function getUpdateConfigRoute(
           if (!registeredModules.has(moduleName) || isNil(grpcSdk.emailProvider))
             throw new ConduitError('INVALID_PARAMS', 400, 'Module not available');
           updatedConfig = await grpcSdk.emailProvider.setConfig(newConfig);
-          await conduit.getConfigManager().set(moduleName, JSON.parse(updatedConfig));
+          await conduit.getConfigManager().set(moduleName, updatedConfig);
           break;
         case 'core':
           updatedConfig = await conduit.getConfigManager().set('core', newConfig);
@@ -54,7 +54,7 @@ export function getUpdateConfigRoute(
           if (!registeredModules.has(moduleName) || !grpcSdk.isAvailable(moduleName))
             throw new ConduitError('INVALID_PARAMS', 400, 'Module not available');
           updatedConfig = await grpcSdk.getModule<any>(moduleName)!.setConfig(newConfig);
-          await conduit.getConfigManager().set(moduleName, JSON.parse(updatedConfig));
+          await conduit.getConfigManager().set(moduleName, updatedConfig);
       }
       return { result: { config: updatedConfig } };
     },

--- a/packages/core/src/config-manager/config-storage/index.ts
+++ b/packages/core/src/config-manager/config-storage/index.ts
@@ -20,13 +20,13 @@ export class ConfigStorage {
   onDatabaseAvailable() {
     this.firstSync()
       .then(() => {
-        console.log('Reconciliation with db successful');
+        ConduitGrpcSdk.Logger.log('Reconciliation with db successful');
         this.changeState(false);
         this.reconcileMonitor();
       })
       .catch(err => {
         this.changeState(false);
-        console.error('Reconciliation with db failed!');
+        ConduitGrpcSdk.Logger.error('Reconciliation with db failed!');
       });
   }
 
@@ -112,13 +112,13 @@ export class ConfigStorage {
     });
     Promise.all(promises)
       .then(() => {
-        console.log('Module configurations reconciled!');
+        ConduitGrpcSdk.Logger.log('Module configurations reconciled!');
         this.toBeReconciled = [];
         this.changeState(false);
       })
       .catch(e => {
-        console.error('Module configurations failed to reconcile!');
-        console.error(e);
+        ConduitGrpcSdk.Logger.error('Module configurations failed to reconcile!');
+        ConduitGrpcSdk.Logger.error(e);
         this.changeState(false);
       });
   }

--- a/packages/core/src/config-manager/index.ts
+++ b/packages/core/src/config-manager/index.ts
@@ -225,6 +225,14 @@ export default class ConfigManager implements IConfigManager {
     return callback(null, { result: JSON.stringify(config) });
   }
 
+  async configurePackage(moduleName: string, config: any) {
+    const existingConfig = await this.get(moduleName);
+    if (!existingConfig) {
+      await this.set(moduleName, config);
+    }
+    return await this.addFieldsToModule(moduleName, config);
+  }
+
   async addFieldsToModule(moduleName: string, moduleConfig: any) {
     let existingConfig = this._configStorage.getConfig(moduleName);
     existingConfig = { ...moduleConfig, ...existingConfig };

--- a/packages/core/src/config-manager/index.ts
+++ b/packages/core/src/config-manager/index.ts
@@ -5,7 +5,6 @@ import ConduitGrpcSdk, {
   GrpcResponse,
   GrpcServer,
 } from '@conduitplatform/grpc-sdk';
-import { isNil } from 'lodash';
 import {
   ConduitCommons,
   GetConfigResponse,

--- a/packages/core/src/config-manager/index.ts
+++ b/packages/core/src/config-manager/index.ts
@@ -96,7 +96,7 @@ export default class ConfigManager implements IConfigManager {
         return Promise.resolve();
       }
     } catch {
-      console.error('Failed to recover state');
+      ConduitGrpcSdk.Logger.error('Failed to recover state');
     }
   }
 
@@ -105,10 +105,10 @@ export default class ConfigManager implements IConfigManager {
       .getState()
       .setKey('config', JSON.stringify(state))
       .then(() => {
-        console.log('Updated state');
+        ConduitGrpcSdk.Logger.log('Updated state');
       })
       .catch(() => {
-        console.error('Failed to recover state');
+        ConduitGrpcSdk.Logger.error('Failed to recover state');
       });
   }
 
@@ -185,7 +185,7 @@ export default class ConfigManager implements IConfigManager {
       }
       return moduleConfig;
     } catch (e) {
-      console.error(`Could not update "${moduleName}" configuration`);
+      ConduitGrpcSdk.Logger.error(`Could not update "${moduleName}" configuration`);
     }
   }
 

--- a/packages/core/src/config-manager/index.ts
+++ b/packages/core/src/config-manager/index.ts
@@ -245,7 +245,7 @@ export default class ConfigManager implements IConfigManager {
     try {
       await this.grpcSdk.isModuleUp(
         moduleName,
-        this.serviceDiscovery.registeredModules.get(moduleName)!.address[0],
+        this.serviceDiscovery.registeredModules.get(moduleName)!.address,
       );
     } catch (e) {
       return false;

--- a/packages/core/src/config-manager/index.ts
+++ b/packages/core/src/config-manager/index.ts
@@ -153,16 +153,15 @@ export default class ConfigManager implements IConfigManager {
   }
 
   getGrpc(call: GrpcRequest<{ key: string }>, callback: GrpcResponse<{ data: string }>) {
-    this.get(call.request.key)
-      .then(r => {
-        callback(null, { data: JSON.stringify(r) });
-      })
-      .catch(err => {
-        callback({
+    this.get(call.request.key).then(r => {
+      if (!r) {
+        return callback({
           code: status.INTERNAL,
-          message: err.message ? err.message : err,
+          message: 'Config for module not set!',
         });
-      });
+      }
+      callback(null, { data: JSON.stringify(r) });
+    });
   }
 
   async get(moduleName: string) {

--- a/packages/core/src/config-manager/service-discovery/index.ts
+++ b/packages/core/src/config-manager/service-discovery/index.ts
@@ -302,10 +302,10 @@ export class ServiceDiscovery {
         return this.sdk.getState().setKey('config', JSON.stringify(state));
       })
       .then(() => {
-        console.log('Updated state');
+        ConduitGrpcSdk.Logger.log('Updated state');
       })
       .catch(() => {
-        console.error('Failed to recover state');
+        ConduitGrpcSdk.Logger.error('Failed to recover state');
       });
   }
 }

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -1,29 +1,7 @@
 export default {
   env: {
-    format: String,
+    format: 'String',
     default: 'development',
     enum: ['production', 'development', 'test'],
-  },
-  hostUrl: {
-    type: String,
-    default: 'http://localhost:3000',
-  },
-  transports: {
-    rest: {
-      enabled: {
-        type: Boolean,
-        default: true,
-      },
-    },
-    graphql: {
-      enabled: {
-        type: Boolean,
-        default: true,
-      },
-    },
-  },
-  port: {
-    type: Number,
-    default: 8080,
   },
 };


### PR DESCRIPTION
This PR is meant to further test and bugfix #212.

Note: `Database` awaits `Router` before registering its `Admin` routes.
We still need to decouple router/admin logic from `SchemaController` and `CustomEndpointController`.

Here's a list of known issues we need to fix or explore further:

- [X] Security Client schema ownership migration
- [X] Express request conduit object not set
- [X] Modules no longer awaiting Database
- [X] Security Client admin route changes from `main` not included properly
- [x] Scrap unused Router port config option
- [x] Unnest Router config boolean option: security.clientValidation.enabled
- [x] Make Admin REST optional? As long as GraphQL is enabled
- [x] Add Admin transports config options
- [x] Migrate leftover console logs/warns to ConduitLogger (maybe split this one off)
- [x] Fix Admin sdk routes getting dumped
- [x] Fix Forms not properly waiting for Email
- [x] Fix Admin Swagger route middleware check (lacking unoptimization)
- [x] Fix Admin GraphQL
- [x] Fix sdk routes not getting reregistered post Core restart
- [x] Fix GraphQL JSON parsing
- [x] Fix module set config

I'm going to update this list as we move forward.

Furthermore, admin routes are still somewhat coupled to Router, meaning they won't actually initially register without it, even though they can technically work with it going offline.
Lets resolve this in a separate PR.

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** <!--(check at least one)-->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other (please describe)

**Does this PR introduce a breaking change?** <!-- (check one) -->

- [ ] Yes
- [X] No
