### PR TITLE
chore(core): convert update config to a PATCH route

### DIFF
--- a/packages/core/src/config-manager/admin/routes/PatchConfig.route.ts
+++ b/packages/core/src/config-manager/admin/routes/PatchConfig.route.ts
@@ -8,7 +8,7 @@ import ConduitGrpcSdk, {
 } from '@conduitplatform/grpc-sdk';
 import { ConduitRoute, ConduitRouteReturnDefinition } from '@conduitplatform/hermes';
 
-export function getUpdateConfigRoute(
+export function getPatchConfigRoute(
   grpcSdk: ConduitGrpcSdk,
   conduit: ConduitCommons,
   registeredModules: Map<string, RegisteredModule>,
@@ -16,7 +16,7 @@ export function getUpdateConfigRoute(
   return new ConduitRoute(
     {
       path: '/config/:module',
-      action: ConduitRouteActions.UPDATE,
+      action: ConduitRouteActions.PATCH,
       urlParams: {
         module: { type: RouteOptionType.String, required: true },
       },

--- a/packages/core/src/config-manager/admin/routes/index.ts
+++ b/packages/core/src/config-manager/admin/routes/index.ts
@@ -1,3 +1,3 @@
 export * from './GetModules.route';
 export * from './GetConfig.route';
-export * from './UpdateConfig.route';
+export * from './PatchConfig.route';

--- a/packages/core/src/config-manager/index.ts
+++ b/packages/core/src/config-manager/index.ts
@@ -116,8 +116,8 @@ export default class ConfigManager implements IConfigManager {
       .then(config => {
         callback(null, {
           data: JSON.stringify({
-            url: ((config! as unknown) as { hostUrl: string }).hostUrl,
-            env: ((config! as unknown) as { env: string })!.env,
+            url: (config! as unknown as { hostUrl: string }).hostUrl,
+            env: (config! as unknown as { env: string })!.env,
           }),
         });
       })
@@ -286,7 +286,7 @@ export default class ConfigManager implements IConfigManager {
     this.sdk
       .getAdmin()
       .registerRoute(
-        adminRoutes.getUpdateConfigRoute(
+        adminRoutes.getPatchConfigRoute(
           this.grpcSdk,
           this.sdk,
           this.serviceDiscovery.registeredModules,


### PR DESCRIPTION
Config update route request type is now of type PATCH.
This is actually a Breaking Change, but the commit is not marked as such due to a release candidate for v0.14.0 been already out.

**What kind of change does this PR introduce?** <!--(check at least one)-->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [X] Other (please describe)

**Does this PR introduce a breaking change?** <!-- (check one) -->

- [X] Yes
- [ ] No

PUT @ /config/moduleName -> PATCH @ /config/moduleName

**The PR fulfills these requirements:**

- [X] It's submitted to the `main` branch
- [ ] When resolving a specific issue, it's referenced in the PR's description  (e.g. `fix #xxx`, where "xxx" is the issue number)
