### PR TITLE
fix(hermes): Swagger admin section includes admin config routes

### DIFF
--- a/libraries/hermes/src/Rest/Swagger.ts
+++ b/libraries/hermes/src/Rest/Swagger.ts
@@ -45,7 +45,7 @@ export class SwaggerGenerator {
     const prefix =
       baseName.indexOf('/') !== -1 ? baseName.substring(0, baseName.indexOf('/')) : '';
     let serviceName: string;
-    if (baseName.includes('admin')) {
+    if (baseName.startsWith('admin')) {
       serviceName = 'admin';
     } else if (prefix.trim() === '') {
       serviceName = 'core';


### PR DESCRIPTION
Fixes administrative Swagger's `admin` section including admin configuration routes that should otherwise be placed in `config`.

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** <!--(check at least one)-->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other (please describe)

**Does this PR introduce a breaking change?** <!-- (check one) -->

- [ ] Yes
- [X] No

<!-- If yes, please describe the impact and migration path for existing applications. -->

**The PR fulfills these requirements:**

- [X] It's submitted to the `main` branch
- [ ] When resolving a specific issue, it's referenced in the PR's description  (e.g. `fix #xxx`, where "xxx" is the issue number)