### PR TITLE
fix(admin,hermes): GraphQL middleware and return type fixes

### DIFF
--- a/libraries/hermes/src/GraphQl/GraphQL.ts
+++ b/libraries/hermes/src/GraphQl/GraphQL.ts
@@ -399,10 +399,13 @@ export class GraphQLController extends ConduitRouter {
           }
 
           if (r.result && !(typeof route.returnTypeFields === 'string')) {
-            result = JSON.parse(result);
+            if (typeof r.result === 'string') {
+              // only grpc route data is stringified
+              result = JSON.parse(result);
+            }
           } else {
             result = {
-              result: self.extractResult(route.returnTypeFields as string, result),
+              result: this.extractResult(route.returnTypeFields as string, result),
             };
           }
           return result;

--- a/packages/admin/src/index.ts
+++ b/packages/admin/src/index.ts
@@ -72,11 +72,11 @@ export default class AdminModule extends IConduitAdmin {
   grpcSdk: ConduitGrpcSdk;
   private _router: ConduitRoutingController;
   private _sdkRoutes: ConduitRoute[] = [
-    adminRoutes.getLoginRoute(this.commons),
-    adminRoutes.getCreateAdminRoute(this.commons),
+    adminRoutes.getLoginRoute(),
+    adminRoutes.getCreateAdminRoute(),
     adminRoutes.getAdminUsersRoute(),
     adminRoutes.deleteAdminUserRoute(),
-    adminRoutes.changePasswordRoute(this.commons),
+    adminRoutes.changePasswordRoute(),
     adminRoutes.getReadyRoute(),
   ];
   private readonly _grpcRoutes: {

--- a/packages/admin/src/routes/ChangePasswordRoute.ts
+++ b/packages/admin/src/routes/ChangePasswordRoute.ts
@@ -1,4 +1,3 @@
-import { ConduitCommons } from '@conduitplatform/commons';
 import {
   ConduitError,
   ConduitRouteActions,
@@ -11,7 +10,7 @@ import { isNil } from 'lodash';
 import { Admin } from '../models';
 import { ConduitRoute, ConduitRouteReturnDefinition } from '@conduitplatform/hermes';
 
-export function changePasswordRoute(conduit: ConduitCommons) {
+export function changePasswordRoute() {
   return new ConduitRoute(
     {
       path: '/change-password',

--- a/packages/admin/src/routes/CreateAdmin.route.ts
+++ b/packages/admin/src/routes/CreateAdmin.route.ts
@@ -1,4 +1,3 @@
-import { ConduitCommons } from '@conduitplatform/commons';
 import { Admin } from '../models';
 import { isNil } from 'lodash';
 import { hashPassword } from '../utils/auth';
@@ -11,7 +10,7 @@ import {
 } from '@conduitplatform/grpc-sdk';
 import { ConduitRoute, ConduitRouteReturnDefinition } from '@conduitplatform/hermes';
 
-export function getCreateAdminRoute(conduit: ConduitCommons) {
+export function getCreateAdminRoute() {
   return new ConduitRoute(
     {
       path: '/admins',

--- a/packages/admin/src/routes/Login.route.ts
+++ b/packages/admin/src/routes/Login.route.ts
@@ -1,4 +1,4 @@
-import { ConduitCommons, IConfigManager } from '@conduitplatform/commons';
+import { ConduitCommons } from '@conduitplatform/commons';
 import { Admin } from '../models';
 import { isNil } from 'lodash';
 import { comparePasswords, signToken } from '../utils/auth';
@@ -11,7 +11,7 @@ import {
 } from '@conduitplatform/grpc-sdk';
 import { ConduitRoute, ConduitRouteReturnDefinition } from '@conduitplatform/hermes';
 
-export function getLoginRoute(conduit: ConduitCommons) {
+export function getLoginRoute() {
   return new ConduitRoute(
     {
       path: '/login',
@@ -25,7 +25,6 @@ export function getLoginRoute(conduit: ConduitCommons) {
       token: ConduitString.Required,
     }),
     async (params: ConduitRouteParameters) => {
-      const config: IConfigManager = conduit.getConfigManager();
       const { username, password } = params.params!;
       if (isNil(username) || isNil(password)) {
         throw new ConduitError(


### PR DESCRIPTION
Fixes publicly accessible GraphQL queries and mutations being blocked by `Admin`'s auth middleware.
Fixes sdk route (package route) object return types getting json parsed.
Leftover cleanup.

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** <!--(check at least one)-->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other (please describe)

**Does this PR introduce a breaking change?** <!-- (check one) -->

- [ ] Yes
- [X] No

<!-- If yes, please describe the impact and migration path for existing applications. -->

**The PR fulfills these requirements:**

- [X] It's submitted to the `main` branch
- [ ] When resolving a specific issue, it's referenced in the PR's description  (e.g. `fix #xxx`, where "xxx" is the issue number)