### PR TITLE
fix(database,email,forms): handler returned types not matching declared types

### DIFF
--- a/modules/database/src/admin/schema.admin.ts
+++ b/modules/database/src/admin/schema.admin.ts
@@ -105,13 +105,13 @@ export class SchemaAdmin {
     );
     const totalCountPromise = schemaAdapter.model.countDocuments(query);
 
-    const [schemasExtensions, totalCount] = await Promise.all([
+    const [schemasExtensions, count] = await Promise.all([
       schemasExtensionsPromise,
       totalCountPromise,
     ]).catch((e: Error) => {
       throw new GrpcError(status.INTERNAL, e.message);
     });
-    return { schemasExtensions, totalCount };
+    return { schemasExtensions, count };
   }
 
   async createSchema(call: ParsedRouterRequest): Promise<UnparsedRouterResponse> {

--- a/modules/email/src/admin/index.ts
+++ b/modules/email/src/admin/index.ts
@@ -220,14 +220,14 @@ export class AdminHandlers {
       sort,
     );
     const totalCountPromise = EmailTemplate.getInstance().countDocuments(query);
-    const [templateDocuments, totalCount] = await Promise.all([
+    const [templateDocuments, count] = await Promise.all([
       templateDocumentsPromise,
       totalCountPromise,
     ]).catch((e: Error) => {
       throw new GrpcError(status.INTERNAL, e.message);
     });
 
-    return { result: { templateDocuments, totalCount } };
+    return { result: { templateDocuments, count } };
   }
 
   async createTemplate(call: ParsedRouterRequest): Promise<UnparsedRouterResponse> {
@@ -438,8 +438,8 @@ export class AdminHandlers {
         variables: element.versions[0].variables,
       });
     });
-    const totalCount = templateDocuments.length;
-    return { templateDocuments, totalCount };
+    const count = templateDocuments.length;
+    return { templateDocuments, count };
   }
 
   async syncExternalTemplates(
@@ -449,7 +449,6 @@ export class AdminHandlers {
     const externalTemplates: any = await this.emailService.getExternalTemplates();
 
     const updated = [];
-    let totalCount = 0;
     for (const element of externalTemplates) {
       const templateDocument = await EmailTemplate.getInstance().findOne({
         externalId: element.id,
@@ -475,8 +474,7 @@ export class AdminHandlers {
       updated.push(updatedTemplate);
     }
 
-    totalCount = updated.length;
-    return { updated, totalCount };
+    return { updated, count: updated.length };
   }
 
   async sendEmail(call: ParsedRouterRequest): Promise<UnparsedRouterResponse> {

--- a/modules/forms/src/admin/index.ts
+++ b/modules/forms/src/admin/index.ts
@@ -239,8 +239,7 @@ export class AdminHandlers {
       .catch(e => {
         throw new GrpcError(status.INTERNAL, e.message);
       });
-    const totalCount = forms.deletedCount;
-    return { forms, totalCount };
+    return { forms, count: forms.deletedCount };
   }
 
   async getFormReplies(call: ParsedRouterRequest): Promise<UnparsedRouterResponse> {


### PR DESCRIPTION
Fixes certain handlers still returning `totalCount` despite their return signature suggesting they return `count`.
All counts are now in truly consistently returned as `count` across all routes.

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** <!--(check at least one)-->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other (please describe)

**Does this PR introduce a breaking change?** <!-- (check one) -->

- [ ] Yes
- [X] No

Branding this as a bugfix instead of a  breaking change as our route doc already specified that return type.

**The PR fulfills these requirements:**

- [X] It's submitted to the `main` branch
- [ ] When resolving a specific issue, it's referenced in the PR's description  (e.g. `fix #xxx`, where "xxx" is the issue number)
