### PR TITLE
fix(hermes,router):  socket registration, security client validation

### DIFF
--- a/libraries/hermes/src/Socket/Socket.ts
+++ b/libraries/hermes/src/Socket/Socket.ts
@@ -63,7 +63,7 @@ export class SocketController extends ConduitRouter {
     if (this._registeredNamespaces.has(namespace)) {
       if (
         ObjectHash.sha1(conduitSocket) !==
-        ObjectHash.sha1(this._registeredRoutes.get(namespace))
+        ObjectHash.sha1(this._registeredNamespaces.get(namespace))
       ) {
         this.removeNamespace(namespace);
       } else {

--- a/modules/router/src/security/handlers/client-validation/index.ts
+++ b/modules/router/src/security/handlers/client-validation/index.ts
@@ -25,6 +25,7 @@ export class ClientValidator {
   }
 
   async middleware(req: ConduitRequest, res: Response, next: NextFunction) {
+    if (isNil(req.conduit)) req.conduit = {};
     const { clientid, clientsecret } = req.headers;
     // Exclude webhooks, admin calls and http pings
     if (req.path.indexOf('/hook') === 0 || ['/', '/health'].includes(req.path)) {


### PR DESCRIPTION
This PR addresses a couple of crashes related to socket route reregistration and client validation introduced in `bdde3cdf`.

**What kind of change does this PR introduce?** <!--(check at least one)-->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other (please describe)

**Does this PR introduce a breaking change?** <!-- (check one) -->

- [ ] Yes
- [X] No

<!-- If yes, please describe the impact and migration path for existing applications. -->

**The PR fulfills these requirements:**

- [X] It's submitted to the `main` branch
- [ ] When resolving a specific issue, it's referenced in the PR's description  (e.g. `fix #xxx`, where "xxx" is the issue number)