### PR TITLE
fix(admin,commons,core,grpc-sdk,router,storage): config updates

### DIFF
--- a/libraries/grpc-sdk/src/modules/config/index.ts
+++ b/libraries/grpc-sdk/src/modules/config/index.ts
@@ -48,17 +48,6 @@ export class Config extends ConduitModule<typeof ConfigDefinition> {
     });
   }
 
-  updateConfig(config: any, name: string) {
-    const request = {
-      config: JSON.stringify(config),
-      moduleName: name,
-    };
-
-    return this.client!.updateConfig(request).then(res => {
-      return JSON.parse(res.result);
-    });
-  }
-
   addFieldsToConfig(config: any, name: string) {
     const request = {
       config: JSON.stringify(config),

--- a/libraries/grpc-sdk/src/modules/config/index.ts
+++ b/libraries/grpc-sdk/src/modules/config/index.ts
@@ -48,6 +48,17 @@ export class Config extends ConduitModule<typeof ConfigDefinition> {
     });
   }
 
+  updateConfig(config: any, name: string) {
+    const request = {
+      config: JSON.stringify(config),
+      moduleName: name,
+    };
+
+    return this.client!.updateConfig(request).then(res => {
+      return JSON.parse(res.result);
+    });
+  }
+
   addFieldsToConfig(config: any, name: string) {
     const request = {
       config: JSON.stringify(config),

--- a/modules/router/src/Router.ts
+++ b/modules/router/src/Router.ts
@@ -144,7 +144,6 @@ export default class ConduitDefaultRouter extends ManagedModule<Config> {
   }
 
   async onConfig() {
-    await this.updateConfig();
     let atLeastOne = false;
 
     if (ConfigController.getInstance().config.transports.graphql) {

--- a/modules/storage/src/Storage.ts
+++ b/modules/storage/src/Storage.ts
@@ -70,7 +70,6 @@ export default class Storage extends ManagedModule<Config> {
     if (!ConfigController.getInstance().config.active) {
       this.updateHealth(HealthCheckStatus.NOT_SERVING);
     } else {
-      await this.updateConfig();
       await this.grpcSdk.monitorModule(
         'authentication',
         serving => {
@@ -79,14 +78,8 @@ export default class Storage extends ManagedModule<Config> {
         },
         false,
       );
-      const {
-        provider,
-        local,
-        google,
-        azure,
-        aws,
-        aliyun,
-      } = ConfigController.getInstance().config;
+      const { provider, local, google, azure, aws, aliyun } =
+        ConfigController.getInstance().config;
       this.storageProvider = createStorageProvider(provider, {
         local,
         google,

--- a/packages/admin/src/index.ts
+++ b/packages/admin/src/index.ts
@@ -149,9 +149,8 @@ export default class AdminModule extends IConduitAdmin {
 
   async subscribeToBusEvents() {
     this.grpcSdk.bus!.subscribe('config:update:admin', (config: string) => {
-      config = JSON.parse(config);
-      ConfigController.getInstance().config = config;
-      this.onConfig();
+      const cfg: convict.Config<any> = JSON.parse(config);
+      this.handleConfigUpdate(cfg);
     });
     ConfigController.getInstance().config = await this.commons
       .getConfigManager()
@@ -180,6 +179,12 @@ export default class AdminModule extends IConduitAdmin {
       }
       next();
     }, false);
+  }
+
+  /** Used to proc onConfig() via ConfigManager on the same Core instance (Redis broadcast limitation). */
+  handleConfigUpdate(config: convict.Config<any>) {
+    ConfigController.getInstance().config = config;
+    this.onConfig();
   }
 
   protected onConfig() {

--- a/packages/commons/src/modules/Admin/ConduitAdmin.ts
+++ b/packages/commons/src/modules/Admin/ConduitAdmin.ts
@@ -1,6 +1,7 @@
 import { GrpcServer } from '@conduitplatform/grpc-sdk';
 import { ConduitRoute } from '@conduitplatform/hermes';
 import { ConduitCommons } from '../../index';
+import convict from 'convict';
 
 export abstract class IConduitAdmin {
   protected constructor(protected readonly commons: ConduitCommons) {}
@@ -9,6 +10,6 @@ export abstract class IConduitAdmin {
   abstract subscribeToBusEvents(): Promise<void>;
   abstract registerRoute(route: ConduitRoute): void;
   abstract setConfig(moduleConfig: any): Promise<any>;
-
+  abstract handleConfigUpdate(config: convict.Config<any>): void;
   protected abstract onConfig(): void;
 }

--- a/packages/core/src/config-manager/index.ts
+++ b/packages/core/src/config-manager/index.ts
@@ -172,14 +172,10 @@ export default class ConfigManager implements IConfigManager {
 
   async set(moduleName: string, moduleConfig: any) {
     try {
-      switch (moduleName) {
-        case 'core':
-        case 'admin':
-          await this._configStorage.setConfig(moduleName, JSON.stringify(moduleConfig));
-          break;
-        default:
-          await this._configStorage.setConfig(moduleName, JSON.stringify(moduleConfig));
-          break;
+      await this._configStorage.setConfig(moduleName, JSON.stringify(moduleConfig));
+      if (moduleName === 'admin') {
+        this.grpcSdk.bus!.publish('config:update:admin', JSON.stringify(moduleConfig));
+        this.sdk.getAdmin().handleConfigUpdate(moduleConfig);
       }
       return moduleConfig;
     } catch (e) {


### PR DESCRIPTION
Fixes `Admin` not handling live config updates.
Fixes `Router` and `Storage` using last configuration during `onConfig()` calls.

We could also fix the Convict schema type, but doing so in `Commons` would require importing the config schema from `Admin`.

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** <!--(check at least one)-->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other (please describe)

**Does this PR introduce a breaking change?** <!-- (check one) -->

- [ ] Yes
- [X] No

<!-- If yes, please describe the impact and migration path for existing applications. -->

**The PR fulfills these requirements:**

- [X] It's submitted to the `main` branch
- [ ] When resolving a specific issue, it's referenced in the PR's description  (e.g. `fix #xxx`, where "xxx" is the issue number)
