### PR TITLE
fix(grpc-sdk,commons,core,admin): config validation

### DIFF
--- a/libraries/grpc-sdk/src/classes/ManagedModule.ts
+++ b/libraries/grpc-sdk/src/classes/ManagedModule.ts
@@ -108,13 +108,17 @@ export abstract class ManagedModule<T> extends ConduitServiceModule {
         });
       }
       let config = JSON.parse(call.request.newConfig);
+      config = { ...this.config.getProperties(), ...config };
       config = await this.preConfig(config);
+      const previousConfig = this.config.getProperties();
       try {
         this.config.load(config).validate();
+        config = this.config.getProperties();
       } catch (e) {
+        this.config.load(previousConfig);
         return callback({
           code: status.INVALID_ARGUMENT,
-          message: 'Invalid configuration values',
+          message: 'Invalid configuration values: ' + e.message,
         });
       }
       ConfigController.getInstance().config = config;

--- a/libraries/grpc-sdk/src/index.ts
+++ b/libraries/grpc-sdk/src/index.ts
@@ -296,14 +296,15 @@ export default class ConduitGrpcSdk {
     });
   }
 
-  async monitorModule(
+  monitorModule(
     moduleName: string,
     callback: (serving: boolean) => void,
     wait: boolean = true,
   ) {
-    if (wait) await this.waitForExistence(moduleName);
-    this._modules['chat']?.healthClient
-      ?.check({})
+    let waitPromise = Promise.resolve();
+    if (wait) waitPromise.then(() => this.waitForExistence(moduleName));
+    waitPromise
+      .then(() => this._modules['chat']?.healthClient?.check({}))
       .then(res => {
         callback(res?.status === HealthCheckResponse_ServingStatus.SERVING);
       })

--- a/libraries/grpc-sdk/src/index.ts
+++ b/libraries/grpc-sdk/src/index.ts
@@ -301,7 +301,7 @@ export default class ConduitGrpcSdk {
     callback: (serving: boolean) => void,
     wait: boolean = true,
   ) {
-    let waitPromise = Promise.resolve();
+    const waitPromise = Promise.resolve();
     if (wait) waitPromise.then(() => this.waitForExistence(moduleName));
     waitPromise
       .then(() => this._modules['chat']?.healthClient?.check({}))

--- a/modules/authentication/src/Authentication.ts
+++ b/modules/authentication/src/Authentication.ts
@@ -88,7 +88,7 @@ export default class Authentication extends ManagedModule<Config> {
       let refreshedOnce = false;
       await this.registerSchemas();
       if (config.local.verification.send_email) {
-        await this.grpcSdk.monitorModule('email', serving => {
+        this.grpcSdk.monitorModule('email', serving => {
           this.sendEmail = serving;
           this.refreshAppRoutes();
           refreshedOnce = true;

--- a/packages/commons/src/modules/Admin/ConduitAdmin.ts
+++ b/packages/commons/src/modules/Admin/ConduitAdmin.ts
@@ -1,6 +1,6 @@
-import { GrpcServer, ConfigController } from '@conduitplatform/grpc-sdk';
-import { ConduitCommons } from '../../index';
+import { GrpcServer } from '@conduitplatform/grpc-sdk';
 import { ConduitRoute } from '@conduitplatform/hermes';
+import { ConduitCommons } from '../../index';
 
 export abstract class IConduitAdmin {
   protected constructor(protected readonly commons: ConduitCommons) {}
@@ -8,11 +8,7 @@ export abstract class IConduitAdmin {
   abstract initialize(server: GrpcServer): Promise<void>;
   abstract subscribeToBusEvents(): Promise<void>;
   abstract registerRoute(route: ConduitRoute): void;
-
-  setConfig(moduleConfig: any) {
-    ConfigController.getInstance().config = moduleConfig;
-    this.commons.getBus().publish('config:update:admin', JSON.stringify(moduleConfig));
-  }
+  abstract setConfig(moduleConfig: any): Promise<any>;
 
   protected abstract onConfig(): void;
 }

--- a/packages/commons/src/modules/Core/index.ts
+++ b/packages/commons/src/modules/Core/index.ts
@@ -3,7 +3,5 @@ import { ConduitCommons } from '../..';
 export abstract class IConduitCore {
   protected constructor(protected readonly commons: ConduitCommons) {}
 
-  setConfig(moduleConfig: any) {
-    this.commons.getBus().publish('config:update:core', JSON.stringify(moduleConfig));
-  }
+  abstract setConfig(moduleConfig: any): Promise<any>;
 }

--- a/packages/core/src/config-manager/admin/routes/UpdateConfig.route.ts
+++ b/packages/core/src/config-manager/admin/routes/UpdateConfig.route.ts
@@ -37,10 +37,20 @@ export function getUpdateConfigRoute(
       }
       switch (moduleName) {
         case 'core':
-          updatedConfig = await conduit.getConfigManager().set('core', newConfig);
+          updatedConfig = await conduit
+            .getCore()
+            .setConfig(newConfig)
+            .catch(e => {
+              throw new ConduitError(e.name, e.status, e.message);
+            });
           break;
         case 'admin':
-          updatedConfig = await conduit.getConfigManager().set('admin', newConfig);
+          updatedConfig = await conduit
+            .getAdmin()
+            .setConfig(newConfig)
+            .catch(e => {
+              throw new ConduitError(e.name, e.status, e.message);
+            });
           break;
         default:
           if (!registeredModules.has(moduleName) || !grpcSdk.isAvailable(moduleName))
@@ -54,8 +64,10 @@ export function getUpdateConfigRoute(
                 .setConfig({ newConfig: JSON.stringify(newConfig) })
             ).updatedConfig,
           );
-          await conduit.getConfigManager().set(moduleName, updatedConfig);
+          // await conduit.getConfigManager().set(moduleName, updatedConfig);
+          break;
       }
+      await conduit.getConfigManager().set(moduleName, updatedConfig);
       return { result: { config: updatedConfig } };
     },
   );

--- a/packages/core/src/config-manager/index.ts
+++ b/packages/core/src/config-manager/index.ts
@@ -122,7 +122,7 @@ export default class ConfigManager implements IConfigManager {
           }),
         });
       })
-      .catch(e => {
+      .catch(() => {
         return callback({
           code: status.NOT_FOUND,
           message: 'Server config not found!',
@@ -173,15 +173,13 @@ export default class ConfigManager implements IConfigManager {
 
   async set(moduleName: string, moduleConfig: any) {
     try {
-      await this._configStorage.setConfig(moduleName, JSON.stringify(moduleConfig));
       switch (moduleName) {
         case 'core':
-          this.sdk.getCore().setConfig(moduleConfig);
-          break;
         case 'admin':
-          this.sdk.getAdmin().setConfig(moduleConfig);
+          await this._configStorage.setConfig(moduleName, JSON.stringify(moduleConfig));
           break;
         default:
+          await this._configStorage.setConfig(moduleName, JSON.stringify(moduleConfig));
           break;
       }
       return moduleConfig;

--- a/packages/core/src/config-manager/index.ts
+++ b/packages/core/src/config-manager/index.ts
@@ -192,7 +192,7 @@ export default class ConfigManager implements IConfigManager {
     call: GrpcRequest<UpdateRequest>,
     callback: GrpcCallback<UpdateResponse>,
   ) {
-    const moduleName = call.request.moduleName;
+    const moduleName = call.metadata!.get('module-name')![0] as string;
     const moduleConfig = JSON.parse(call.request.config);
     try {
       await this.set(moduleName, moduleConfig);
@@ -214,12 +214,13 @@ export default class ConfigManager implements IConfigManager {
     call: GrpcRequest<UpdateRequest>,
     callback: GrpcCallback<UpdateResponse>,
   ) {
+    const moduleName = call.metadata!.get('module-name')![0] as string;
     let config = JSON.parse(call.request.config);
-    const existingConfig = await this.get(call.request.moduleName);
+    const existingConfig = await this.get(moduleName);
     if (!existingConfig) {
-      await this.set(call.request.moduleName, config);
+      await this.set(moduleName, config);
     }
-    config = await this.addFieldsToModule(call.request.moduleName, config);
+    config = await this.addFieldsToModule(moduleName, config);
     return callback(null, { result: JSON.stringify(config) });
   }
 
@@ -255,8 +256,9 @@ export default class ConfigManager implements IConfigManager {
     call: GrpcRequest<UpdateRequest>,
     callback: GrpcCallback<UpdateResponse>,
   ) {
+    const moduleName = call.metadata!.get('module-name')![0] as string;
     const newFields = JSON.parse(call.request.config);
-    this.addFieldsToModule(call.request.moduleName, newFields)
+    this.addFieldsToModule(moduleName, newFields)
       .then(r => {
         return callback(null, { result: JSON.stringify(r) });
       })

--- a/packages/core/src/config/index.ts
+++ b/packages/core/src/config/index.ts
@@ -1,5 +1,7 @@
 import convict from 'convict';
-
 import AppConfigSchema from './config';
 
+const config = convict(AppConfigSchema);
+const configProperties = config.getProperties();
+export type Config = typeof configProperties;
 export default convict(AppConfigSchema);

--- a/packages/core/src/core.proto
+++ b/packages/core/src/core.proto
@@ -22,7 +22,6 @@ service Admin {
   rpc RegisterAdminRoute (RegisterAdminRouteRequest) returns (Empty);
 }
 
-
 message RegisterAdminRouteRequest {
   repeated PathDefinition routes = 1;
   string protoFile = 2;
@@ -110,15 +109,15 @@ message GetRedisDetailsResponse {
 message GetConfigResponse {
   string data = 1;
 }
+
 message UpdateRequest {
   string config = 1;
-  string moduleName = 2;
 }
+
 message UpdateResponse {
   string result = 1;
 }
 
 message RegisterModulesConfigRequest {
-  string moduleName = 1;
-  string newModulesConfigSchema = 2;
+  string newModulesConfigSchema = 1;
 }


### PR DESCRIPTION
This PR addresses the following issues:

- [X] Convict validation being broken for `Core` and `Admin` update config requests
- [X] Config's `updateConfig()`, `addFieldsToConfig()` and `configureModule()` calls accepting `moduleName` as an explicit gRPC param

**What kind of change does this PR introduce?** <!--(check at least one)-->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other (please describe)

**Does this PR introduce a breaking change?** <!-- (check one) -->

- [X] Yes
- [ ] No

<!-- If yes, please describe the impact and migration path for existing applications. -->

Config's `updateConfig()`, `addFieldsToConfig()` and `configureModule()` no longer accept an explicit gRPC param. The module name is instead received from the gRPC call's metadata. Meaning only the target module itself can update its configuration going forward.

**The PR fulfills these requirements:**

- [X] It's submitted to the `main` branch
- [ ] When resolving a specific issue, it's referenced in the PR's description  (e.g. `fix #xxx`, where "xxx" is the issue number)
