### PR TITLE
fix(hermes,router,admin): decouple router logic

### DIFF
--- a/libraries/hermes/src/Rest/Rest.ts
+++ b/libraries/hermes/src/Rest/Rest.ts
@@ -28,7 +28,6 @@ export class RestController extends ConduitRouter {
 
   constructor(
     grpcSdk: ConduitGrpcSdk,
-    privateHeaders: string[] = [],
     swaggerRouterMetadata: SwaggerRouterMetadata = {
       urlPrefix: '',
       securitySchemes: {},
@@ -38,7 +37,10 @@ export class RestController extends ConduitRouter {
   ) {
     super(grpcSdk);
     this._registeredLocalRoutes = new Map();
-    this._privateHeaders = privateHeaders;
+    this._privateHeaders =
+      swaggerRouterMetadata.globalSecurityHeaders.length > 0
+        ? Object.keys(swaggerRouterMetadata.globalSecurityHeaders[0])
+        : [];
     this._swagger = new SwaggerGenerator(swaggerRouterMetadata);
     this.initializeRouter();
   }
@@ -168,7 +170,6 @@ export class RestController extends ConduitRouter {
         .then((r: any) => {
           if (r.redirect) {
             res.removeHeader('Authorization');
-            res.removeHeader('authorization');
             this._privateHeaders.forEach(h => res.removeHeader(h));
             return res.redirect(r.redirect);
           } else {

--- a/libraries/hermes/src/index.ts
+++ b/libraries/hermes/src/index.ts
@@ -33,7 +33,6 @@ export class ConduitRoutingController {
     private readonly baseUrl: string,
     private readonly grpcSdk: ConduitGrpcSdk,
     cleanupTimeoutMs: number = 0,
-    private readonly privateHeaders: string[] = [],
     private readonly swaggerMetadata?: SwaggerRouterMetadata,
   ) {
     this._cleanupTimeoutMs = cleanupTimeoutMs < 0 ? 0 : Math.round(cleanupTimeoutMs);
@@ -83,11 +82,7 @@ export class ConduitRoutingController {
 
   initRest() {
     if (this._restRouter) return;
-    this._restRouter = new RestController(
-      this.grpcSdk,
-      this.privateHeaders,
-      this.swaggerMetadata,
-    );
+    this._restRouter = new RestController(this.grpcSdk, this.swaggerMetadata);
   }
 
   initGraphQL() {

--- a/modules/router/src/Router.ts
+++ b/modules/router/src/Router.ts
@@ -5,6 +5,7 @@ import ConduitGrpcSdk, {
   DatabaseProvider,
   GrpcCallback,
   GrpcRequest,
+  Indexable,
   HealthCheckStatus,
   ManagedModule,
 } from '@conduitplatform/grpc-sdk';
@@ -18,6 +19,7 @@ import {
   grpcToConduitRoute,
   RouteT,
   SocketPush,
+  SwaggerRouterMetadata,
 } from '@conduitplatform/hermes';
 import { isNaN, isNil } from 'lodash';
 import AppConfigSchema, { Config } from './config';
@@ -30,6 +32,43 @@ import {
   RegisterConduitRouteRequest_PathDefinition,
   SocketData,
 } from './protoTypes/router';
+
+const swaggerRouterMetadata: SwaggerRouterMetadata = {
+  urlPrefix: '',
+  securitySchemes: {
+    clientId: {
+      name: 'clientid',
+      type: 'apiKey',
+      in: 'header',
+      description: 'A security client id, retrievable through [POST] /security/client',
+    },
+    clientSecret: {
+      name: 'clientSecret',
+      type: 'apiKey',
+      in: 'header',
+      description:
+        'A security client secret, retrievable through [POST] /security/client',
+    },
+    userToken: {
+      type: 'http',
+      scheme: 'bearer',
+      bearerFormat: 'Bearer',
+      description:
+        'A user authentication token, retrievable through [POST] /authentication/local or [POST] /authentication/renew',
+    },
+  },
+  globalSecurityHeaders: [
+    {
+      clientId: [],
+      clientSecret: [],
+    },
+  ],
+  setExtraRouteHeaders(route: ConduitRoute, swaggerRouteDoc: Indexable): void {
+    if (route.input.middlewares?.includes('authMiddleware')) {
+      swaggerRouteDoc.security[0].userToken = [];
+    }
+  },
+};
 
 export default class ConduitDefaultRouter extends ManagedModule<Config> {
   config = AppConfigSchema;
@@ -72,6 +111,8 @@ export default class ConduitDefaultRouter extends ManagedModule<Config> {
       '',
       this.grpcSdk,
       1000,
+      ['clientid', 'clientsecret'],
+      swaggerRouterMetadata,
     );
     this.registerGlobalMiddleware(
       'conduitRequestMiddleware',

--- a/modules/router/src/Router.ts
+++ b/modules/router/src/Router.ts
@@ -111,7 +111,6 @@ export default class ConduitDefaultRouter extends ManagedModule<Config> {
       '',
       this.grpcSdk,
       1000,
-      ['clientid', 'clientsecret'],
       swaggerRouterMetadata,
     );
     this.registerGlobalMiddleware(

--- a/packages/admin/src/index.ts
+++ b/packages/admin/src/index.ts
@@ -92,6 +92,7 @@ export default class AdminModule extends IConduitAdmin {
       '/',
       this.grpcSdk,
       1000,
+      ['masterkey'],
       swaggerRouterMetadata,
     );
     this._grpcRoutes = {};

--- a/packages/admin/src/index.ts
+++ b/packages/admin/src/index.ts
@@ -39,7 +39,7 @@ import helmet from 'helmet';
 import { generateConfigDefaults } from './utils/config';
 
 const swaggerRouterMetadata: SwaggerRouterMetadata = {
-  urlPrefix: '/',
+  urlPrefix: '',
   securitySchemes: {
     masterKey: {
       name: 'masterkey',

--- a/packages/admin/src/index.ts
+++ b/packages/admin/src/index.ts
@@ -92,7 +92,6 @@ export default class AdminModule extends IConduitAdmin {
       '/',
       this.grpcSdk,
       1000,
-      ['masterkey'],
       swaggerRouterMetadata,
     );
     this._grpcRoutes = {};


### PR DESCRIPTION
Decouples Router-specific logic from Hermes.
Fixes Admin Swagger paths being prefixed by an additional slash.

I'm retrieving any private headers to be removed before redirects from the provided `SwaggerRouterMetadata` object.
Casing may differ, but http headers are case-insensitive anyway as should be `removeHeader()`'s case-matching.

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** <!--(check at least one)-->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other (please describe)

**Does this PR introduce a breaking change?** <!-- (check one) -->

- [ ] Yes
- [X] No

<!-- If yes, please describe the impact and migration path for existing applications. -->

**The PR fulfills these requirements:**

- [X] It's submitted to the `main` branch
- [ ] When resolving a specific issue, it's referenced in the PR's description  (e.g. `fix #xxx`, where "xxx" is the issue number)