### PR TITLE
fix(grpc-sdk): monitorModule() not awaiting module before first callback call

### DIFF
--- a/libraries/grpc-sdk/src/index.ts
+++ b/libraries/grpc-sdk/src/index.ts
@@ -313,8 +313,7 @@ export default class ConduitGrpcSdk {
     callback: (serving: boolean) => void,
     wait: boolean = true,
   ) {
-    const waitPromise = Promise.resolve();
-    if (wait) waitPromise.then(() => this.waitForExistence(moduleName));
+    const waitPromise = wait ? this.waitForExistence(moduleName) : Promise.resolve();
     waitPromise
       .then(() => this._modules[moduleName]?.healthClient?.check({}))
       .then(res => {
@@ -322,9 +321,11 @@ export default class ConduitGrpcSdk {
       })
       .catch(() => {
         callback(false);
+      })
+      .then(() => {
+        const emitter = this.config.getModuleWatcher();
+        emitter.on(`module-connection-update:${moduleName}`, callback);
       });
-    const emitter = this.config.getModuleWatcher();
-    emitter.on(`module-connection-update:${moduleName}`, callback);
   }
 
   unmonitorModule(moduleName: string) {


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** <!--(check at least one)-->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other (please describe)

**Does this PR introduce a breaking change?** <!-- (check one) -->

- [ ] Yes
- [X] No

<!-- If yes, please describe the impact and migration path for existing applications. -->

**The PR fulfills these requirements:**

- [X] It's submitted to the `main` branch
- [ ] When resolving a specific issue, it's referenced in the PR's description  (e.g. `fix #xxx`, where "xxx" is the issue number)
