### PR TITLE
Schema collection names renaming (on new deployments)

### DIFF
--- a/modules/database/src/adapters/DatabaseAdapter.ts
+++ b/modules/database/src/adapters/DatabaseAdapter.ts
@@ -55,10 +55,7 @@ export abstract class DatabaseAdapter<T extends Schema> {
     if (imported) {
       this.foreignSchemaCollections.delete(schema.collectionName);
     } else {
-      let collectionName =
-        schema.collectionName !== ''
-          ? schema.collectionName
-          : this.getCollectionName(schema);
+      let collectionName = this.getCollectionName(schema);
       if (cndPrefix && !this.models['_DeclaredSchema']) {
         collectionName = collectionName.startsWith('_')
           ? `cnd${collectionName}`
@@ -71,6 +68,9 @@ export abstract class DatabaseAdapter<T extends Schema> {
           collectionName = collectionName.startsWith('_')
             ? `cnd${collectionName}`
             : `cnd_${collectionName}`;
+        } else {
+          //recover collection name from DeclaredSchema
+          collectionName = declaredSchema.collectionName;
         }
       }
       (schema as any).collectionName = collectionName;

--- a/modules/database/src/adapters/DatabaseAdapter.ts
+++ b/modules/database/src/adapters/DatabaseAdapter.ts
@@ -54,9 +54,11 @@ export abstract class DatabaseAdapter<T extends Schema> {
     }
     if (imported) {
       this.foreignSchemaCollections.delete(schema.collectionName);
-      schema as any;
     } else {
-      let collectionName = this.getCollectionName(schema);
+      let collectionName =
+        schema.collectionName !== ''
+          ? schema.collectionName
+          : this.getCollectionName(schema);
       if (cndPrefix && !this.models['_DeclaredSchema']) {
         collectionName = collectionName.startsWith('_')
           ? `cnd${collectionName}`
@@ -78,7 +80,7 @@ export abstract class DatabaseAdapter<T extends Schema> {
 
   protected abstract _createSchemaFromAdapter(schema: ConduitSchema): Promise<Schema>;
 
-  protected abstract getCollectionName(schema: ConduitSchema): string;
+  abstract getCollectionName(schema: ConduitSchema): string;
 
   async createCustomSchemaFromAdapter(schema: ConduitSchema) {
     schema.ownerModule = 'database';

--- a/modules/database/src/adapters/DatabaseAdapter.ts
+++ b/modules/database/src/adapters/DatabaseAdapter.ts
@@ -8,6 +8,8 @@ import { ConduitDatabaseSchema } from '../interfaces/ConduitDatabaseSchema';
 type _ConduitSchema = Omit<ConduitSchema, 'schemaOptions'> & {
   modelOptions: ConduitModelOptions;
   extensions: DeclaredSchemaExtension[];
+} & {
+  -readonly [k in keyof ConduitSchema]: ConduitSchema[k];
 };
 export abstract class DatabaseAdapter<T extends Schema> {
   protected readonly maxConnTimeoutMs: number;
@@ -73,7 +75,7 @@ export abstract class DatabaseAdapter<T extends Schema> {
           collectionName = declaredSchema.collectionName;
         }
       }
-      (schema as any).collectionName = collectionName;
+      (schema as _ConduitSchema).collectionName = collectionName;
     }
     return this._createSchemaFromAdapter(schema);
   }

--- a/modules/database/src/adapters/DatabaseAdapter.ts
+++ b/modules/database/src/adapters/DatabaseAdapter.ts
@@ -54,23 +54,25 @@ export abstract class DatabaseAdapter<T extends Schema> {
     }
     if (imported) {
       this.foreignSchemaCollections.delete(schema.collectionName);
-    }
-    let collectionName = this.getCollectionName(schema);
-    if (cndPrefix && !this.models['_DeclaredSchema']) {
-      collectionName = collectionName.startsWith('_')
-        ? `cnd${collectionName}`
-        : `cnd_${collectionName}`;
-    } else if (cndPrefix) {
-      const declaredSchema = await this.models['_DeclaredSchema'].findOne({
-        name: schema.name,
-      });
-      if (!declaredSchema) {
+      schema as any;
+    } else {
+      let collectionName = this.getCollectionName(schema);
+      if (cndPrefix && !this.models['_DeclaredSchema']) {
         collectionName = collectionName.startsWith('_')
           ? `cnd${collectionName}`
           : `cnd_${collectionName}`;
+      } else if (cndPrefix) {
+        const declaredSchema = await this.models['_DeclaredSchema'].findOne({
+          name: schema.name,
+        });
+        if (!declaredSchema) {
+          collectionName = collectionName.startsWith('_')
+            ? `cnd${collectionName}`
+            : `cnd_${collectionName}`;
+        }
       }
+      (schema as any).collectionName = collectionName;
     }
-    (schema as any).collectionName = collectionName;
     return this._createSchemaFromAdapter(schema);
   }
 

--- a/modules/database/src/adapters/mongoose-adapter/index.ts
+++ b/modules/database/src/adapters/mongoose-adapter/index.ts
@@ -93,19 +93,19 @@ export class MongooseAdapter extends DatabaseAdapter<MongooseSchema> {
     (await this.mongoose.connection.db.listCollections().toArray()).forEach(c =>
       collectionNames.push(c.name),
     );
-    const declaredSchemaCollectionName = this.models['_DeclaredSchema'].originalSchema
-      .collectionName;
+    const declaredSchemaCollectionName =
+      this.models['_DeclaredSchema'].originalSchema.collectionName;
     for (const collection of collectionNames) {
       if (collection === declaredSchemaCollectionName) continue;
-      const collectionInDeclaredSchemas = ((declaredSchemas as unknown) as ConduitSchema[]).some(
-        (declaredSchema: ConduitSchema) => {
-          if (declaredSchema.collectionName && declaredSchema.collectionName !== '') {
-            return declaredSchema.collectionName === collection;
-          } else {
-            return pluralize(declaredSchema.name) === collection;
-          }
-        },
-      );
+      const collectionInDeclaredSchemas = (
+        declaredSchemas as unknown as ConduitSchema[]
+      ).some((declaredSchema: ConduitSchema) => {
+        if (declaredSchema.collectionName && declaredSchema.collectionName !== '') {
+          return declaredSchema.collectionName === collection;
+        } else {
+          return pluralize(declaredSchema.name) === collection;
+        }
+      });
       if (!collectionInDeclaredSchemas) {
         this.foreignSchemaCollections.add(collection);
       }
@@ -153,14 +153,14 @@ export class MongooseAdapter extends DatabaseAdapter<MongooseSchema> {
       {},
     );
     // Wipe Pending Schemas
-    const pendingSchemaCollectionName = this.models['_PendingSchemas'].originalSchema
-      .collectionName;
+    const pendingSchemaCollectionName =
+      this.models['_PendingSchemas'].originalSchema.collectionName;
     await db.collection(pendingSchemaCollectionName).deleteMany({});
     // Update Collection Names and Find Introspectable Schemas
     const importedSchemas: string[] = [];
-    ((declaredSchemas as unknown) as ConduitSchema[]).forEach((schema: ConduitSchema) => {
+    (declaredSchemas as unknown as ConduitSchema[]).forEach((schema: ConduitSchema) => {
       this.updateCollectionName(schema);
-      if (((schema as unknown) as _ConduitSchema).modelOptions.conduit!.imported) {
+      if ((schema as unknown as _ConduitSchema).modelOptions.conduit!.imported) {
         importedSchemas.push(schema.collectionName);
       }
     });
@@ -248,6 +248,15 @@ export class MongooseAdapter extends DatabaseAdapter<MongooseSchema> {
       return { model: this.models[schemaName], relations: null };
     }
     throw new GrpcError(status.NOT_FOUND, `Schema ${schemaName} not defined yet`);
+  }
+
+  async checkDeclaredSchemaExistance() {
+    const collections = await this.mongoose.connection.db.listCollections().toArray();
+    const declaredSchema = collections.find(c => c.name === '_declaredschemas');
+    if (declaredSchema) {
+      return true;
+    }
+    return false;
   }
 
   async deleteSchema(

--- a/modules/database/src/adapters/mongoose-adapter/index.ts
+++ b/modules/database/src/adapters/mongoose-adapter/index.ts
@@ -243,12 +243,9 @@ export class MongooseAdapter extends DatabaseAdapter<MongooseSchema> {
   }
 
   async checkDeclaredSchemaExistance() {
-    const collections = await this.mongoose.connection.db.listCollections().toArray();
-    const declaredSchema = collections.find(c => c.name === '_declaredschemas');
-    if (declaredSchema) {
-      return true;
-    }
-    return false;
+    return !!(await this.mongoose.connection.db.listCollections().toArray()).find(
+      c => c.name === '_declaredschemas',
+    );
   }
 
   async deleteSchema(

--- a/modules/database/src/adapters/mongoose-adapter/index.ts
+++ b/modules/database/src/adapters/mongoose-adapter/index.ts
@@ -159,7 +159,6 @@ export class MongooseAdapter extends DatabaseAdapter<MongooseSchema> {
     // Update Collection Names and Find Introspectable Schemas
     const importedSchemas: string[] = [];
     (declaredSchemas as unknown as ConduitSchema[]).forEach((schema: ConduitSchema) => {
-      this.updateCollectionName(schema);
       if ((schema as unknown as _ConduitSchema).modelOptions.conduit!.imported) {
         importedSchemas.push(schema.collectionName);
       }
@@ -193,17 +192,12 @@ export class MongooseAdapter extends DatabaseAdapter<MongooseSchema> {
     return introspectedSchemas;
   }
 
-  protected updateCollectionName(schema: ConduitSchema, setPrefix = false) {
+  protected getCollectionName(schema: ConduitSchema) {
     let collectionName =
       schema.collectionName && schema.collectionName !== ''
         ? schema.collectionName
         : pluralize(schema.name);
-    if (setPrefix && this.foreignSchemaCollections.has(collectionName)) {
-      collectionName = collectionName.startsWith('_')
-        ? `cnd${collectionName}`
-        : `cnd_${collectionName}`;
-    }
-    (schema as any).collectionName = collectionName;
+    return collectionName;
   }
 
   protected async _createSchemaFromAdapter(

--- a/modules/database/src/adapters/mongoose-adapter/index.ts
+++ b/modules/database/src/adapters/mongoose-adapter/index.ts
@@ -192,7 +192,7 @@ export class MongooseAdapter extends DatabaseAdapter<MongooseSchema> {
     return introspectedSchemas;
   }
 
-  protected getCollectionName(schema: ConduitSchema) {
+  getCollectionName(schema: ConduitSchema) {
     let collectionName =
       schema.collectionName && schema.collectionName !== ''
         ? schema.collectionName

--- a/modules/database/src/adapters/mongoose-adapter/index.ts
+++ b/modules/database/src/adapters/mongoose-adapter/index.ts
@@ -193,11 +193,9 @@ export class MongooseAdapter extends DatabaseAdapter<MongooseSchema> {
   }
 
   getCollectionName(schema: ConduitSchema) {
-    let collectionName =
-      schema.collectionName && schema.collectionName !== ''
-        ? schema.collectionName
-        : pluralize(schema.name);
-    return collectionName;
+    return schema.collectionName && schema.collectionName !== ''
+      ? schema.collectionName
+      : pluralize(schema.name);
   }
 
   protected async _createSchemaFromAdapter(

--- a/modules/database/src/adapters/sequelize-adapter/SequelizeSchema.ts
+++ b/modules/database/src/adapters/sequelize-adapter/SequelizeSchema.ts
@@ -83,7 +83,7 @@ export class SequelizeSchema implements SchemaAdapter<ModelCtor<any>> {
       };
     }
 
-    this.model = sequelize.define(schema.name, schema.modelSchema, {
+    this.model = sequelize.define(schema.collectionName, schema.modelSchema, {
       ...schema.modelOptions,
       freezeTableName: true,
     });
@@ -136,9 +136,9 @@ export class SequelizeSchema implements SchemaAdapter<ModelCtor<any>> {
       parsedQuery = query;
     }
     const options: FindOptions = { where: parseQuery(parsedQuery), raw: true };
-    options.attributes = ({
+    options.attributes = {
       exclude: [...this.excludedFields],
-    } as unknown) as FindAttributeOptions;
+    } as unknown as FindAttributeOptions;
     if (!isNil(select) && select !== '') {
       options.attributes = this.parseSelect(select);
     }
@@ -176,9 +176,9 @@ export class SequelizeSchema implements SchemaAdapter<ModelCtor<any>> {
       parsedQuery = query;
     }
     const options: FindOptions = { where: parseQuery(parsedQuery), raw: true };
-    options.attributes = ({
+    options.attributes = {
       exclude: [...this.excludedFields],
-    } as unknown) as FindAttributeOptions;
+    } as unknown as FindAttributeOptions;
     if (!isNil(skip)) {
       options.offset = skip;
     }

--- a/modules/database/src/adapters/sequelize-adapter/index.ts
+++ b/modules/database/src/adapters/sequelize-adapter/index.ts
@@ -81,7 +81,6 @@ export class SequelizeAdapter extends DatabaseAdapter<SequelizeSchema> {
     // Update Collection Names and Find Introspectable Schemas
     const importedSchemas: string[] = [];
     declaredSchemas.forEach((schema: ConduitSchema) => {
-      this.updateCollectionName(schema);
       if ((schema as Indexable).modelOptions.conduit.imported) {
         importedSchemas.push(schema.collectionName);
       }
@@ -159,18 +158,12 @@ export class SequelizeAdapter extends DatabaseAdapter<SequelizeSchema> {
     return schema;
   }
 
-  protected updateCollectionName(schema: ConduitSchema, setPrefix = false) {
+  protected getCollectionName(schema: ConduitSchema, setPrefix = false) {
     let collectionName =
       schema.collectionName && schema.collectionName !== ''
         ? schema.collectionName
         : schema.name;
-    if (setPrefix && this.foreignSchemaCollections.has(collectionName)) {
-      collectionName = collectionName.startsWith('_')
-        ? `cnd${collectionName}`
-        : `cnd_${collectionName}`;
-    }
-    (schema as any).collectionName = collectionName;
-    (schema as any).name = collectionName;
+    return collectionName;
   }
 
   protected async _createSchemaFromAdapter(

--- a/modules/database/src/adapters/sequelize-adapter/index.ts
+++ b/modules/database/src/adapters/sequelize-adapter/index.ts
@@ -206,7 +206,7 @@ export class SequelizeAdapter extends DatabaseAdapter<SequelizeSchema> {
   }
 
   async checkDeclaredSchemaExistance() {
-    const declaredSchema = (
+    return (
       (
         await this.sequelize.query(
           `SELECT EXISTS (
@@ -220,10 +220,6 @@ export class SequelizeAdapter extends DatabaseAdapter<SequelizeSchema> {
         )
       )[0][0] as any
     ).exists;
-    if (declaredSchema) {
-      return true;
-    }
-    return false;
   }
 
   async deleteSchema(

--- a/modules/database/src/adapters/sequelize-adapter/index.ts
+++ b/modules/database/src/adapters/sequelize-adapter/index.ts
@@ -212,6 +212,16 @@ export class SequelizeAdapter extends DatabaseAdapter<SequelizeSchema> {
     return this.models[schema.name];
   }
 
+  async checkDeclaredSchemaExistance() {
+    const declaredSchema = (
+      await this.sequelize.query(`IF (OBJECT_ID("_DeclaredSchema") IS NOT NULL )`)
+    )[0];
+    if (declaredSchema) {
+      return true;
+    }
+    return false;
+  }
+
   async deleteSchema(
     schemaName: string,
     deleteData: boolean,

--- a/modules/database/src/adapters/sequelize-adapter/index.ts
+++ b/modules/database/src/adapters/sequelize-adapter/index.ts
@@ -158,7 +158,7 @@ export class SequelizeAdapter extends DatabaseAdapter<SequelizeSchema> {
     return schema;
   }
 
-  protected getCollectionName(schema: ConduitSchema, setPrefix = false) {
+  getCollectionName(schema: ConduitSchema, setPrefix = false) {
     let collectionName =
       schema.collectionName && schema.collectionName !== ''
         ? schema.collectionName
@@ -176,7 +176,7 @@ export class SequelizeAdapter extends DatabaseAdapter<SequelizeSchema> {
           schema,
         );
       }
-      delete this.sequelize.models[schema.name];
+      delete this.sequelize.models[schema.collectionName];
     }
     const owned = await this.checkModelOwnership(schema);
     if (!owned) {

--- a/modules/database/src/adapters/sequelize-adapter/index.ts
+++ b/modules/database/src/adapters/sequelize-adapter/index.ts
@@ -207,8 +207,19 @@ export class SequelizeAdapter extends DatabaseAdapter<SequelizeSchema> {
 
   async checkDeclaredSchemaExistance() {
     const declaredSchema = (
-      await this.sequelize.query(`IF (OBJECT_ID("_DeclaredSchema") IS NOT NULL )`)
-    )[0];
+      (
+        await this.sequelize.query(
+          `SELECT EXISTS (
+    SELECT FROM 
+        information_schema.tables 
+    WHERE 
+        table_schema LIKE '${sqlSchemaName}' AND 
+        table_type LIKE 'BASE TABLE' AND
+        table_name = '_DeclaredSchema'
+    );`,
+        )
+      )[0][0] as any
+    ).exists;
     if (declaredSchema) {
       return true;
     }

--- a/modules/database/src/adapters/sequelize-adapter/index.ts
+++ b/modules/database/src/adapters/sequelize-adapter/index.ts
@@ -158,7 +158,7 @@ export class SequelizeAdapter extends DatabaseAdapter<SequelizeSchema> {
     return schema;
   }
 
-  getCollectionName(schema: ConduitSchema, setPrefix = false) {
+  getCollectionName(schema: ConduitSchema) {
     const collectionName =
       schema.collectionName && schema.collectionName !== ''
         ? schema.collectionName
@@ -218,7 +218,7 @@ export class SequelizeAdapter extends DatabaseAdapter<SequelizeSchema> {
         table_name = '_DeclaredSchema'
     );`,
         )
-      )[0][0] as any
+      )[0][0] as { exists: boolean }
     ).exists;
   }
 

--- a/modules/database/src/adapters/sequelize-adapter/index.ts
+++ b/modules/database/src/adapters/sequelize-adapter/index.ts
@@ -159,7 +159,7 @@ export class SequelizeAdapter extends DatabaseAdapter<SequelizeSchema> {
   }
 
   getCollectionName(schema: ConduitSchema, setPrefix = false) {
-    let collectionName =
+    const collectionName =
       schema.collectionName && schema.collectionName !== ''
         ? schema.collectionName
         : schema.name;

--- a/modules/database/src/admin/schema.admin.ts
+++ b/modules/database/src/admin/schema.admin.ts
@@ -636,6 +636,9 @@ export class SchemaAdmin {
               : defaultPermissions,
           },
         );
+        (recreatedSchema as any).collectionName = this.database.getCollectionName(
+          schema as any,
+        ); //keep collection name without prefix
         await this.database.createSchemaFromAdapter(recreatedSchema, true);
       }),
     );

--- a/modules/database/src/admin/schema.admin.ts
+++ b/modules/database/src/admin/schema.admin.ts
@@ -16,7 +16,7 @@ import { CustomEndpointController } from '../controllers/customEndpoints/customE
 import { DatabaseAdapter } from '../adapters/DatabaseAdapter';
 import { MongooseSchema } from '../adapters/mongoose-adapter/MongooseSchema';
 import { SequelizeSchema } from '../adapters/sequelize-adapter/SequelizeSchema';
-import { DeclaredSchemaExtension, ParsedQuery } from '../interfaces';
+import { ParsedQuery } from '../interfaces';
 
 const escapeStringRegexp = require('escape-string-regexp');
 

--- a/modules/database/src/admin/schema.admin.ts
+++ b/modules/database/src/admin/schema.admin.ts
@@ -164,14 +164,8 @@ export class SchemaAdmin {
   }
 
   async patchSchema(call: ParsedRouterRequest): Promise<UnparsedRouterResponse> {
-    let {
-      id,
-      name,
-      fields,
-      modelOptions,
-      permissions,
-      crudOperations,
-    } = call.request.params;
+    let { id, name, fields, modelOptions, permissions, crudOperations } =
+      call.request.params;
 
     if (!isNil(name) && name !== '') {
       throw new GrpcError(
@@ -349,8 +343,8 @@ export class SchemaAdmin {
       throw new GrpcError(status.NOT_FOUND, 'Schema does not exist');
     }
 
-    requestedSchema.modelOptions.conduit.cms.enabled = !requestedSchema.modelOptions
-      .conduit.cms.enabled;
+    requestedSchema.modelOptions.conduit.cms.enabled =
+      !requestedSchema.modelOptions.conduit.cms.enabled;
 
     const updatedSchema = await this.database
       .getSchemaModel('_DeclaredSchema')
@@ -598,8 +592,11 @@ export class SchemaAdmin {
     const schemaNames = schemas.map(schema => schema.name);
     await Promise.all(
       schemas.map(async (schema: _ConduitSchema) => {
+        const importedName = schema.name.startsWith('_')
+          ? `imp${schema.name}`
+          : `imp_${schema.name}`;
         const recreatedSchema = new ConduitSchema(
-          schema.name,
+          importedName,
           schema.fields,
           schema.modelOptions,
         );

--- a/modules/database/src/controllers/cms/schema.controller.ts
+++ b/modules/database/src/controllers/cms/schema.controller.ts
@@ -91,7 +91,12 @@ export class SchemaController {
             if (typeof r.modelOptions === 'string') {
               r.modelOptions = JSON.parse(r.modelOptions);
             }
-            const schema = new ConduitSchema(r.name, r.fields, r.modelOptions);
+            const schema = new ConduitSchema(
+              r.name,
+              r.fields,
+              r.modelOptions,
+              r.collectionName,
+            );
             promise = promise.then(r => {
               return this.database.createCustomSchemaFromAdapter(schema);
             });


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/ConduitPlatform/Conduit/blob/main/.github/CONTRIBUTING.md#pull-request-guidelines
-->
This PR introduces conduit-based naming for system schema collections. It adds a "cnd_" prefix to conduit system schemas (for new deployments only) to properly distinguish them with custom CMS schemas. It also registers imported schemas with an "imp_" prefix in the declared schema name to mark it as imported upon introspection. 
Upgraded DBs will not be impacted and will maintain their current schema naming.

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** <!--(check at least one)-->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [x] Refactor
- [ ] Build-related changes
- [ ] Other (please describe)

**Does this PR introduce a breaking change?** <!-- (check one) -->

- [ ] Yes
- [x] No

<!-- If yes, please describe the impact and migration path for existing applications. -->

**The PR fulfills these requirements:**

- [x] It's submitted to the `main` branch
- [ ] When resolving a specific issue, it's referenced in the PR's description  (e.g. `fix #xxx`, where "xxx" is the issue number)

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature <!-- to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it -->

**Other information:**
