### PR TITLE
fix(authentication): email dependent app route registration

### DIFF
--- a/modules/authentication/src/routes/index.ts
+++ b/modules/authentication/src/routes/index.ts
@@ -24,7 +24,7 @@ import { OAuth2Settings } from '../handlers/oauth2/interfaces/OAuth2Settings';
 type OAuthHandler = typeof oauth2;
 
 export class AuthenticationRoutes {
-  private readonly localHandlers: LocalHandlers;
+  private localHandlers: LocalHandlers;
   private readonly serviceHandler: ServiceHandler;
   private readonly commonHandlers: CommonHandlers;
   private readonly phoneHandlers: PhoneHandlers;
@@ -33,13 +33,18 @@ export class AuthenticationRoutes {
   constructor(
     readonly server: GrpcServer,
     private readonly grpcSdk: ConduitGrpcSdk,
-    private readonly emailServing: boolean,
+    private localSendVerificationEmail: boolean,
   ) {
     this._routingManager = new RoutingManager(this.grpcSdk.router!, server);
-    this.localHandlers = new LocalHandlers(grpcSdk, emailServing);
     this.serviceHandler = new ServiceHandler(grpcSdk);
     this.commonHandlers = new CommonHandlers(grpcSdk);
     this.phoneHandlers = new PhoneHandlers(grpcSdk);
+    this.updateLocalHandlers(localSendVerificationEmail);
+  }
+
+  updateLocalHandlers(sendVerificationEmail: boolean) {
+    this.localSendVerificationEmail = sendVerificationEmail;
+    this.localHandlers = new LocalHandlers(this.grpcSdk, sendVerificationEmail);
   }
 
   async registerRoutes() {


### PR DESCRIPTION
This PR simplifies `Authentication`'s app route registration process.
Any `Email`-dependent routes are now registered once `Email` is online and serving and `Authentication` no longer attempts to handle `Email` module going offline.
Fixes an issue where email serving status would not propagate down to handlers, resulting in incorrect route registration.

I'm using a timeout so as not to register routes twice whenever `Email`-dependent functionality is enabled and the module is already serving at the time `Authentication` is being brought up.

There's a couple of issues currently preventing this from working as expected, but they're both unrelated to `Authentication` and shouldn't require further changes on this side once resolved:

- `Core`'s `watchModules()` gRPC stream is restarted whenever Router goes online, meaning bringing up `Email` straight after `Router` without restarting `Authentication` won't register additional routes.
- `gRPC-sdk`'s `monitorModule()` does not await for the module to become available before first executing the provided callback (#256)

The first issue is related to Core temporarily going offline while registering its HTTP routes via `Router`.
I've already opened a PR for the second one.

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** <!--(check at least one)-->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other (please describe)

**Does this PR introduce a breaking change?** <!-- (check one) -->

- [ ] Yes
- [X] No

<!-- If yes, please describe the impact and migration path for existing applications. -->

**The PR fulfills these requirements:**

- [X] It's submitted to the `main` branch
- [ ] When resolving a specific issue, it's referenced in the PR's description  (e.g. `fix #xxx`, where "xxx" is the issue number)
