### PR TITLE
Prometheus Metrics Support

### DIFF
--- a/libraries/grpc-sdk/package.json
+++ b/libraries/grpc-sdk/package.json
@@ -25,6 +25,7 @@
     "ioredis": "^5.1.0",
     "lodash": "^4.17.21",
     "nice-grpc": "^1.2.0",
+    "nice-grpc-prometheus": "^0.1.0",
     "prom-client": "^14.0.1",
     "protobufjs": "^6.11.3",
     "winston": "^3.8.1",

--- a/libraries/grpc-sdk/package.json
+++ b/libraries/grpc-sdk/package.json
@@ -20,10 +20,12 @@
     "@types/ioredis": "^4.28.10",
     "@types/lodash": "^4.14.182",
     "convict": "^6.2.3",
+    "express": "^4.18.1",
     "fast-jwt": "^1.6.0",
     "ioredis": "^5.1.0",
     "lodash": "^4.17.21",
     "nice-grpc": "^1.2.0",
+    "prom-client": "^14.0.1",
     "protobufjs": "^6.11.3",
     "winston": "^3.8.1",
     "winston-loki": "^6.0.5"

--- a/libraries/grpc-sdk/src/classes/ConduitServiceModule.ts
+++ b/libraries/grpc-sdk/src/classes/ConduitServiceModule.ts
@@ -64,7 +64,7 @@ export abstract class ConduitServiceModule {
     }
     if (!init) {
       ConduitGrpcSdk.Metrics.set(
-        'health_state',
+        'module_health_state',
         state === HealthCheckStatus.SERVING ? 1 : 0,
       );
     }

--- a/libraries/grpc-sdk/src/classes/ConduitServiceModule.ts
+++ b/libraries/grpc-sdk/src/classes/ConduitServiceModule.ts
@@ -63,7 +63,7 @@ export abstract class ConduitServiceModule {
       );
     }
     if (!init) {
-      ConduitGrpcSdk.Metrics.set(
+      ConduitGrpcSdk.Metrics?.set(
         'module_health_state',
         state === HealthCheckStatus.SERVING ? 1 : 0,
       );

--- a/libraries/grpc-sdk/src/classes/GrpcServer.ts
+++ b/libraries/grpc-sdk/src/classes/GrpcServer.ts
@@ -41,9 +41,7 @@ export class GrpcServer {
     protoDescription: string,
     functions: { [name: string]: Function },
   ): Promise<GrpcServer> {
-    if (process.env.GRPC_KEY) {
-      functions = wrapGrpcFunctions(functions);
-    }
+    functions = wrapGrpcFunctions(functions);
     if (this._serviceNames.indexOf(protoDescription) !== -1) {
       ConduitGrpcSdk.Logger.log('Service already exists, performing replace');
       this._services[this._serviceNames.indexOf(protoDescription)] = {

--- a/libraries/grpc-sdk/src/classes/ManagedModule.ts
+++ b/libraries/grpc-sdk/src/classes/ManagedModule.ts
@@ -82,6 +82,12 @@ export abstract class ManagedModule<T> extends ConduitServiceModule {
    */
   async onConfig() {}
 
+  /**
+   * This is triggered when a module needs to initialize its own custom metric
+   * types and configuration by using the sdk's ConduitMetrics.
+   */
+  async initializeMetrics() {}
+
   async createGrpcServer(servicePort?: string) {
     this.grpcServer = new GrpcServer(servicePort);
     this._port = (await this.grpcServer.createNewServer()).toString();

--- a/libraries/grpc-sdk/src/classes/ManagedModule.ts
+++ b/libraries/grpc-sdk/src/classes/ManagedModule.ts
@@ -86,7 +86,7 @@ export abstract class ManagedModule<T> extends ConduitServiceModule {
    * This is triggered when a module needs to initialize its own custom metric
    * types and configuration by using the sdk's ConduitMetrics.
    */
-  async initializeMetrics() {}
+  initializeMetrics() {}
 
   async createGrpcServer(servicePort?: string) {
     this.grpcServer = new GrpcServer(servicePort);

--- a/libraries/grpc-sdk/src/classes/ManagedModule.ts
+++ b/libraries/grpc-sdk/src/classes/ManagedModule.ts
@@ -1,6 +1,6 @@
 import ConduitGrpcSdk, {
-  GrpcServer,
   ConduitService,
+  GrpcServer,
   SetConfigRequest,
   SetConfigResponse,
 } from '..';
@@ -84,7 +84,7 @@ export abstract class ManagedModule<T> extends ConduitServiceModule {
 
   /**
    * This is triggered when a module needs to initialize its own custom metric
-   * types and configuration by using the sdk's ConduitMetrics?.
+   * types and configuration by using the sdk's ConduitMetrics.
    */
   initializeMetrics() {}
 

--- a/libraries/grpc-sdk/src/classes/ManagedModule.ts
+++ b/libraries/grpc-sdk/src/classes/ManagedModule.ts
@@ -84,7 +84,7 @@ export abstract class ManagedModule<T> extends ConduitServiceModule {
 
   /**
    * This is triggered when a module needs to initialize its own custom metric
-   * types and configuration by using the sdk's ConduitMetrics.
+   * types and configuration by using the sdk's ConduitMetrics?.
    */
   initializeMetrics() {}
 

--- a/libraries/grpc-sdk/src/classes/ModuleManager.ts
+++ b/libraries/grpc-sdk/src/classes/ModuleManager.ts
@@ -95,10 +95,10 @@ export class ModuleManager<T> {
     }
   }
 
-  private async initializeMetrics() {
-    if (process.env['METRICS_ENABLED'] === 'true') {
+  private initializeMetrics() {
+    if (process.env['METRICS_PORT']) {
       this.grpcSdk.initializeDefaultMetrics();
-      await this.module.initializeMetrics();
+      this.module.initializeMetrics();
     }
   }
 }

--- a/libraries/grpc-sdk/src/classes/ModuleManager.ts
+++ b/libraries/grpc-sdk/src/classes/ModuleManager.ts
@@ -76,6 +76,7 @@ export class ModuleManager<T> {
     await this.module.startGrpcServer();
     await this.module.onServerStart();
     await this.module.preRegister();
+    await this.initializeMetrics();
   }
 
   private async postRegisterLifecycle(): Promise<void> {
@@ -91,6 +92,13 @@ export class ModuleManager<T> {
       if (config) ConfigController.getInstance().config = config;
       if (!config || config.active || !config.hasOwnProperty('active'))
         await this.module.onConfig();
+    }
+  }
+
+  private async initializeMetrics() {
+    if (process.env['METRICS_ENABLED'] === 'true') {
+      this.grpcSdk.initializeDefaultMetrics();
+      await this.module.initializeMetrics();
     }
   }
 }

--- a/libraries/grpc-sdk/src/classes/ModuleManager.ts
+++ b/libraries/grpc-sdk/src/classes/ModuleManager.ts
@@ -74,9 +74,9 @@ export class ModuleManager<T> {
     await this.grpcSdk.initializeEventBus();
     await this.module.handleConfigSyncUpdate();
     await this.module.startGrpcServer();
+    await this.initializeMetrics();
     await this.module.onServerStart();
     await this.module.preRegister();
-    await this.initializeMetrics();
   }
 
   private async postRegisterLifecycle(): Promise<void> {

--- a/libraries/grpc-sdk/src/helpers/RoutingUtilities.ts
+++ b/libraries/grpc-sdk/src/helpers/RoutingUtilities.ts
@@ -73,16 +73,14 @@ function getFormattedModuleName(moduleName: string) {
   return moduleName.replace('-', '_');
 }
 
-export function wrapFunctionsAsync(functions: {
-  [name: string]: RequestHandlers;
-}): {
+export function wrapFunctionsAsync(functions: { [name: string]: RequestHandlers }): {
   [name: string]: (call: Indexable, callback?: Indexable) => void;
 } {
   const modifiedFunctions: {
     [name: string]: (call: Indexable, callback?: Indexable) => void;
   } = {};
   Object.keys(functions).forEach(key => {
-    modifiedFunctions[key] = wrapRouterGrpcFunction(functions[key]);
+    modifiedFunctions[key] = wrapRouterGrpcFunction(functions[key], 'client');
   });
   return modifiedFunctions;
 }

--- a/libraries/grpc-sdk/src/helpers/wrapGrpcFunctions.ts
+++ b/libraries/grpc-sdk/src/helpers/wrapGrpcFunctions.ts
@@ -33,7 +33,7 @@ export function wrapGrpcFunctions(functions: { [name: string]: Function }) {
           return;
         }
       }
-      ConduitGrpcSdk.Metrics.increment('grpc_requests');
+      ConduitGrpcSdk.Metrics.increment('internal_grpc_requests_total');
       functions[name](call, callback);
     };
   });

--- a/libraries/grpc-sdk/src/helpers/wrapGrpcFunctions.ts
+++ b/libraries/grpc-sdk/src/helpers/wrapGrpcFunctions.ts
@@ -1,5 +1,6 @@
 import { createVerifier } from 'fast-jwt';
 import { status } from '@grpc/grpc-js';
+import ConduitGrpcSdk from '../index';
 
 interface JWT {
   moduleName: string;
@@ -8,28 +9,31 @@ interface JWT {
 
 export function wrapGrpcFunctions(functions: { [name: string]: Function }) {
   const grpcKey = process.env.GRPC_KEY;
-  const verify = createVerifier({ key: grpcKey });
   const wrappedFunctions: { [name: string]: Function } = {};
   Object.keys(functions).forEach(name => {
     wrappedFunctions[name] = (call: any, callback: any) => {
-      const grpcToken = call.metadata.get('grpc-token')[0];
-      if (!grpcToken) {
-        callback({
-          code: status.PERMISSION_DENIED,
-          message: 'No gRPC protection token provided',
-        });
-        return;
+      if (grpcKey) {
+        const verify = createVerifier({ key: grpcKey });
+        const grpcToken = call.metadata.get('grpc-token')[0];
+        if (!grpcToken) {
+          callback({
+            code: status.PERMISSION_DENIED,
+            message: 'No gRPC protection token provided',
+          });
+          return;
+        }
+        try {
+          const jwt: JWT = verify(grpcToken);
+          call.metadata.set('module-name', jwt.moduleName);
+        } catch {
+          callback({
+            code: status.PERMISSION_DENIED,
+            message: 'Failed to verify gRPC protection token. GRPC_KEY value differs',
+          });
+          return;
+        }
       }
-      try {
-        const jwt: JWT = verify(grpcToken);
-        call.metadata.set('module-name', jwt.moduleName);
-      } catch {
-        callback({
-          code: status.PERMISSION_DENIED,
-          message: 'Failed to verify gRPC protection token. GRPC_KEY value differs',
-        });
-        return;
-      }
+      ConduitGrpcSdk.Metrics.increment('grpc_requests');
       functions[name](call, callback);
     };
   });

--- a/libraries/grpc-sdk/src/helpers/wrapGrpcFunctions.ts
+++ b/libraries/grpc-sdk/src/helpers/wrapGrpcFunctions.ts
@@ -33,7 +33,7 @@ export function wrapGrpcFunctions(functions: { [name: string]: Function }) {
           return;
         }
       }
-      ConduitGrpcSdk.Metrics.increment('internal_grpc_requests_total');
+      ConduitGrpcSdk.Metrics?.increment('internal_grpc_requests_total');
       functions[name](call, callback);
     };
   });

--- a/libraries/grpc-sdk/src/helpers/wrapRouterFunctions.ts
+++ b/libraries/grpc-sdk/src/helpers/wrapRouterFunctions.ts
@@ -46,8 +46,10 @@ function generateLog(
 
   ConduitGrpcSdk.Logger.log(log);
   ConduitGrpcSdk.Metrics.set('grpc_request_latency_seconds', latency / 1000);
-  ConduitGrpcSdk.Metrics.increment('grpc_response_codes_total', 1, {
-    code: status ?? '200',
+
+  const successStatus = !status || status.toString().charAt(0) === '2';
+  ConduitGrpcSdk.Metrics.increment('grpc_response_statuses_total', 1, {
+    success: successStatus ? 'true' : 'false',
   });
 }
 

--- a/libraries/grpc-sdk/src/helpers/wrapRouterFunctions.ts
+++ b/libraries/grpc-sdk/src/helpers/wrapRouterFunctions.ts
@@ -45,8 +45,9 @@ function generateLog(
   log += ` ${status ?? '200'} ${latency}`;
 
   ConduitGrpcSdk.Logger.log(log);
-  ConduitGrpcSdk.Metrics.set('request_latency', latency, {
-    status_code: status ?? '200',
+  ConduitGrpcSdk.Metrics.set('grpc_request_latency_seconds', latency / 1000);
+  ConduitGrpcSdk.Metrics.increment('grpc_response_codes_total', 1, {
+    code: status ?? '200',
   });
 }
 
@@ -65,7 +66,7 @@ export function wrapRouterGrpcFunction(
   return (call: any, callback: any) => {
     const requestReceive = Date.now();
     let routerRequest = true;
-    ConduitGrpcSdk.Metrics.increment(`${routerType}_grpc_requests`);
+    ConduitGrpcSdk.Metrics.increment(`${routerType}_grpc_requests_total`);
     try {
       call.request.context = parseRequestData(call.request.context);
       call.request.params = parseRequestData(call.request.params);
@@ -75,7 +76,7 @@ export function wrapRouterGrpcFunction(
         call.request.headers = parseRequestData(call.request.headers);
       }
     } catch (e) {
-      ConduitGrpcSdk.Metrics.increment(`${routerType}_grpc_errors`);
+      ConduitGrpcSdk.Metrics.increment(`${routerType}_grpc_errors_total`);
       generateLog(routerRequest, requestReceive, call, status.INTERNAL);
       ConduitGrpcSdk.Logger.error((e as Error).message ?? 'Something went wrong');
       return callback({
@@ -115,7 +116,7 @@ export function wrapRouterGrpcFunction(
         generateLog(routerRequest, requestReceive, call, undefined);
       })
       .catch(error => {
-        ConduitGrpcSdk.Metrics.increment(`${routerType}_grpc_errors`);
+        ConduitGrpcSdk.Metrics.increment(`${routerType}_grpc_errors_total`);
         generateLog(routerRequest, requestReceive, call, error.code ?? status.INTERNAL);
         ConduitGrpcSdk.Logger.error(error.message ?? 'Something went wrong');
         callback({

--- a/libraries/grpc-sdk/src/helpers/wrapRouterFunctions.ts
+++ b/libraries/grpc-sdk/src/helpers/wrapRouterFunctions.ts
@@ -45,10 +45,10 @@ function generateLog(
   log += ` ${status ?? '200'} ${latency}`;
 
   ConduitGrpcSdk.Logger.log(log);
-  ConduitGrpcSdk.Metrics.set('grpc_request_latency_seconds', latency / 1000);
+  ConduitGrpcSdk.Metrics?.set('grpc_request_latency_seconds', latency / 1000);
 
   const successStatus = !status || status.toString().charAt(0) === '2';
-  ConduitGrpcSdk.Metrics.increment('grpc_response_statuses_total', 1, {
+  ConduitGrpcSdk.Metrics?.increment('grpc_response_statuses_total', 1, {
     success: successStatus ? 'true' : 'false',
   });
 }
@@ -68,7 +68,7 @@ export function wrapRouterGrpcFunction(
   return (call: any, callback: any) => {
     const requestReceive = Date.now();
     let routerRequest = true;
-    ConduitGrpcSdk.Metrics.increment(`${routerType}_grpc_requests_total`);
+    ConduitGrpcSdk.Metrics?.increment(`${routerType}_grpc_requests_total`);
     try {
       call.request.context = parseRequestData(call.request.context);
       call.request.params = parseRequestData(call.request.params);
@@ -78,7 +78,7 @@ export function wrapRouterGrpcFunction(
         call.request.headers = parseRequestData(call.request.headers);
       }
     } catch (e) {
-      ConduitGrpcSdk.Metrics.increment(`${routerType}_grpc_errors_total`);
+      ConduitGrpcSdk.Metrics?.increment(`${routerType}_grpc_errors_total`);
       generateLog(routerRequest, requestReceive, call, status.INTERNAL);
       ConduitGrpcSdk.Logger.error((e as Error).message ?? 'Something went wrong');
       return callback({
@@ -118,7 +118,7 @@ export function wrapRouterGrpcFunction(
         generateLog(routerRequest, requestReceive, call, undefined);
       })
       .catch(error => {
-        ConduitGrpcSdk.Metrics.increment(`${routerType}_grpc_errors_total`);
+        ConduitGrpcSdk.Metrics?.increment(`${routerType}_grpc_errors_total`);
         generateLog(routerRequest, requestReceive, call, error.code ?? status.INTERNAL);
         ConduitGrpcSdk.Logger.error(error.message ?? 'Something went wrong');
         callback({

--- a/libraries/grpc-sdk/src/helpers/wrapRouterFunctions.ts
+++ b/libraries/grpc-sdk/src/helpers/wrapRouterFunctions.ts
@@ -56,10 +56,12 @@ function parseRequestData(data: string) {
 
 export function wrapRouterGrpcFunction(
   fun: RequestHandlers,
+  routerType: string,
 ): (call: Indexable, callback: any) => void {
   return (call: any, callback: any) => {
     const requestReceive = Date.now();
     let routerRequest = true;
+    ConduitGrpcSdk.Metrics.increment(`${routerType}_http_requests`);
     try {
       call.request.context = parseRequestData(call.request.context);
       call.request.params = parseRequestData(call.request.params);

--- a/libraries/grpc-sdk/src/index.ts
+++ b/libraries/grpc-sdk/src/index.ts
@@ -407,12 +407,6 @@ export default class ConduitGrpcSdk {
 
   initializeDefaultMetrics() {
     for (const metric of Object.values(defaultMetrics)) {
-      (metric.config as Indexable).labelNames = [
-        'module_instance',
-        'status_code',
-        'incoming_path',
-        'outgoing_path',
-      ];
       this.registerMetric(metric.type, metric.config);
     }
   }

--- a/libraries/grpc-sdk/src/index.ts
+++ b/libraries/grpc-sdk/src/index.ts
@@ -91,7 +91,10 @@ export default class ConduitGrpcSdk {
     const instance = this.name.startsWith('module_')
       ? this.name.substring(8)
       : Crypto.randomBytes(16).toString('hex');
-    ConduitGrpcSdk.Metrics = new ConduitMetrics(this.name, instance);
+
+    if (process.env.METRICS_ENABLED === 'true') {
+      ConduitGrpcSdk.Metrics = new ConduitMetrics(this.name, instance);
+    }
     if (process.env.LOKI_URL && process.env.LOKI_URL !== '') {
       ConduitGrpcSdk.Logger.addTransport(
         new LokiTransport({
@@ -389,6 +392,8 @@ export default class ConduitGrpcSdk {
         }
       });
   }
+
+  initializeDefaultMetrics() {}
 
   createModuleClient(moduleName: string, moduleUrl: string) {
     if (

--- a/libraries/grpc-sdk/src/index.ts
+++ b/libraries/grpc-sdk/src/index.ts
@@ -22,8 +22,8 @@ import { Client } from 'nice-grpc';
 import { status } from '@grpc/grpc-js';
 import { sleep } from './utilities';
 import {
-  HealthDefinition,
   HealthCheckResponse_ServingStatus,
+  HealthDefinition,
 } from './protoUtils/grpc_health_check';
 import {
   GetRedisDetailsResponse,
@@ -38,7 +38,6 @@ import path from 'path';
 import LokiTransport from 'winston-loki';
 import { ConduitMetrics } from './metrics';
 import defaultMetrics from './metrics/config/defaults';
-import { Indexable } from './interfaces';
 import {
   CounterConfiguration,
   GaugeConfiguration,

--- a/libraries/grpc-sdk/src/index.ts
+++ b/libraries/grpc-sdk/src/index.ts
@@ -103,6 +103,9 @@ export default class ConduitGrpcSdk {
 
     if (process.env.METRICS_PORT) {
       ConduitGrpcSdk.Metrics = new ConduitMetrics(this.name, this.instance);
+      ConduitGrpcSdk.Metrics.setDefaultLabels({
+        module_instance: this.instance,
+      });
     }
     if (process.env.LOKI_URL && process.env.LOKI_URL !== '') {
       ConduitGrpcSdk.Logger.addTransport(
@@ -404,9 +407,12 @@ export default class ConduitGrpcSdk {
 
   initializeDefaultMetrics() {
     for (const metric of Object.values(defaultMetrics)) {
-      (metric.config as Indexable).labels = {
-        instance: this.instance,
-      };
+      (metric.config as Indexable).labelNames = [
+        'module_instance',
+        'status_code',
+        'incoming_path',
+        'outgoing_path',
+      ];
       this.registerMetric(metric.type, metric.config);
     }
   }

--- a/libraries/grpc-sdk/src/index.ts
+++ b/libraries/grpc-sdk/src/index.ts
@@ -414,16 +414,16 @@ export default class ConduitGrpcSdk {
   registerMetric(type: MetricType, config: MetricConfiguration) {
     switch (type) {
       case MetricType.Counter:
-        ConduitGrpcSdk.Metrics.createCounter(config as CounterConfiguration<any>);
+        ConduitGrpcSdk.Metrics?.createCounter(config as CounterConfiguration<any>);
         break;
       case MetricType.Gauge:
-        ConduitGrpcSdk.Metrics.createGauge(config as GaugeConfiguration<any>);
+        ConduitGrpcSdk.Metrics?.createGauge(config as GaugeConfiguration<any>);
         break;
       case MetricType.Histogram:
-        ConduitGrpcSdk.Metrics.createHistogram(config as HistogramConfiguration<any>);
+        ConduitGrpcSdk.Metrics?.createHistogram(config as HistogramConfiguration<any>);
         break;
       case MetricType.Summary:
-        ConduitGrpcSdk.Metrics.createSummary(config as SummaryConfiguration<any>);
+        ConduitGrpcSdk.Metrics?.createSummary(config as SummaryConfiguration<any>);
         break;
     }
   }

--- a/libraries/grpc-sdk/src/metrics/MetricsServer.ts
+++ b/libraries/grpc-sdk/src/metrics/MetricsServer.ts
@@ -33,7 +33,8 @@ export class MetricsServer {
         );
     });
     server.get('/metrics', async (req: express.Request, res: express.Response) => {
-      return res.status(200).send(await this.Registry.metrics());
+      const metrics = await this.Registry.metrics();
+      return res.status(200).send(metrics);
     });
     server.get('/metrics/:name', async (req: express.Request, res: express.Response) => {
       return res

--- a/libraries/grpc-sdk/src/metrics/MetricsServer.ts
+++ b/libraries/grpc-sdk/src/metrics/MetricsServer.ts
@@ -36,10 +36,11 @@ export class MetricsServer {
       const metrics = await this.Registry.metrics();
       return res.status(200).send(metrics);
     });
-    server.get('/metrics/:name', async (req: express.Request, res: express.Response) => {
-      return res
-        .status(200)
-        .send(await this.Registry.getSingleMetricAsString(req.params.name));
+    server.get('/metrics/reset', async (req: express.Request, res: express.Response) => {
+      this.Registry.resetMetrics();
+      return res.status(200).send({
+        message: 'Metrics reset',
+      });
     });
     return server;
   }

--- a/libraries/grpc-sdk/src/metrics/MetricsServer.ts
+++ b/libraries/grpc-sdk/src/metrics/MetricsServer.ts
@@ -1,0 +1,47 @@
+import ConduitGrpcSdk from '../index';
+import express from 'express';
+import * as client from 'prom-client';
+
+export class MetricsServer {
+  private readonly moduleName: string;
+  private readonly instance: string;
+  private readonly Registry: client.Registry;
+
+  constructor(moduleName: string, instance: string, registry: client.Registry) {
+    this.moduleName = moduleName;
+    this.instance = instance;
+    this.Registry = registry;
+  }
+
+  initialize() {
+    this._initialize();
+  }
+
+  private _initialize() {
+    const server = express();
+    const port = process.env.METRICS_PORT || 9091;
+    const url = '0.0.0.0:' + port.toString();
+    server.listen(port, () => {
+      ConduitGrpcSdk.Logger.info(`Metrics server listening on: ${url}`);
+    });
+    server.get('/', (req: express.Request, res: express.Response) => {
+      return res
+        .status(200)
+        .send(
+          `Conduit Metrics for module: ${this.moduleName}, instance: ${this.instance}`,
+        );
+    });
+    server.get('/metrics', async (req: express.Request, res: express.Response) => {
+      return res.status(200).send(await this.Registry.metrics());
+    });
+    server.get(
+      '/metrics/counter/:name',
+      async (req: express.Request, res: express.Response) => {
+        return res
+          .status(200)
+          .send(await this.Registry.getSingleMetricAsString(req.params.name));
+      },
+    );
+    return server;
+  }
+}

--- a/libraries/grpc-sdk/src/metrics/MetricsServer.ts
+++ b/libraries/grpc-sdk/src/metrics/MetricsServer.ts
@@ -48,7 +48,7 @@ export class MetricsServer {
   getHttpPort() {
     const value = process.env['METRICS_PORT'];
     if (!value) {
-      ConduitGrpcSdk.Logger.error(`Metrics HTTP Port not set`);
+      ConduitGrpcSdk.Logger.error(`Metrics HTTP port not set`);
       process.exit(-1);
     }
     const port = parseInt(value, 10);

--- a/libraries/grpc-sdk/src/metrics/MetricsServer.ts
+++ b/libraries/grpc-sdk/src/metrics/MetricsServer.ts
@@ -1,6 +1,7 @@
-import ConduitGrpcSdk from '../index';
+import ConduitGrpcSdk, { ConduitError } from '../index';
 import express from 'express';
 import * as client from 'prom-client';
+import { isNaN } from 'lodash';
 
 export class MetricsServer {
   private readonly moduleName: string;
@@ -19,7 +20,7 @@ export class MetricsServer {
 
   private _initialize() {
     const server = express();
-    const port = process.env.METRICS_PORT || 9091;
+    const port = this.getHttpPort();
     const url = '0.0.0.0:' + port.toString();
     server.listen(port, () => {
       ConduitGrpcSdk.Logger.info(`Metrics server listening on: ${url}`);
@@ -34,14 +35,25 @@ export class MetricsServer {
     server.get('/metrics', async (req: express.Request, res: express.Response) => {
       return res.status(200).send(await this.Registry.metrics());
     });
-    server.get(
-      '/metrics/counter/:name',
-      async (req: express.Request, res: express.Response) => {
-        return res
-          .status(200)
-          .send(await this.Registry.getSingleMetricAsString(req.params.name));
-      },
-    );
+    server.get('/metrics/:name', async (req: express.Request, res: express.Response) => {
+      return res
+        .status(200)
+        .send(await this.Registry.getSingleMetricAsString(req.params.name));
+    });
     return server;
+  }
+
+  getHttpPort() {
+    const value = process.env['METRICS_PORT'];
+    if (!value) {
+      ConduitGrpcSdk.Logger.error(`Metrics HTTP Port not set`);
+      process.exit(-1);
+    }
+    const port = parseInt(value, 10);
+    if (isNaN(port) || port < 1 || port > 65535) {
+      ConduitGrpcSdk.Logger.error(`Invalid HTTP port value: ${port}`);
+      process.exit(-1);
+    }
+    return port;
   }
 }

--- a/libraries/grpc-sdk/src/metrics/MetricsServer.ts
+++ b/libraries/grpc-sdk/src/metrics/MetricsServer.ts
@@ -1,4 +1,4 @@
-import ConduitGrpcSdk, { ConduitError } from '../index';
+import ConduitGrpcSdk from '../index';
 import express from 'express';
 import * as client from 'prom-client';
 import { isNaN } from 'lodash';

--- a/libraries/grpc-sdk/src/metrics/config/defaults.ts
+++ b/libraries/grpc-sdk/src/metrics/config/defaults.ts
@@ -30,11 +30,10 @@ export default {
     },
   },
   healthState: {
-    type: MetricType.Histogram,
+    type: MetricType.Gauge,
     config: {
       name: 'health_state',
       help: 'Tracks the health state of the module',
-      buckets: [0, 1],
     },
   },
   grpcRequestLatency: {

--- a/libraries/grpc-sdk/src/metrics/config/defaults.ts
+++ b/libraries/grpc-sdk/src/metrics/config/defaults.ts
@@ -1,60 +1,76 @@
 import { MetricType } from '../../types';
 
 export default {
-  grpcRequests: {
+  internalGrpcRequests: {
     type: MetricType.Counter,
     config: {
-      name: 'grpc_requests',
-      help: 'Tracks the number of grpc requests',
+      name: 'internal_grpc_requests_total',
+      help: "Tracks the total number of Conduit's internal gRPC requests",
     },
   },
-  clientHttpRequests: {
+  clientGrpcRequests: {
     type: MetricType.Counter,
     config: {
-      name: 'client_http_requests',
-      help: 'Tracks the number of the client http requests',
+      name: 'client_grpc_requests_total',
+      help: 'Tracks the total number of the client gRPC requests',
     },
   },
-  adminHttpRequests: {
+  adminGrpcRequests: {
     type: MetricType.Counter,
     config: {
-      name: 'admin_http_requests',
-      help: 'Tracks the number of the admin http requests',
+      name: 'admin_grpc_requests_total',
+      help: 'Tracks the total number of the admin gRPC requests',
     },
   },
-  clientHttpErrors: {
+  clientGrpcErrors: {
     type: MetricType.Counter,
     config: {
-      name: 'client_http_errors',
-      help: 'Tracks the number of client http errors',
+      name: 'client_grpc_errors_total',
+      help: 'Tracks the total number of client grpc errors',
     },
   },
-  adminHttpErrors: {
+  adminGrpcErrors: {
     type: MetricType.Counter,
     config: {
-      name: 'admin_http_errors',
-      help: 'Tracks the number of admin http errors',
+      name: 'admin_grpc_errors_total',
+      help: 'Tracks the total number of admin grpc errors',
     },
   },
   healthState: {
     type: MetricType.Gauge,
     config: {
-      name: 'health_state',
+      name: 'health_state_total',
       help: 'Tracks the health state of the module',
     },
   },
-  requestLatency: {
+  grpcRequestLatency: {
     type: MetricType.Gauge,
     config: {
-      name: 'request_latency',
-      help: 'Tracks the latency of http requests',
+      name: 'grpc_request_latency_total',
+      help: 'Tracks the latency of grpc requests',
     },
   },
-  httpErrorRate: {
+  adminHttpErrorRate: {
     type: MetricType.Summary,
     config: {
       name: 'http_error_rate',
       help: 'Tracks the error rate of http requests',
+      percentiles: [0.5, 0.75, 0.9, 0.95, 0.99, 0.999],
+    },
+  },
+  clientHttpErrorRate: {
+    type: MetricType.Summary,
+    config: {
+      name: 'client_http_error_rate',
+      help: 'Tracks the error rate of client http requests',
+      percentiles: [0.5, 0.75, 0.9, 0.95, 0.99, 0.999],
+    },
+  },
+  adminHTTPErrorRate: {
+    type: MetricType.Summary,
+    config: {
+      name: 'admin_http_error_rate',
+      help: 'Tracks the error rate of admin http requests',
       percentiles: [0.5, 0.75, 0.9, 0.95, 0.99, 0.999],
     },
   },

--- a/libraries/grpc-sdk/src/metrics/config/defaults.ts
+++ b/libraries/grpc-sdk/src/metrics/config/defaults.ts
@@ -8,13 +8,6 @@ export default {
       help: 'Tracks the number of grpc requests',
     },
   },
-  grpcRequestsPerMinute: {
-    type: MetricType.Counter,
-    config: {
-      name: 'grpc_requests_per_minute',
-      help: 'Tracks the number of grpc requests per minute',
-    },
-  },
   clientHttpRequests: {
     type: MetricType.Counter,
     config: {
@@ -29,6 +22,20 @@ export default {
       help: 'Tracks the number of the admin http requests',
     },
   },
+  clientHttpErrors: {
+    type: MetricType.Counter,
+    config: {
+      name: 'client_http_errors',
+      help: 'Tracks the number of client http errors',
+    },
+  },
+  adminHttpErrors: {
+    type: MetricType.Counter,
+    config: {
+      name: 'admin_http_errors',
+      help: 'Tracks the number of admin http errors',
+    },
+  },
   healthState: {
     type: MetricType.Gauge,
     config: {
@@ -36,19 +43,11 @@ export default {
       help: 'Tracks the health state of the module',
     },
   },
-  grpcRequestLatency: {
-    type: MetricType.Histogram,
+  requestLatency: {
+    type: MetricType.Gauge,
     config: {
-      name: 'grpc_request_latency',
-      help: 'Tracks the latency of grpc requests',
-      buckets: [0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10],
-    },
-  },
-  httpErrors: {
-    type: MetricType.Counter,
-    config: {
-      name: 'http_errors',
-      help: 'Tracks the number of http errors',
+      name: 'request_latency',
+      help: 'Tracks the latency of http requests',
     },
   },
   httpErrorRate: {

--- a/libraries/grpc-sdk/src/metrics/config/defaults.ts
+++ b/libraries/grpc-sdk/src/metrics/config/defaults.ts
@@ -36,18 +36,26 @@ export default {
       help: 'Tracks the total number of admin grpc errors',
     },
   },
-  healthState: {
+  moduleHealthState: {
     type: MetricType.Gauge,
     config: {
-      name: 'health_state_total',
+      name: 'module_health_state',
       help: 'Tracks the health state of the module',
     },
   },
   grpcRequestLatency: {
     type: MetricType.Gauge,
     config: {
-      name: 'grpc_request_latency_total',
-      help: 'Tracks the latency of grpc requests',
+      name: 'grpc_request_latency_seconds',
+      help: 'Tracks the latency of grpc requests in seconds',
+    },
+  },
+  grpcResponseCode: {
+    type: MetricType.Counter,
+    config: {
+      name: 'grpc_response_codes_total',
+      help: 'Tracks the total number of grpc response codes',
+      labelNames: ['code'],
     },
   },
   adminHttpErrorRate: {

--- a/libraries/grpc-sdk/src/metrics/config/defaults.ts
+++ b/libraries/grpc-sdk/src/metrics/config/defaults.ts
@@ -58,28 +58,4 @@ export default {
       labelNames: ['success'],
     },
   },
-  adminHttpErrorRate: {
-    type: MetricType.Summary,
-    config: {
-      name: 'http_error_rate',
-      help: 'Tracks the error rate of http requests',
-      percentiles: [0.5, 0.75, 0.9, 0.95, 0.99, 0.999],
-    },
-  },
-  clientHttpErrorRate: {
-    type: MetricType.Summary,
-    config: {
-      name: 'client_http_error_rate',
-      help: 'Tracks the error rate of client http requests',
-      percentiles: [0.5, 0.75, 0.9, 0.95, 0.99, 0.999],
-    },
-  },
-  adminHTTPErrorRate: {
-    type: MetricType.Summary,
-    config: {
-      name: 'admin_http_error_rate',
-      help: 'Tracks the error rate of admin http requests',
-      percentiles: [0.5, 0.75, 0.9, 0.95, 0.99, 0.999],
-    },
-  },
 };

--- a/libraries/grpc-sdk/src/metrics/config/defaults.ts
+++ b/libraries/grpc-sdk/src/metrics/config/defaults.ts
@@ -1,0 +1,56 @@
+import { MetricType } from '../../types';
+
+export default {
+  grpcRequests: {
+    type: MetricType.Counter,
+    config: {
+      name: 'grpc_requests',
+      help: 'Tracks the number of grpc requests',
+    },
+  },
+  grpcRequestsPerMinute: {
+    type: MetricType.Counter,
+    config: {
+      name: 'grpc_requests_per_minute',
+      help: 'Tracks the number of grpc requests per minute',
+    },
+  },
+  httpRequests: {
+    type: MetricType.Counter,
+    config: {
+      name: 'http_requests',
+      help: 'Tracks the number of http requests',
+    },
+  },
+  healthState: {
+    type: MetricType.Histogram,
+    config: {
+      name: 'health_state',
+      help: 'Tracks the health state of the module',
+      buckets: ['Healthy', 'Unhealthy'],
+    },
+  },
+  grpcRequestLatency: {
+    type: MetricType.Histogram,
+    config: {
+      name: 'grpc_request_latency',
+      help: 'Tracks the latency of grpc requests',
+      buckets: [0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10],
+    },
+  },
+  httpErrors: {
+    type: MetricType.Counter,
+    config: {
+      name: 'http_errors',
+      help: 'Tracks the number of http errors',
+    },
+  },
+  httpErrorRate: {
+    type: MetricType.Summary,
+    config: {
+      name: 'http_error_rate',
+      help: 'Tracks the error rate of http requests',
+      percentiles: [0.5, 0.75, 0.9, 0.95, 0.99, 0.999],
+    },
+  },
+};

--- a/libraries/grpc-sdk/src/metrics/config/defaults.ts
+++ b/libraries/grpc-sdk/src/metrics/config/defaults.ts
@@ -15,11 +15,18 @@ export default {
       help: 'Tracks the number of grpc requests per minute',
     },
   },
-  httpRequests: {
+  clientHttpRequests: {
     type: MetricType.Counter,
     config: {
-      name: 'http_requests',
-      help: 'Tracks the number of http requests',
+      name: 'client_http_requests',
+      help: 'Tracks the number of the client http requests',
+    },
+  },
+  adminHttpRequests: {
+    type: MetricType.Counter,
+    config: {
+      name: 'admin_http_requests',
+      help: 'Tracks the number of the admin http requests',
     },
   },
   healthState: {

--- a/libraries/grpc-sdk/src/metrics/config/defaults.ts
+++ b/libraries/grpc-sdk/src/metrics/config/defaults.ts
@@ -27,7 +27,7 @@ export default {
     config: {
       name: 'health_state',
       help: 'Tracks the health state of the module',
-      buckets: ['Healthy', 'Unhealthy'],
+      buckets: [0, 1],
     },
   },
   grpcRequestLatency: {

--- a/libraries/grpc-sdk/src/metrics/config/defaults.ts
+++ b/libraries/grpc-sdk/src/metrics/config/defaults.ts
@@ -50,12 +50,12 @@ export default {
       help: 'Tracks the latency of grpc requests in seconds',
     },
   },
-  grpcResponseCode: {
+  grpcResponseStatuses: {
     type: MetricType.Counter,
     config: {
-      name: 'grpc_response_codes_total',
+      name: 'grpc_response_statuses_total',
       help: 'Tracks the total number of grpc response codes',
-      labelNames: ['code'],
+      labelNames: ['success'],
     },
   },
   adminHttpErrorRate: {

--- a/libraries/grpc-sdk/src/metrics/config/index.ts
+++ b/libraries/grpc-sdk/src/metrics/config/index.ts
@@ -1,1 +1,0 @@
-export * from './defaults';

--- a/libraries/grpc-sdk/src/metrics/config/index.ts
+++ b/libraries/grpc-sdk/src/metrics/config/index.ts
@@ -1,0 +1,1 @@
+export * from './defaults';

--- a/libraries/grpc-sdk/src/metrics/index.ts
+++ b/libraries/grpc-sdk/src/metrics/index.ts
@@ -7,7 +7,7 @@ import {
   SummaryConfiguration,
 } from 'prom-client';
 import { MetricsServer } from './MetricsServer';
-import ConduitGrpcSdk from '../index';
+import { registry as niceGrpcRegistry } from 'nice-grpc-prometheus';
 
 export class ConduitMetrics {
   private readonly moduleName: string;
@@ -18,7 +18,8 @@ export class ConduitMetrics {
   constructor(moduleName: string, instance: string) {
     this.moduleName = moduleName;
     this.instance = instance;
-    this.Registry = new client.Registry(); //global registry
+    const globalRegistry = new client.Registry();
+    this.Registry = client.Registry.merge([globalRegistry, niceGrpcRegistry]);
     this._httpServer = new MetricsServer(moduleName, instance, this.Registry);
     this._httpServer.initialize();
     this.collectDefaultMetrics();

--- a/libraries/grpc-sdk/src/metrics/index.ts
+++ b/libraries/grpc-sdk/src/metrics/index.ts
@@ -71,6 +71,14 @@ export class ConduitMetrics {
     return metricInstance.dec(decrement);
   }
 
+  set(metric: string, value: number) {
+    const metricInstance = this.Registry.getSingleMetric(metric);
+    if (!(metricInstance instanceof client.Gauge)) {
+      throw new Error(`Metric ${metric} is not a Gauge`);
+    }
+    return metricInstance.set(value);
+  }
+
   observe(metric: string, value: number) {
     const metricInstance = this.Registry.getSingleMetric(metric);
     if (

--- a/libraries/grpc-sdk/src/metrics/index.ts
+++ b/libraries/grpc-sdk/src/metrics/index.ts
@@ -3,6 +3,7 @@ import {
   CounterConfiguration,
   GaugeConfiguration,
   HistogramConfiguration,
+  LabelValues,
   SummaryConfiguration,
 } from 'prom-client';
 import { MetricsServer } from './MetricsServer';
@@ -77,6 +78,14 @@ export class ConduitMetrics {
       throw new Error(`Metric ${metric} is not a Gauge`);
     }
     return metricInstance.set(value);
+  }
+
+  setOnLabel(metric: string, labels: LabelValues<any>, value: number) {
+    const metricInstance = this.Registry.getSingleMetric(metric);
+    if (!(metricInstance instanceof client.Gauge)) {
+      throw new Error(`Metric ${metric} is not a Gauge`);
+    }
+    return metricInstance.set(labels, value);
   }
 
   observe(metric: string, value: number) {

--- a/libraries/grpc-sdk/src/metrics/index.ts
+++ b/libraries/grpc-sdk/src/metrics/index.ts
@@ -1,0 +1,52 @@
+import * as client from 'prom-client';
+import { MetricType } from '../types';
+import {
+  CounterConfiguration,
+  GaugeConfiguration,
+  HistogramConfiguration,
+  SummaryConfiguration,
+} from 'prom-client';
+import { MetricsServer } from './MetricsServer';
+
+export class ConduitMetrics {
+  private readonly moduleName: string;
+  private readonly instance: string;
+  private readonly Registry: client.Registry;
+  private _httpServer: MetricsServer;
+
+  constructor(moduleName: string, instance: string) {
+    this.moduleName = moduleName;
+    this.instance = instance;
+    this.Registry = client.register; //global registry
+    this._httpServer = new MetricsServer(moduleName, instance, this.Registry);
+    this._httpServer.initialize();
+    this.collectDefaultMetrics();
+  }
+
+  setDefaultLabels(labels: { [key: string]: string }) {
+    this.Registry.setDefaultLabels(labels);
+  }
+
+  collectDefaultMetrics() {
+    const collectDefaultMetrics = client.collectDefaultMetrics;
+    collectDefaultMetrics({
+      labels: {
+        module: this.moduleName,
+        instance: this.instance,
+      },
+    });
+  }
+
+  createCounter(metric: MetricType.Counter, config: CounterConfiguration<any>) {
+    return new client.Counter(config);
+  }
+  createSummary(metric: MetricType.Summary, config: SummaryConfiguration<any>) {
+    return new client.Summary(config);
+  }
+  createHistogram(metric: MetricType.Histogram, config: HistogramConfiguration<any>) {
+    return new client.Histogram(config);
+  }
+  createGauge(metric: MetricType.Gauge, config: GaugeConfiguration<any>) {
+    return new client.Gauge(config);
+  }
+}

--- a/libraries/grpc-sdk/src/metrics/index.ts
+++ b/libraries/grpc-sdk/src/metrics/index.ts
@@ -37,16 +37,16 @@ export class ConduitMetrics {
     });
   }
 
-  createCounter(metric: MetricType.Counter, config: CounterConfiguration<any>) {
+  createCounter(config: CounterConfiguration<any>) {
     return new client.Counter(config);
   }
-  createSummary(metric: MetricType.Summary, config: SummaryConfiguration<any>) {
+  createSummary(config: SummaryConfiguration<any>) {
     return new client.Summary(config);
   }
-  createHistogram(metric: MetricType.Histogram, config: HistogramConfiguration<any>) {
+  createHistogram(config: HistogramConfiguration<any>) {
     return new client.Histogram(config);
   }
-  createGauge(metric: MetricType.Gauge, config: GaugeConfiguration<any>) {
+  createGauge(config: GaugeConfiguration<any>) {
     return new client.Gauge(config);
   }
 }

--- a/libraries/grpc-sdk/src/metrics/index.ts
+++ b/libraries/grpc-sdk/src/metrics/index.ts
@@ -66,7 +66,9 @@ export class ConduitMetrics {
     ) {
       throw new Error(`Metric ${metric} is not an incrementable metric`);
     }
-    return metricInstance.labels({ ...labels }).inc(increment);
+    return labels
+      ? metricInstance.labels({ ...labels }).inc(increment)
+      : metricInstance.inc(increment);
   }
 
   decrement(metric: string, decrement: number = 1, labels?: LabelValues<any>) {
@@ -74,7 +76,9 @@ export class ConduitMetrics {
     if (!(metricInstance instanceof client.Gauge)) {
       throw new Error(`Metric ${metric} is not a decrementable metric`);
     }
-    return metricInstance.labels({ ...labels }).dec(decrement);
+    return labels
+      ? metricInstance.labels({ ...labels }).dec(decrement)
+      : metricInstance.dec(decrement);
   }
 
   set(metric: string, value: number, labels?: LabelValues<any>) {
@@ -82,7 +86,9 @@ export class ConduitMetrics {
     if (!(metricInstance instanceof client.Gauge)) {
       throw new Error(`Metric ${metric} is not a Gauge`);
     }
-    return metricInstance.labels({ ...labels }).set(value);
+    return labels
+      ? metricInstance.labels({ ...labels }).set(value)
+      : metricInstance.set(value);
   }
 
   observe(metric: string, value: number, labels?: LabelValues<any>) {
@@ -93,6 +99,8 @@ export class ConduitMetrics {
     ) {
       throw new Error(`Metric ${metric} is not a Histogram`);
     }
-    return metricInstance.labels({ ...labels }).observe(value);
+    return labels
+      ? metricInstance.labels({ ...labels }).observe(value)
+      : metricInstance.observe(value);
   }
 }

--- a/libraries/grpc-sdk/src/modules/admin/index.ts
+++ b/libraries/grpc-sdk/src/modules/admin/index.ts
@@ -45,7 +45,7 @@ export class Admin extends ConduitModule<typeof AdminDefinition> {
   ): Promise<any> {
     const modifiedFunctions: { [name: string]: Function } = {};
     Object.keys(functions).forEach(key => {
-      modifiedFunctions[key] = wrapRouterGrpcFunction(functions[key]);
+      modifiedFunctions[key] = wrapRouterGrpcFunction(functions[key], 'admin');
     });
     let protoFunctions = '';
     paths.forEach(r => {

--- a/libraries/grpc-sdk/src/modules/config/index.ts
+++ b/libraries/grpc-sdk/src/modules/config/index.ts
@@ -3,12 +3,11 @@ import { ConduitModule } from '../../classes/ConduitModule';
 import { HealthCheckStatus } from '../../types';
 import {
   ConfigDefinition,
-  RegisterModuleRequest,
   ModuleHealthRequest,
+  RegisterModuleRequest,
 } from '../../protoUtils/core';
 import { Indexable } from '../../interfaces';
 import ConduitGrpcSdk from '../../index';
-import { ConduitMetrics } from '../../metrics';
 
 export class Config extends ConduitModule<typeof ConfigDefinition> {
   private readonly emitter = new EventEmitter();

--- a/libraries/grpc-sdk/src/modules/config/index.ts
+++ b/libraries/grpc-sdk/src/modules/config/index.ts
@@ -134,11 +134,9 @@ export class Config extends ConduitModule<typeof ConfigDefinition> {
     this.client!.moduleHealthProbe(request)
       .then(res => {
         if (!res && self.coreLive) {
-          ConduitGrpcSdk.Metrics.observe('health_state', 0);
           ConduitGrpcSdk.Logger.warn('Core unhealthy');
           self.coreLive = false;
         } else if (res && !self.coreLive) {
-          ConduitGrpcSdk.Metrics.observe('health_state', 1);
           ConduitGrpcSdk.Logger.log('Core is live');
           self.coreLive = true;
           self.watchModules();
@@ -146,7 +144,6 @@ export class Config extends ConduitModule<typeof ConfigDefinition> {
       })
       .catch(e => {
         if (self.coreLive) {
-          ConduitGrpcSdk.Metrics.observe('health_state', 0);
           ConduitGrpcSdk.Logger.warn('Core unhealthy');
           self.coreLive = false;
         }

--- a/libraries/grpc-sdk/src/modules/config/index.ts
+++ b/libraries/grpc-sdk/src/modules/config/index.ts
@@ -8,6 +8,7 @@ import {
 } from '../../protoUtils/core';
 import { Indexable } from '../../interfaces';
 import ConduitGrpcSdk from '../../index';
+import { ConduitMetrics } from '../../metrics';
 
 export class Config extends ConduitModule<typeof ConfigDefinition> {
   private readonly emitter = new EventEmitter();
@@ -133,9 +134,11 @@ export class Config extends ConduitModule<typeof ConfigDefinition> {
     this.client!.moduleHealthProbe(request)
       .then(res => {
         if (!res && self.coreLive) {
+          ConduitGrpcSdk.Metrics.observe('health_state', 0);
           ConduitGrpcSdk.Logger.warn('Core unhealthy');
           self.coreLive = false;
         } else if (res && !self.coreLive) {
+          ConduitGrpcSdk.Metrics.observe('health_state', 1);
           ConduitGrpcSdk.Logger.log('Core is live');
           self.coreLive = true;
           self.watchModules();
@@ -143,6 +146,7 @@ export class Config extends ConduitModule<typeof ConfigDefinition> {
       })
       .catch(e => {
         if (self.coreLive) {
+          ConduitGrpcSdk.Metrics.observe('health_state', 0);
           ConduitGrpcSdk.Logger.warn('Core unhealthy');
           self.coreLive = false;
         }

--- a/libraries/grpc-sdk/src/types/index.ts
+++ b/libraries/grpc-sdk/src/types/index.ts
@@ -1,5 +1,6 @@
 import { Metadata, status } from '@grpc/grpc-js';
 import { Context, Params, Headers, Indexable } from '../interfaces';
+import { MetricType } from 'prom-client';
 
 export type GrpcRequest<T> = { request: T; metadata?: Metadata };
 export type GrpcResponse<T> = (
@@ -65,3 +66,11 @@ export enum HealthCheckStatus {
   NOT_SERVING,
   SERVICE_UNKNOWN,
 }
+
+export {
+  MetricType,
+  CounterConfiguration,
+  GaugeConfiguration,
+  SummaryConfiguration,
+  HistogramConfiguration,
+} from 'prom-client';

--- a/libraries/grpc-sdk/src/types/index.ts
+++ b/libraries/grpc-sdk/src/types/index.ts
@@ -1,6 +1,11 @@
 import { Metadata, status } from '@grpc/grpc-js';
 import { Context, Params, Headers, Indexable } from '../interfaces';
-import { MetricType } from 'prom-client';
+import {
+  CounterConfiguration,
+  GaugeConfiguration,
+  HistogramConfiguration,
+  SummaryConfiguration,
+} from 'prom-client';
 
 export type GrpcRequest<T> = { request: T; metadata?: Metadata };
 export type GrpcResponse<T> = (
@@ -67,10 +72,15 @@ export enum HealthCheckStatus {
   SERVICE_UNKNOWN,
 }
 
-export {
-  MetricType,
-  CounterConfiguration,
-  GaugeConfiguration,
-  SummaryConfiguration,
-  HistogramConfiguration,
-} from 'prom-client';
+export type MetricConfiguration =
+  | CounterConfiguration<any>
+  | SummaryConfiguration<any>
+  | HistogramConfiguration<any>
+  | GaugeConfiguration<any>;
+
+export enum MetricType {
+  Counter,
+  Gauge,
+  Histogram,
+  Summary,
+}

--- a/libraries/hermes/src/Rest/Rest.ts
+++ b/libraries/hermes/src/Rest/Rest.ts
@@ -218,7 +218,7 @@ export class RestController extends ConduitRouter {
   handleError(res: Response): (err: Error | ConduitError) => void {
     return (err: Error | ConduitError | any) => {
       ConduitGrpcSdk.Logger.error(err);
-      ConduitGrpcSdk.Metrics.increment(`admin_http_errors`);
+      ConduitGrpcSdk.Metrics.increment(`admin_grpc_errors_total`);
       if (err.hasOwnProperty('status')) {
         return res.status((err as ConduitError).status).json({
           name: err.name,

--- a/libraries/hermes/src/Rest/Rest.ts
+++ b/libraries/hermes/src/Rest/Rest.ts
@@ -168,7 +168,6 @@ export class RestController extends ConduitRouter {
           }
         })
         .then((r: any) => {
-          ConduitGrpcSdk.Metrics.increment('http_requests');
           if (r.redirect) {
             res.removeHeader('Authorization');
             this._privateHeaders.forEach(h => res.removeHeader(h));

--- a/libraries/hermes/src/Rest/Rest.ts
+++ b/libraries/hermes/src/Rest/Rest.ts
@@ -218,7 +218,6 @@ export class RestController extends ConduitRouter {
   handleError(res: Response): (err: Error | ConduitError) => void {
     return (err: Error | ConduitError | any) => {
       ConduitGrpcSdk.Logger.error(err);
-      ConduitGrpcSdk.Metrics.increment(`admin_grpc_errors_total`);
       if (err.hasOwnProperty('status')) {
         return res.status((err as ConduitError).status).json({
           name: err.name,

--- a/libraries/hermes/src/Rest/Rest.ts
+++ b/libraries/hermes/src/Rest/Rest.ts
@@ -218,6 +218,7 @@ export class RestController extends ConduitRouter {
   handleError(res: Response): (err: Error | ConduitError) => void {
     return (err: Error | ConduitError | any) => {
       ConduitGrpcSdk.Logger.error(err);
+      ConduitGrpcSdk.Metrics.increment(`admin_http_errors`);
       if (err.hasOwnProperty('status')) {
         return res.status((err as ConduitError).status).json({
           name: err.name,

--- a/libraries/hermes/src/Rest/Rest.ts
+++ b/libraries/hermes/src/Rest/Rest.ts
@@ -168,6 +168,7 @@ export class RestController extends ConduitRouter {
           }
         })
         .then((r: any) => {
+          ConduitGrpcSdk.Metrics.increment('http_requests');
           if (r.redirect) {
             res.removeHeader('Authorization');
             this._privateHeaders.forEach(h => res.removeHeader(h));

--- a/libraries/hermes/src/index.ts
+++ b/libraries/hermes/src/index.ts
@@ -242,7 +242,7 @@ export class ConduitRoutingController {
     const address = this.server.address();
     const bind =
       typeof address === 'string' ? 'pipe ' + address : 'port ' + address?.port;
-    ConduitGrpcSdk.Logger.log(this.baseUrl.substr(1) + ' listening on ' + bind);
+    ConduitGrpcSdk.Logger.log('HTTP server listening on ' + bind);
   }
 
   private registerGlobalMiddleware() {

--- a/libraries/hermes/src/index.ts
+++ b/libraries/hermes/src/index.ts
@@ -208,6 +208,7 @@ export class ConduitRoutingController {
             ' handler url: ' +
             url,
         );
+        ConduitGrpcSdk.Metrics.increment('registered_routes_total');
         this.registerConduitRoute(r);
       }
     });

--- a/libraries/hermes/src/index.ts
+++ b/libraries/hermes/src/index.ts
@@ -208,7 +208,7 @@ export class ConduitRoutingController {
             ' handler url: ' +
             url,
         );
-        ConduitGrpcSdk.Metrics.increment('registered_routes_total');
+        ConduitGrpcSdk.Metrics?.increment('registered_routes_total');
         this.registerConduitRoute(r);
       }
     });

--- a/modules/authentication/src/Authentication.ts
+++ b/modules/authentication/src/Authentication.ts
@@ -28,6 +28,7 @@ import {
   UserDeleteResponse,
 } from './protoTypes/authentication';
 import { runMigrations } from './migrations';
+import metricsConfig from './metrics';
 
 export default class Authentication extends ManagedModule<Config> {
   configSchema = AppConfigSchema;
@@ -94,6 +95,12 @@ export default class Authentication extends ManagedModule<Config> {
         this.localSendVerificationEmail = false;
         this.grpcSdk.unmonitorModule('email');
       }
+    }
+  }
+
+  initializeMetrics() {
+    for (const metric of Object.values(metricsConfig)) {
+      this.grpcSdk.registerMetric(metric.type, metric.config);
     }
   }
 

--- a/modules/authentication/src/handlers/common.ts
+++ b/modules/authentication/src/handlers/common.ts
@@ -129,6 +129,7 @@ export class CommonHandlers implements IAuthenticationStrategy {
         ],
       };
     }
+    ConduitGrpcSdk.Metrics.decrement('logged_in_users_total');
     return 'LoggedOut';
   }
 

--- a/modules/authentication/src/handlers/common.ts
+++ b/modules/authentication/src/handlers/common.ts
@@ -129,7 +129,7 @@ export class CommonHandlers implements IAuthenticationStrategy {
         ],
       };
     }
-    ConduitGrpcSdk.Metrics.decrement('logged_in_users_total');
+    ConduitGrpcSdk.Metrics?.decrement('logged_in_users_total');
     return 'LoggedOut';
   }
 

--- a/modules/authentication/src/handlers/local.ts
+++ b/modules/authentication/src/handlers/local.ts
@@ -351,7 +351,7 @@ export class LocalHandlers implements IAuthenticationStrategy {
   }
 
   async authenticate(call: ParsedRouterRequest): Promise<UnparsedRouterResponse> {
-    ConduitGrpcSdk.Metrics.increment('login_requests_total');
+    ConduitGrpcSdk.Metrics?.increment('login_requests_total');
     let { email, password } = call.request.params;
     const context = call.request.context;
     if (isNil(context))
@@ -453,7 +453,7 @@ export class LocalHandlers implements IAuthenticationStrategy {
         setCookies: cookies,
       };
     }
-    ConduitGrpcSdk.Metrics.increment('logged_in_users_total');
+    ConduitGrpcSdk.Metrics?.increment('logged_in_users_total');
     return {
       userId: user._id.toString(),
       accessToken: accessToken!.token,

--- a/modules/authentication/src/handlers/local.ts
+++ b/modules/authentication/src/handlers/local.ts
@@ -351,6 +351,7 @@ export class LocalHandlers implements IAuthenticationStrategy {
   }
 
   async authenticate(call: ParsedRouterRequest): Promise<UnparsedRouterResponse> {
+    ConduitGrpcSdk.Metrics.increment('login_requests_total');
     let { email, password } = call.request.params;
     const context = call.request.context;
     if (isNil(context))
@@ -452,7 +453,7 @@ export class LocalHandlers implements IAuthenticationStrategy {
         setCookies: cookies,
       };
     }
-
+    ConduitGrpcSdk.Metrics.increment('logged_in_users_total');
     return {
       userId: user._id.toString(),
       accessToken: accessToken!.token,

--- a/modules/authentication/src/handlers/oauth2/OAuth2.ts
+++ b/modules/authentication/src/handlers/oauth2/OAuth2.ts
@@ -25,7 +25,8 @@ import { Config } from '../../config';
 import { OAuthRequest } from './interfaces/MakeRequest';
 
 export abstract class OAuth2<T, S extends OAuth2Settings>
-  implements IAuthenticationStrategy {
+  implements IAuthenticationStrategy
+{
   grpcSdk: ConduitGrpcSdk;
   private providerName: string;
   protected settings: S;
@@ -149,6 +150,7 @@ export abstract class OAuth2<T, S extends OAuth2Settings>
   }
 
   async authenticate(call: ParsedRouterRequest): Promise<UnparsedRouterResponse> {
+    ConduitGrpcSdk.Metrics.increment('login_requests_total');
     const payload = await this.connectWithProvider({
       accessToken: call.request.params['access_token'],
       clientId: call.request.params['clientId'],
@@ -161,6 +163,7 @@ export abstract class OAuth2<T, S extends OAuth2Settings>
       call.request.params['clientId'],
       config,
     );
+    ConduitGrpcSdk.Metrics.increment('logged_in_users_total');
     if (config.setCookies.enabled) {
       const cookieOptions = config.setCookies.options;
       const cookies: Cookie[] = [

--- a/modules/authentication/src/handlers/oauth2/OAuth2.ts
+++ b/modules/authentication/src/handlers/oauth2/OAuth2.ts
@@ -150,7 +150,7 @@ export abstract class OAuth2<T, S extends OAuth2Settings>
   }
 
   async authenticate(call: ParsedRouterRequest): Promise<UnparsedRouterResponse> {
-    ConduitGrpcSdk.Metrics.increment('login_requests_total');
+    ConduitGrpcSdk.Metrics?.increment('login_requests_total');
     const payload = await this.connectWithProvider({
       accessToken: call.request.params['access_token'],
       clientId: call.request.params['clientId'],
@@ -163,7 +163,7 @@ export abstract class OAuth2<T, S extends OAuth2Settings>
       call.request.params['clientId'],
       config,
     );
-    ConduitGrpcSdk.Metrics.increment('logged_in_users_total');
+    ConduitGrpcSdk.Metrics?.increment('logged_in_users_total');
     if (config.setCookies.enabled) {
       const cookieOptions = config.setCookies.options;
       const cookies: Cookie[] = [

--- a/modules/authentication/src/handlers/phone.ts
+++ b/modules/authentication/src/handlers/phone.ts
@@ -96,7 +96,7 @@ export class PhoneHandlers implements IAuthenticationStrategy {
   }
 
   async authenticate(call: ParsedRouterRequest): Promise<UnparsedRouterResponse> {
-    ConduitGrpcSdk.Metrics.increment('login_requests_total');
+    ConduitGrpcSdk.Metrics?.increment('login_requests_total');
     const { phone } = call.request.params;
     const context = call.request.context;
     const clientId = context.clientId;
@@ -142,7 +142,7 @@ export class PhoneHandlers implements IAuthenticationStrategy {
             .toDate(),
         });
       }
-      ConduitGrpcSdk.Metrics.increment('logged_in_users_total');
+      ConduitGrpcSdk.Metrics?.increment('logged_in_users_total');
       if (config.setCookies.enabled) {
         const cookieOptions = config.setCookies.options;
         const cookies: Cookie[] = [

--- a/modules/authentication/src/handlers/phone.ts
+++ b/modules/authentication/src/handlers/phone.ts
@@ -96,6 +96,7 @@ export class PhoneHandlers implements IAuthenticationStrategy {
   }
 
   async authenticate(call: ParsedRouterRequest): Promise<UnparsedRouterResponse> {
+    ConduitGrpcSdk.Metrics.increment('login_requests_total');
     const { phone } = call.request.params;
     const context = call.request.context;
     const clientId = context.clientId;
@@ -141,6 +142,7 @@ export class PhoneHandlers implements IAuthenticationStrategy {
             .toDate(),
         });
       }
+      ConduitGrpcSdk.Metrics.increment('logged_in_users_total');
       if (config.setCookies.enabled) {
         const cookieOptions = config.setCookies.options;
         const cookies: Cookie[] = [

--- a/modules/authentication/src/handlers/service.ts
+++ b/modules/authentication/src/handlers/service.ts
@@ -29,6 +29,7 @@ export class ServiceHandler implements IAuthenticationStrategy {
   }
 
   async authenticate(call: ParsedRouterRequest): Promise<UnparsedRouterResponse> {
+    ConduitGrpcSdk.Metrics.increment('login_requests_total');
     const { serviceName, token } = call.request.params;
 
     const context = call.request.context;
@@ -67,6 +68,7 @@ export class ServiceHandler implements IAuthenticationStrategy {
         config,
       },
     );
+    ConduitGrpcSdk.Metrics.increment('logged_in_users_total');
     if (config.setCookies.enabled) {
       const cookieOptions = config.setCookies.options;
       const cookies: Cookie[] = [

--- a/modules/authentication/src/handlers/service.ts
+++ b/modules/authentication/src/handlers/service.ts
@@ -29,7 +29,7 @@ export class ServiceHandler implements IAuthenticationStrategy {
   }
 
   async authenticate(call: ParsedRouterRequest): Promise<UnparsedRouterResponse> {
-    ConduitGrpcSdk.Metrics.increment('login_requests_total');
+    ConduitGrpcSdk.Metrics?.increment('login_requests_total');
     const { serviceName, token } = call.request.params;
 
     const context = call.request.context;
@@ -68,7 +68,7 @@ export class ServiceHandler implements IAuthenticationStrategy {
         config,
       },
     );
-    ConduitGrpcSdk.Metrics.increment('logged_in_users_total');
+    ConduitGrpcSdk.Metrics?.increment('logged_in_users_total');
     if (config.setCookies.enabled) {
       const cookieOptions = config.setCookies.options;
       const cookies: Cookie[] = [

--- a/modules/authentication/src/metrics/index.ts
+++ b/modules/authentication/src/metrics/index.ts
@@ -1,0 +1,18 @@
+import { MetricType } from '@conduitplatform/grpc-sdk';
+
+export default {
+  loginRequests: {
+    type: MetricType.Counter,
+    config: {
+      name: 'login_requests_total',
+      help: 'Tracks the total number of login requests',
+    },
+  },
+  loggedInUsers: {
+    type: MetricType.Gauge,
+    config: {
+      name: 'logged_in_users_total',
+      help: 'Tracks the total number of logged in users',
+    },
+  },
+};

--- a/modules/chat/src/Chat.ts
+++ b/modules/chat/src/Chat.ts
@@ -216,7 +216,6 @@ export default class Chat extends ManagedModule<Config> {
         readBy: [userId],
       })
       .then(() => {
-        ConduitGrpcSdk.Metrics.increment('messages_sent_total');
         return this.grpcSdk.router?.socketPush({
           event: 'message',
           receivers: [roomId],

--- a/modules/chat/src/admin/index.ts
+++ b/modules/chat/src/admin/index.ts
@@ -188,7 +188,7 @@ export class AdminHandlers {
       .catch((e: Error) => {
         throw new GrpcError(status.INTERNAL, e.message);
       });
-    ConduitGrpcSdk.Metrics.increment('chat_rooms_total');
+    ConduitGrpcSdk.Metrics?.increment('chat_rooms_total');
     return chatRoom;
   }
 
@@ -211,7 +211,7 @@ export class AdminHandlers {
       .catch((e: Error) => {
         throw new GrpcError(status.INTERNAL, e.message);
       });
-    ConduitGrpcSdk.Metrics.decrement('chat_rooms_total');
+    ConduitGrpcSdk.Metrics?.decrement('chat_rooms_total');
     return 'Done';
   }
 

--- a/modules/chat/src/admin/index.ts
+++ b/modules/chat/src/admin/index.ts
@@ -180,7 +180,7 @@ export class AdminHandlers {
       );
     }
     await this.validateUsersInput(participants);
-    return await ChatRoom.getInstance()
+    const chatRoom = await ChatRoom.getInstance()
       .create({
         name: call.request.params.name,
         participants: Array.from(new Set([...participants])),
@@ -188,6 +188,8 @@ export class AdminHandlers {
       .catch((e: Error) => {
         throw new GrpcError(status.INTERNAL, e.message);
       });
+    ConduitGrpcSdk.Metrics.increment('chat_rooms_total');
+    return chatRoom;
   }
 
   async deleteRooms(call: ParsedRouterRequest): Promise<UnparsedRouterResponse> {
@@ -209,6 +211,7 @@ export class AdminHandlers {
       .catch((e: Error) => {
         throw new GrpcError(status.INTERNAL, e.message);
       });
+    ConduitGrpcSdk.Metrics.decrement('chat_rooms_total');
     return 'Done';
   }
 

--- a/modules/chat/src/metrics/index.ts
+++ b/modules/chat/src/metrics/index.ts
@@ -1,0 +1,18 @@
+import { MetricType } from '@conduitplatform/grpc-sdk';
+
+export default {
+  chatRooms: {
+    type: MetricType.Gauge,
+    config: {
+      name: 'chat_rooms_total',
+      help: 'Tracks the total number of chat rooms',
+    },
+  },
+  messagesSent: {
+    type: MetricType.Counter,
+    config: {
+      name: 'messages_sent_total',
+      help: 'Tracks the total number of messages sent',
+    },
+  },
+};

--- a/modules/chat/src/routes/index.ts
+++ b/modules/chat/src/routes/index.ts
@@ -390,7 +390,7 @@ export class ChatRoutes {
       room: roomId,
       readBy: [user._id],
     });
-    ConduitGrpcSdk.Metrics.increment('messages_sent_total');
+    ConduitGrpcSdk.Metrics?.increment('messages_sent_total');
     return {
       event: 'message',
       receivers: [roomId],

--- a/modules/chat/src/routes/index.ts
+++ b/modules/chat/src/routes/index.ts
@@ -390,6 +390,7 @@ export class ChatRoutes {
       room: roomId,
       readBy: [user._id],
     });
+    ConduitGrpcSdk.Metrics.increment('messages_sent_total');
     return {
       event: 'message',
       receivers: [roomId],

--- a/modules/database/src/Database.ts
+++ b/modules/database/src/Database.ts
@@ -35,6 +35,7 @@ import { SchemaController } from './controllers/cms/schema.controller';
 import { CustomEndpointController } from './controllers/customEndpoints/customEndpoint.controller';
 import { status } from '@grpc/grpc-js';
 import path from 'path';
+import metricsConfig from './metrics';
 
 export default class DatabaseModule extends ManagedModule<void> {
   configSchema = undefined;
@@ -130,6 +131,12 @@ export default class DatabaseModule extends ManagedModule<void> {
     const coreHealth = (await this.grpcSdk.core.check()) as unknown as HealthCheckStatus;
     this.onCoreHealthChange(coreHealth);
     await this.grpcSdk.core.watch('');
+  }
+
+  initializeMetrics() {
+    for (const metric of Object.values(metricsConfig)) {
+      this.grpcSdk.registerMetric(metric.type, metric.config);
+    }
   }
 
   private onCoreHealthChange(state: HealthCheckStatus) {

--- a/modules/database/src/adapters/DatabaseAdapter.ts
+++ b/modules/database/src/adapters/DatabaseAdapter.ts
@@ -1,4 +1,8 @@
-import { ConduitModelOptions, ConduitSchema, GrpcError } from '@conduitplatform/grpc-sdk';
+import ConduitGrpcSdk, {
+  ConduitModelOptions,
+  ConduitSchema,
+  GrpcError,
+} from '@conduitplatform/grpc-sdk';
 import { DeclaredSchemaExtension, Schema } from '../interfaces';
 import { validateExtensionFields } from './utils/extensions';
 import { status } from '@grpc/grpc-js';
@@ -77,7 +81,13 @@ export abstract class DatabaseAdapter<T extends Schema> {
       }
       (schema as _ConduitSchema).collectionName = collectionName;
     }
-    return this._createSchemaFromAdapter(schema);
+    const createdSchema = this._createSchemaFromAdapter(schema);
+    if (!this.registeredSchemas.has(schema.name)) {
+      ConduitGrpcSdk.Metrics.increment('registered_schemas_total', 1, {
+        imported: imported ? 'true' : 'false',
+      });
+    }
+    return createdSchema;
   }
 
   protected abstract _createSchemaFromAdapter(schema: ConduitSchema): Promise<Schema>;

--- a/modules/database/src/adapters/DatabaseAdapter.ts
+++ b/modules/database/src/adapters/DatabaseAdapter.ts
@@ -83,7 +83,7 @@ export abstract class DatabaseAdapter<T extends Schema> {
     }
     const createdSchema = this._createSchemaFromAdapter(schema);
     if (!this.registeredSchemas.has(schema.name)) {
-      ConduitGrpcSdk.Metrics.increment('registered_schemas_total', 1, {
+      ConduitGrpcSdk.Metrics?.increment('registered_schemas_total', 1, {
         imported: imported ? 'true' : 'false',
       });
     }

--- a/modules/database/src/adapters/mongoose-adapter/index.ts
+++ b/modules/database/src/adapters/mongoose-adapter/index.ts
@@ -83,6 +83,9 @@ export class MongooseAdapter extends DatabaseAdapter<MongooseSchema> {
       .then(() => {
         ConduitGrpcSdk.Logger.log('Mongoose connection established successfully');
       });
+    this.mongoose.set('debug', () => {
+      ConduitGrpcSdk.Metrics.increment('database_queries_total');
+    });
   }
 
   async retrieveForeignSchemas(): Promise<void> {

--- a/modules/database/src/adapters/mongoose-adapter/index.ts
+++ b/modules/database/src/adapters/mongoose-adapter/index.ts
@@ -84,7 +84,7 @@ export class MongooseAdapter extends DatabaseAdapter<MongooseSchema> {
         ConduitGrpcSdk.Logger.log('Mongoose connection established successfully');
       });
     this.mongoose.set('debug', () => {
-      ConduitGrpcSdk.Metrics.increment('database_queries_total');
+      ConduitGrpcSdk.Metrics?.increment('database_queries_total');
     });
   }
 

--- a/modules/database/src/adapters/sequelize-adapter/SequelizeSchema.ts
+++ b/modules/database/src/adapters/sequelize-adapter/SequelizeSchema.ts
@@ -20,7 +20,7 @@ import ConduitGrpcSdk, { ConduitSchema, Indexable } from '@conduitplatform/grpc-
 
 const deepdash = require('deepdash/standalone');
 
-const incrementDBQueries = () =>
+const incrementDbQueries = () =>
   ConduitGrpcSdk.Metrics.increment('database_queries_total');
 
 export class SequelizeSchema implements SchemaAdapter<ModelCtor<any>> {
@@ -92,7 +92,7 @@ export class SequelizeSchema implements SchemaAdapter<ModelCtor<any>> {
         },
       };
     }
-    incrementDBQueries();
+    incrementDbQueries();
     this.model = sequelize.define(schema.collectionName, schema.modelSchema, {
       ...schema.modelOptions,
       freezeTableName: true,
@@ -100,7 +100,7 @@ export class SequelizeSchema implements SchemaAdapter<ModelCtor<any>> {
   }
 
   sync() {
-    incrementDBQueries();
+    incrementDbQueries();
     return this.model.sync({ alter: true });
   }
 
@@ -113,7 +113,7 @@ export class SequelizeSchema implements SchemaAdapter<ModelCtor<any>> {
     }
     parsedQuery.createdAt = new Date();
     parsedQuery.updatedAt = new Date();
-    incrementDBQueries();
+    incrementDbQueries();
     await this.createWithPopulations(parsedQuery);
     return this.model.create(parsedQuery, { raw: true });
   }
@@ -131,7 +131,7 @@ export class SequelizeSchema implements SchemaAdapter<ModelCtor<any>> {
       doc.updatedAt = date;
       await this.createWithPopulations(doc);
     }
-    incrementDBQueries();
+    incrementDbQueries();
     return this.model.bulkCreate(parsedQuery);
   }
 
@@ -154,14 +154,14 @@ export class SequelizeSchema implements SchemaAdapter<ModelCtor<any>> {
     if (!isNil(select) && select !== '') {
       options.attributes = this.parseSelect(select);
     }
-    incrementDBQueries();
+    incrementDbQueries();
     const document = await this.model.findOne(options);
 
     if (!isNil(populate) && !isNil(relations)) {
       for (const relation of populate) {
         if (this.relations.hasOwnProperty(relation)) {
           if (relations.hasOwnProperty(this.relations[relation])) {
-            incrementDBQueries();
+            incrementDbQueries();
             document[relation] = await relations[this.relations[relation]].findOne({
               _id: document[relation],
             });
@@ -214,7 +214,7 @@ export class SequelizeSchema implements SchemaAdapter<ModelCtor<any>> {
           if (this.relations.hasOwnProperty(relation)) {
             if (relations.hasOwnProperty(this.relations[relation])) {
               if (!cache.hasOwnProperty(document[relation])) {
-                incrementDBQueries();
+                incrementDbQueries();
                 cache[document[relation]] = await relations[
                   this.relations[relation]
                 ].findOne({ _id: document[relation] });
@@ -236,7 +236,7 @@ export class SequelizeSchema implements SchemaAdapter<ModelCtor<any>> {
     } else {
       parsedQuery = query;
     }
-    incrementDBQueries();
+    incrementDbQueries();
     return this.model.destroy({ where: parseQuery(parsedQuery), limit: 1 });
   }
 
@@ -247,7 +247,7 @@ export class SequelizeSchema implements SchemaAdapter<ModelCtor<any>> {
     } else {
       parsedQuery = query;
     }
-    incrementDBQueries();
+    incrementDbQueries();
     return this.model.destroy({ where: parseQuery(parsedQuery) });
   }
 
@@ -265,7 +265,7 @@ export class SequelizeSchema implements SchemaAdapter<ModelCtor<any>> {
       parsedQuery = query;
     }
     if (parsedQuery.hasOwnProperty('$inc')) {
-      incrementDBQueries();
+      incrementDbQueries();
       await this.model.increment(parsedQuery['$inc'], { where: { _id: id } }).catch(e => {
         ConduitGrpcSdk.Logger.error(e);
       });
@@ -281,7 +281,7 @@ export class SequelizeSchema implements SchemaAdapter<ModelCtor<any>> {
       }
     } else if (parsedQuery.hasOwnProperty('$set')) {
       parsedQuery = parsedQuery['$set'];
-      incrementDBQueries();
+      incrementDbQueries();
       const record = await this.model.findByPk(id, { raw: true }).catch(e => {
         ConduitGrpcSdk.Logger.error(e);
       });
@@ -292,7 +292,7 @@ export class SequelizeSchema implements SchemaAdapter<ModelCtor<any>> {
 
     if (parsedQuery.hasOwnProperty('$push')) {
       for (const key in parsedQuery['$push']) {
-        incrementDBQueries();
+        incrementDbQueries();
         await this.model
           .update(
             {
@@ -321,7 +321,7 @@ export class SequelizeSchema implements SchemaAdapter<ModelCtor<any>> {
           dbDocument[key].splice(ind, 1);
         }
       }
-      incrementDBQueries();
+      incrementDbQueries();
       await this.model.update(parsedQuery, { where: { _id: id } }).catch(e => {
         ConduitGrpcSdk.Logger.error(e);
       });
@@ -329,7 +329,7 @@ export class SequelizeSchema implements SchemaAdapter<ModelCtor<any>> {
     }
 
     parsedQuery.updatedAt = new Date();
-    incrementDBQueries();
+    incrementDbQueries();
     await this.createWithPopulations(parsedQuery);
     const document = (await this.model.upsert({ _id: id, ...parsedQuery }))[0];
     if (!isNil(populate) && !isNil(relations)) {
@@ -338,7 +338,7 @@ export class SequelizeSchema implements SchemaAdapter<ModelCtor<any>> {
         if (this.relations.hasOwnProperty(relation)) {
           if (relations.hasOwnProperty(this.relations[relation])) {
             if (!cache.hasOwnProperty(document[relation])) {
-              incrementDBQueries();
+              incrementDbQueries();
               cache[document[relation]] = await relations[
                 this.relations[relation]
               ].findOne({ _id: document[relation] });
@@ -371,11 +371,11 @@ export class SequelizeSchema implements SchemaAdapter<ModelCtor<any>> {
     }
 
     parsedFilter = parseQuery(parsedFilter);
-    incrementDBQueries();
+    incrementDbQueries();
     if (query.hasOwnProperty('$inc')) {
       await this.model
         // @ts-ignore
-        ?.increment(parsedQuery['$inc'] as any, { where: parsedFilter })
+        .increment(parsedQuery['$inc'] as any, { where: parsedFilter })
         .catch(e => {
           ConduitGrpcSdk.Logger.error(e);
         });
@@ -383,7 +383,7 @@ export class SequelizeSchema implements SchemaAdapter<ModelCtor<any>> {
     }
 
     if (updateProvidedOnly) {
-      incrementDBQueries();
+      incrementDbQueries();
       const record = await this.model
         // @ts-ignore
         .findOne({ where: parsedFilter, raw: true })
@@ -397,7 +397,7 @@ export class SequelizeSchema implements SchemaAdapter<ModelCtor<any>> {
 
     if (parsedQuery.hasOwnProperty('$push')) {
       for (const key in parsedQuery['$push']) {
-        incrementDBQueries();
+        incrementDbQueries();
         await this.model
           .update(
             {
@@ -428,7 +428,7 @@ export class SequelizeSchema implements SchemaAdapter<ModelCtor<any>> {
             document[key].splice(ind, 1);
           }
         }
-        incrementDBQueries();
+        incrementDbQueries();
         // @ts-ignore
         await this.model.update(document, { where: parsedFilter }).catch(e => {
           ConduitGrpcSdk.Logger.error(e);
@@ -437,7 +437,7 @@ export class SequelizeSchema implements SchemaAdapter<ModelCtor<any>> {
       delete parsedQuery['$pull'];
     }
 
-    incrementDBQueries();
+    incrementDbQueries();
     parsedQuery.updatedAt = new Date();
     await this.createWithPopulations(parsedQuery);
     // @ts-ignore
@@ -451,12 +451,12 @@ export class SequelizeSchema implements SchemaAdapter<ModelCtor<any>> {
     } else {
       parsedQuery = query;
     }
-    incrementDBQueries();
+    incrementDbQueries();
     return this.model.count({ where: parseQuery(parsedQuery) });
   }
 
   private async createWithPopulations(document: ParsedQuery) {
-    incrementDBQueries();
+    incrementDbQueries();
     return createWithPopulations(this.originalSchema.fields, document, this.adapter);
   }
 

--- a/modules/database/src/adapters/sequelize-adapter/SequelizeSchema.ts
+++ b/modules/database/src/adapters/sequelize-adapter/SequelizeSchema.ts
@@ -266,11 +266,9 @@ export class SequelizeSchema implements SchemaAdapter<ModelCtor<any>> {
     }
     if (parsedQuery.hasOwnProperty('$inc')) {
       incrementDBQueries();
-      await this.model
-        ?.increment(parsedQuery['$inc'], { where: { _id: id } })
-        .catch(e => {
-          ConduitGrpcSdk.Logger.error(e);
-        });
+      await this.model.increment(parsedQuery['$inc'], { where: { _id: id } }).catch(e => {
+        ConduitGrpcSdk.Logger.error(e);
+      });
       delete parsedQuery['$inc'];
     }
 

--- a/modules/database/src/adapters/sequelize-adapter/SequelizeSchema.ts
+++ b/modules/database/src/adapters/sequelize-adapter/SequelizeSchema.ts
@@ -256,9 +256,11 @@ export class SequelizeSchema implements SchemaAdapter<ModelCtor<any>> {
       parsedQuery = query;
     }
     if (parsedQuery.hasOwnProperty('$inc')) {
-      await this.model.increment(parsedQuery['$inc'], { where: { _id: id } }).catch(e => {
-        ConduitGrpcSdk.Logger.error(e);
-      });
+      await this.model
+        ?.increment(parsedQuery['$inc'], { where: { _id: id } })
+        .catch(e => {
+          ConduitGrpcSdk.Logger.error(e);
+        });
       delete parsedQuery['$inc'];
     }
 
@@ -359,7 +361,7 @@ export class SequelizeSchema implements SchemaAdapter<ModelCtor<any>> {
     if (query.hasOwnProperty('$inc')) {
       await this.model
         // @ts-ignore
-        .increment(parsedQuery['$inc'] as any, { where: parsedFilter })
+        ?.increment(parsedQuery['$inc'] as any, { where: parsedFilter })
         .catch(e => {
           ConduitGrpcSdk.Logger.error(e);
         });

--- a/modules/database/src/admin/customEndpoints/customEndpoints.admin.ts
+++ b/modules/database/src/admin/customEndpoints/customEndpoints.admin.ts
@@ -387,6 +387,7 @@ export class CustomEndpointsAdmin {
         throw new GrpcError(status.INTERNAL, e.message);
       });
     this.customEndpointController.refreshEndpoints();
+    ConduitGrpcSdk.Metrics.decrement('custom_endpoints_total');
     return 'Custom Endpoint deleted';
   }
 

--- a/modules/database/src/admin/customEndpoints/customEndpoints.admin.ts
+++ b/modules/database/src/admin/customEndpoints/customEndpoints.admin.ts
@@ -387,7 +387,7 @@ export class CustomEndpointsAdmin {
         throw new GrpcError(status.INTERNAL, e.message);
       });
     this.customEndpointController.refreshEndpoints();
-    ConduitGrpcSdk.Metrics.decrement('custom_endpoints_total');
+    ConduitGrpcSdk.Metrics?.decrement('custom_endpoints_total');
     return 'Custom Endpoint deleted';
   }
 

--- a/modules/database/src/controllers/customEndpoints/utils.ts
+++ b/modules/database/src/controllers/customEndpoints/utils.ts
@@ -1,4 +1,4 @@
-import {
+import ConduitGrpcSdk, {
   ConduitRouteActions,
   RequestHandlers,
   RouteBuilder,
@@ -129,5 +129,6 @@ export function createCustomEndpointRoute(
     }
   }
   route.return(getOperation(endpoint.operation) + endpoint.name, returns);
+  ConduitGrpcSdk.Metrics.increment('custom_endpoints_total');
   return route.build();
 }

--- a/modules/database/src/controllers/customEndpoints/utils.ts
+++ b/modules/database/src/controllers/customEndpoints/utils.ts
@@ -129,6 +129,6 @@ export function createCustomEndpointRoute(
     }
   }
   route.return(getOperation(endpoint.operation) + endpoint.name, returns);
-  ConduitGrpcSdk.Metrics.increment('custom_endpoints_total');
+  ConduitGrpcSdk.Metrics?.increment('custom_endpoints_total');
   return route.build();
 }

--- a/modules/database/src/metrics/index.ts
+++ b/modules/database/src/metrics/index.ts
@@ -1,0 +1,34 @@
+import { MetricType } from '@conduitplatform/grpc-sdk';
+
+export default {
+  databaseQueries: {
+    type: MetricType.Counter,
+    config: {
+      name: 'database_queries_total',
+      help: 'Tracks the total number of database queries',
+    },
+  },
+  databaseQueryErrors: {
+    //TODO: create global query error handler to track this
+    type: MetricType.Counter,
+    config: {
+      name: 'database_query_errors_total',
+      help: 'Tracks the total number of database query errors',
+    },
+  },
+  registeredSchemas: {
+    type: MetricType.Counter,
+    config: {
+      name: 'registered_schemas_total',
+      help: 'Tracks the total number of registered schemas',
+      labelNames: ['imported'],
+    },
+  },
+  customEndpoints: {
+    type: MetricType.Gauge,
+    config: {
+      name: 'custom_endpoints_total',
+      help: 'Tracks the total number of custom endpoints',
+    },
+  },
+};

--- a/modules/database/src/metrics/index.ts
+++ b/modules/database/src/metrics/index.ts
@@ -8,14 +8,14 @@ export default {
       help: 'Tracks the total number of database queries',
     },
   },
-  databaseQueryErrors: {
-    //TODO: create global query error handler to track this
-    type: MetricType.Counter,
-    config: {
-      name: 'database_query_errors_total',
-      help: 'Tracks the total number of database query errors',
-    },
-  },
+  // databaseQueryErrors: {
+  //   //TODO: create global query error handler to track this
+  //   type: MetricType.Counter,
+  //   config: {
+  //     name: 'database_query_errors_total',
+  //     help: 'Tracks the total number of database query errors',
+  //   },
+  // },
   registeredSchemas: {
     type: MetricType.Counter,
     config: {

--- a/modules/email/src/Email.ts
+++ b/modules/email/src/Email.ts
@@ -22,6 +22,7 @@ import {
   SendEmailRequest,
   SendEmailResponse,
 } from './protoTypes/email';
+import metricsConfig from './metrics';
 
 export default class Email extends ManagedModule<Config> {
   configSchema = AppConfigSchema;
@@ -57,6 +58,12 @@ export default class Email extends ManagedModule<Config> {
       return this.database.createSchemaFromAdapter(modelInstance);
     });
     return Promise.all(promises);
+  }
+
+  initializeMetrics() {
+    for (const metric of Object.values(metricsConfig)) {
+      this.grpcSdk.registerMetric(metric.type, metric.config);
+    }
   }
 
   async preConfig(config: Config) {

--- a/modules/email/src/admin/index.ts
+++ b/modules/email/src/admin/index.ts
@@ -384,7 +384,10 @@ export class AdminHandlers {
       .catch((e: Error) => {
         throw new GrpcError(status.INTERNAL, e.message);
       });
-
+    ConduitGrpcSdk.Metrics.decrement(
+      'email_templates_total',
+      deletedDocuments.deletedCount,
+    );
     return { deletedDocuments };
   }
 

--- a/modules/email/src/admin/index.ts
+++ b/modules/email/src/admin/index.ts
@@ -271,7 +271,7 @@ export class AdminHandlers {
       .catch((e: Error) => {
         throw new GrpcError(status.INTERNAL, e.message);
       });
-
+    ConduitGrpcSdk.Metrics.increment('email_templates_total');
     return { template: newTemplate };
   }
 
@@ -331,7 +331,7 @@ export class AdminHandlers {
     const templateDocument = await EmailTemplate.getInstance().findOne({
       _id: call.request.params.id,
     });
-    if (!isNil(templateDocument)) {
+    if (isNil(templateDocument)) {
       throw new GrpcError(status.NOT_FOUND, 'Template does not exist');
     }
 
@@ -348,7 +348,7 @@ export class AdminHandlers {
           throw new GrpcError(status.INTERNAL, e.message);
         });
     }
-
+    ConduitGrpcSdk.Metrics.decrement('email_templates_total');
     return { deleted };
   }
 
@@ -507,7 +507,7 @@ export class AdminHandlers {
         }
         throw new GrpcError(status.INTERNAL, e.message);
       });
-
+    ConduitGrpcSdk.Metrics.increment('emails_sent_total');
     return { message: 'Email sent' };
   }
 }

--- a/modules/email/src/admin/index.ts
+++ b/modules/email/src/admin/index.ts
@@ -271,7 +271,7 @@ export class AdminHandlers {
       .catch((e: Error) => {
         throw new GrpcError(status.INTERNAL, e.message);
       });
-    ConduitGrpcSdk.Metrics.increment('email_templates_total');
+    ConduitGrpcSdk.Metrics?.increment('email_templates_total');
     return { template: newTemplate };
   }
 
@@ -348,7 +348,7 @@ export class AdminHandlers {
           throw new GrpcError(status.INTERNAL, e.message);
         });
     }
-    ConduitGrpcSdk.Metrics.decrement('email_templates_total');
+    ConduitGrpcSdk.Metrics?.decrement('email_templates_total');
     return { deleted };
   }
 
@@ -384,7 +384,7 @@ export class AdminHandlers {
       .catch((e: Error) => {
         throw new GrpcError(status.INTERNAL, e.message);
       });
-    ConduitGrpcSdk.Metrics.decrement(
+    ConduitGrpcSdk.Metrics?.decrement(
       'email_templates_total',
       deletedDocuments.deletedCount,
     );
@@ -510,7 +510,7 @@ export class AdminHandlers {
         }
         throw new GrpcError(status.INTERNAL, e.message);
       });
-    ConduitGrpcSdk.Metrics.increment('emails_sent_total');
+    ConduitGrpcSdk.Metrics?.increment('emails_sent_total');
     return { message: 'Email sent' };
   }
 }

--- a/modules/email/src/metrics/index.ts
+++ b/modules/email/src/metrics/index.ts
@@ -1,0 +1,11 @@
+import { MetricType } from '@conduitplatform/grpc-sdk';
+
+export default {
+  emailTemplates: {
+    type: MetricType.Gauge,
+    config: {
+      name: 'email_templates_total',
+      help: 'Tracks the total number of email templates',
+    },
+  },
+};

--- a/modules/email/src/metrics/index.ts
+++ b/modules/email/src/metrics/index.ts
@@ -8,4 +8,11 @@ export default {
       help: 'Tracks the total number of email templates',
     },
   },
+  emailsSent: {
+    type: MetricType.Counter,
+    config: {
+      name: 'emails_sent_total',
+      help: 'Tracks the total number of emails sent',
+    },
+  },
 };

--- a/modules/forms/src/Forms.ts
+++ b/modules/forms/src/Forms.ts
@@ -12,6 +12,7 @@ import { FormsController } from './controllers/forms.controller';
 import * as models from './models';
 import path from 'path';
 import { runMigrations } from './migrations';
+import metricsConfig from './metrics';
 
 export default class Forms extends ManagedModule<Config> {
   configSchema = AppConfigSchema;
@@ -44,6 +45,12 @@ export default class Forms extends ManagedModule<Config> {
         this.updateHealth(HealthCheckStatus.NOT_SERVING);
       }
     });
+  }
+
+  initializeMetrics() {
+    for (const metric of Object.values(metricsConfig)) {
+      this.grpcSdk.registerMetric(metric.type, metric.config);
+    }
   }
 
   async onRegister() {

--- a/modules/forms/src/admin/index.ts
+++ b/modules/forms/src/admin/index.ts
@@ -194,7 +194,7 @@ export class AdminHandlers {
       });
 
     this.formsController.refreshRoutes();
-    ConduitGrpcSdk.Metrics.increment('forms_total');
+    ConduitGrpcSdk.Metrics?.increment('forms_total');
     return 'Ok';
   }
 
@@ -241,7 +241,7 @@ export class AdminHandlers {
         throw new GrpcError(status.INTERNAL, e.message);
       });
     const totalCount = forms.deletedCount;
-    ConduitGrpcSdk.Metrics.decrement('forms_total', totalCount);
+    ConduitGrpcSdk.Metrics?.decrement('forms_total', totalCount);
     return { forms, totalCount };
   }
 

--- a/modules/forms/src/admin/index.ts
+++ b/modules/forms/src/admin/index.ts
@@ -194,6 +194,7 @@ export class AdminHandlers {
       });
 
     this.formsController.refreshRoutes();
+    ConduitGrpcSdk.Metrics.increment('forms_total');
     return 'Ok';
   }
 
@@ -239,7 +240,9 @@ export class AdminHandlers {
       .catch(e => {
         throw new GrpcError(status.INTERNAL, e.message);
       });
-    return { forms, count: forms.deletedCount };
+    const totalCount = forms.deletedCount;
+    ConduitGrpcSdk.Metrics.decrement('forms_total', totalCount);
+    return { forms, totalCount };
   }
 
   async getFormReplies(call: ParsedRouterRequest): Promise<UnparsedRouterResponse> {

--- a/modules/forms/src/metrics/index.ts
+++ b/modules/forms/src/metrics/index.ts
@@ -1,0 +1,11 @@
+import { MetricType } from '@conduitplatform/grpc-sdk';
+
+export default {
+  formsCreated: {
+    type: MetricType.Gauge,
+    config: {
+      name: 'forms_total',
+      help: 'Tracks the total number of forms created',
+    },
+  },
+};

--- a/modules/push-notifications/src/PushNotifications.ts
+++ b/modules/push-notifications/src/PushNotifications.ts
@@ -24,6 +24,7 @@ import { isNil } from 'lodash';
 import { status } from '@grpc/grpc-js';
 import { ISendNotification } from './interfaces/ISendNotification';
 import { runMigrations } from './migrations';
+import metricsConfig from './metrics';
 
 export default class PushNotifications extends ManagedModule<Config> {
   configSchema = AppConfigSchema;
@@ -59,6 +60,12 @@ export default class PushNotifications extends ManagedModule<Config> {
         this.updateHealth(HealthCheckStatus.NOT_SERVING);
       }
     });
+  }
+
+  initializeMetrics() {
+    for (const metric of Object.values(metricsConfig)) {
+      this.grpcSdk.registerMetric(metric.type, metric.config);
+    }
   }
 
   async onConfig() {

--- a/modules/push-notifications/src/admin/index.ts
+++ b/modules/push-notifications/src/admin/index.ts
@@ -112,7 +112,7 @@ export class AdminHandlers {
     await this.provider.sendToDevice(params).catch(e => {
       throw new GrpcError(status.INTERNAL, e.message);
     });
-    ConduitGrpcSdk.Metrics.increment('push_notifications_sent_total', 1, {
+    ConduitGrpcSdk.Metrics?.increment('push_notifications_sent_total', 1, {
       devices_count: 1,
     });
     return 'Ok';
@@ -142,7 +142,7 @@ export class AdminHandlers {
     await this.provider.sendToManyDevices(params).catch(e => {
       throw new GrpcError(status.INTERNAL, e.message);
     });
-    ConduitGrpcSdk.Metrics.increment('push_notifications_sent_total', 1, {
+    ConduitGrpcSdk.Metrics?.increment('push_notifications_sent_total', 1, {
       devices_count: call.request.params.userIds.length,
     });
     return 'Ok';

--- a/modules/push-notifications/src/admin/index.ts
+++ b/modules/push-notifications/src/admin/index.ts
@@ -112,6 +112,9 @@ export class AdminHandlers {
     await this.provider.sendToDevice(params).catch(e => {
       throw new GrpcError(status.INTERNAL, e.message);
     });
+    ConduitGrpcSdk.Metrics.increment('push_notifications_sent_total', 1, {
+      devices_count: 1,
+    });
     return 'Ok';
   }
 
@@ -138,6 +141,9 @@ export class AdminHandlers {
     };
     await this.provider.sendToManyDevices(params).catch(e => {
       throw new GrpcError(status.INTERNAL, e.message);
+    });
+    ConduitGrpcSdk.Metrics.increment('push_notifications_sent_total', 1, {
+      devices_count: call.request.params.userIds.length,
     });
     return 'Ok';
   }

--- a/modules/push-notifications/src/metrics/index.ts
+++ b/modules/push-notifications/src/metrics/index.ts
@@ -1,0 +1,12 @@
+import { MetricType } from '@conduitplatform/grpc-sdk';
+
+export default {
+  pushNotifications: {
+    type: MetricType.Counter,
+    config: {
+      name: 'push_notifications_sent_total',
+      help: 'Tracks the total number of push notifications sent',
+      labelNames: ['devices_count'],
+    },
+  },
+};

--- a/modules/router/src/Router.ts
+++ b/modules/router/src/Router.ts
@@ -33,6 +33,7 @@ import {
   SocketData,
 } from './protoTypes/router';
 import * as adminRoutes from './admin/routes';
+import metricsConfig from './metrics';
 
 const swaggerRouterMetadata: SwaggerRouterMetadata = {
   urlPrefix: '',
@@ -128,6 +129,12 @@ export default class ConduitDefaultRouter extends ManagedModule<Config> {
     await this.registerSchemas();
     this.adminRouter = new AdminHandlers(this.grpcServer, this.grpcSdk, this);
     this._security = new SecurityModule(this.grpcSdk, this);
+  }
+
+  initializeMetrics() {
+    for (const metric of Object.values(metricsConfig)) {
+      this.grpcSdk.registerMetric(metric.type, metric.config);
+    }
   }
 
   protected registerSchemas() {

--- a/modules/router/src/admin/security.ts
+++ b/modules/router/src/admin/security.ts
@@ -75,6 +75,7 @@ export class SecurityAdmin {
       alias,
       notes,
     });
+    ConduitGrpcSdk.Metrics.increment('security_clients_total');
     return { ...client, clientSecret };
   }
 
@@ -82,6 +83,7 @@ export class SecurityAdmin {
     await Client.getInstance().deleteOne({
       _id: call.request.params!.id,
     });
+    ConduitGrpcSdk.Metrics.decrement('security_clients_total');
     return { message: 'Client deleted' };
   }
 

--- a/modules/router/src/admin/security.ts
+++ b/modules/router/src/admin/security.ts
@@ -75,7 +75,7 @@ export class SecurityAdmin {
       alias,
       notes,
     });
-    ConduitGrpcSdk.Metrics.increment('security_clients_total', 1, {
+    ConduitGrpcSdk.Metrics?.increment('security_clients_total', 1, {
       platform: platform.toLowerCase(),
     });
     return { ...client, clientSecret };
@@ -85,7 +85,7 @@ export class SecurityAdmin {
     await Client.getInstance().deleteOne({
       _id: call.request.params!.id,
     });
-    ConduitGrpcSdk.Metrics.decrement('security_clients_total');
+    ConduitGrpcSdk.Metrics?.decrement('security_clients_total');
     return { message: 'Client deleted' };
   }
 

--- a/modules/router/src/admin/security.ts
+++ b/modules/router/src/admin/security.ts
@@ -75,7 +75,9 @@ export class SecurityAdmin {
       alias,
       notes,
     });
-    ConduitGrpcSdk.Metrics.increment('security_clients_total');
+    ConduitGrpcSdk.Metrics.increment('security_clients_total', 1, {
+      platform: platform.toLowerCase(),
+    });
     return { ...client, clientSecret };
   }
 

--- a/modules/router/src/metrics/index.ts
+++ b/modules/router/src/metrics/index.ts
@@ -13,6 +13,7 @@ export default {
     config: {
       name: 'security_clients_total',
       help: 'Tracks the total number of security clients',
+      labelNames: ['platform'],
     },
   },
 };

--- a/modules/router/src/metrics/index.ts
+++ b/modules/router/src/metrics/index.ts
@@ -1,0 +1,18 @@
+import { MetricType } from '@conduitplatform/grpc-sdk';
+
+export default {
+  registeredRoutes: {
+    type: MetricType.Counter,
+    config: {
+      name: 'registered_routes_total',
+      help: 'Tracks the total number of registered routes',
+    },
+  },
+  securityClients: {
+    type: MetricType.Gauge,
+    config: {
+      name: 'security_clients_total',
+      help: 'Tracks the total number of security clients',
+    },
+  },
+};

--- a/modules/sms/src/Sms.ts
+++ b/modules/sms/src/Sms.ts
@@ -20,6 +20,7 @@ import {
   VerifyRequest,
   VerifyResponse,
 } from './protoTypes/sms';
+import metricsConfig from './metrics';
 
 export default class Sms extends ManagedModule<Config> {
   configSchema = AppConfigSchema;
@@ -44,6 +45,12 @@ export default class Sms extends ManagedModule<Config> {
 
   async onServerStart() {
     this.adminRouter = new AdminHandlers(this.grpcServer, this.grpcSdk, this._provider);
+  }
+
+  initializeMetrics() {
+    for (const metric of Object.values(metricsConfig)) {
+      this.grpcSdk.registerMetric(metric.type, metric.config);
+    }
   }
 
   async preConfig(config: any) {

--- a/modules/sms/src/admin/index.ts
+++ b/modules/sms/src/admin/index.ts
@@ -70,7 +70,7 @@ export class AdminHandlers {
     if (!isNil(errorMessage)) {
       throw new GrpcError(status.INTERNAL, errorMessage);
     }
-    ConduitGrpcSdk.Metrics.increment('sms_sent_total');
+    ConduitGrpcSdk.Metrics?.increment('sms_sent_total');
     return 'SMS sent';
   }
 }

--- a/modules/sms/src/admin/index.ts
+++ b/modules/sms/src/admin/index.ts
@@ -70,7 +70,7 @@ export class AdminHandlers {
     if (!isNil(errorMessage)) {
       throw new GrpcError(status.INTERNAL, errorMessage);
     }
-
+    ConduitGrpcSdk.Metrics.increment('sms_sent_total');
     return 'SMS sent';
   }
 }

--- a/modules/sms/src/metrics/index.ts
+++ b/modules/sms/src/metrics/index.ts
@@ -1,0 +1,11 @@
+import { MetricType } from '@conduitplatform/grpc-sdk';
+
+export default {
+  smsSent: {
+    type: MetricType.Counter,
+    config: {
+      name: 'sms_sent_total',
+      help: 'Tracks the total number of sms sent',
+    },
+  },
+};

--- a/modules/storage/src/Storage.ts
+++ b/modules/storage/src/Storage.ts
@@ -1,29 +1,27 @@
 import ConduitGrpcSdk, {
-  ManagedModule,
-  DatabaseProvider,
   ConfigController,
-  HealthCheckStatus,
+  DatabaseProvider,
   GrpcCallback,
+  HealthCheckStatus,
+  ManagedModule,
   ParsedRouterRequest,
 } from '@conduitplatform/grpc-sdk';
 import AppConfigSchema, { Config } from './config';
 import { AdminRoutes } from './admin';
 import { FileHandlers } from './handlers/file';
 import { StorageRoutes } from './routes';
-import { createStorageProvider, IStorageProvider } from './storage-provider';
 import * as models from './models';
 import path from 'path';
 import { status } from '@grpc/grpc-js';
-import { isNil } from 'lodash';
-import { isEmpty } from 'lodash';
+import { isEmpty, isNil } from 'lodash';
 import { runMigrations } from './migrations';
 import { FileResponse, GetFileDataResponse } from './protoTypes/storage';
 import metricsConfig from './metrics';
-
-type Callback = (arg1: { code: number; message: string }) => void;
 import { IStorageProvider } from './interfaces';
 import { createStorageProvider } from './providers';
 import { getAwsAccountId } from './utils';
+
+type Callback = (arg1: { code: number; message: string }) => void;
 
 export default class Storage extends ManagedModule<Config> {
   configSchema = AppConfigSchema;

--- a/modules/storage/src/metrics/index.ts
+++ b/modules/storage/src/metrics/index.ts
@@ -1,0 +1,32 @@
+import { MetricType } from '@conduitplatform/grpc-sdk';
+
+export default {
+  containers: {
+    type: MetricType.Gauge,
+    config: {
+      name: 'containers_total',
+      help: 'Tracks the total number of containers',
+    },
+  },
+  folders: {
+    type: MetricType.Gauge,
+    config: {
+      name: 'folders_total',
+      help: 'Tracks the total number of folders',
+    },
+  },
+  files: {
+    type: MetricType.Gauge,
+    config: {
+      name: 'files_total',
+      help: 'Tracks the total number of files',
+    },
+  },
+  storageSize: {
+    type: MetricType.Gauge,
+    config: {
+      name: 'storage_size_bytes_total',
+      help: 'Tracks the cumulative size of all files in bytes',
+    },
+  },
+};

--- a/modules/storage/src/models/File.schema.ts
+++ b/modules/storage/src/models/File.schema.ts
@@ -14,6 +14,10 @@ const schema = {
     type: TYPE.String,
     required: true,
   },
+  size: {
+    type: TYPE.Number,
+    required: true,
+  },
   isPublic: {
     type: TYPE.Boolean,
     default: false,
@@ -42,6 +46,7 @@ export class File extends ConduitActiveSchema<File> {
   name!: string;
   folder!: string;
   container!: string;
+  size!: number;
   isPublic?: boolean;
   url!: string;
   mimeType!: string;

--- a/modules/storage/src/providers/aliyun/index.ts
+++ b/modules/storage/src/providers/aliyun/index.ts
@@ -37,7 +37,7 @@ export class AliyunStorage implements IStorageProvider {
   async createContainer(name: string): Promise<boolean | Error> {
     await this._ossClient.putBucket(name);
     this.container(name);
-    ConduitGrpcSdk.Metrics.increment('containers_total');
+    ConduitGrpcSdk.Metrics?.increment('containers_total');
     return true;
   }
 
@@ -49,13 +49,13 @@ export class AliyunStorage implements IStorageProvider {
 
   async deleteContainer(name: string): Promise<boolean | Error> {
     await this._ossClient.deleteBucket(name);
-    ConduitGrpcSdk.Metrics.decrement('containers_total');
+    ConduitGrpcSdk.Metrics?.decrement('containers_total');
     return true;
   }
 
   async createFolder(name: string): Promise<boolean | Error> {
     await this._ossClient.put(name, Buffer.from(''));
-    ConduitGrpcSdk.Metrics.increment('folders_total');
+    ConduitGrpcSdk.Metrics?.increment('folders_total');
     return true;
   }
 
@@ -83,7 +83,7 @@ export class AliyunStorage implements IStorageProvider {
         },
       );
     } while (mark);
-    ConduitGrpcSdk.Metrics.decrement('folders_total');
+    ConduitGrpcSdk.Metrics?.decrement('folders_total');
     return true;
   }
 
@@ -97,15 +97,15 @@ export class AliyunStorage implements IStorageProvider {
         'x-oss-object-acl': isPublic ? 'public-read' : 'private',
       },
     });
-    ConduitGrpcSdk.Metrics.increment('files_total');
-    ConduitGrpcSdk.Metrics.increment('storage_size_bytes_total', data.byteLength);
+    ConduitGrpcSdk.Metrics?.increment('files_total');
+    ConduitGrpcSdk.Metrics?.increment('storage_size_bytes_total', data.byteLength);
     return true;
   }
 
   async delete(fileName: string): Promise<boolean | Error> {
     await this._ossClient.delete(fileName);
-    ConduitGrpcSdk.Metrics.decrement('files_total');
-    // ConduitGrpcSdk.Metrics.decrement('storage_size_bytes_total', fileSize); TODO: get file size from oss client
+    ConduitGrpcSdk.Metrics?.decrement('files_total');
+    // ConduitGrpcSdk.Metrics?.decrement('storage_size_bytes_total', fileSize); TODO: get file size from oss client
     return true;
   }
 

--- a/modules/storage/src/providers/aliyun/index.ts
+++ b/modules/storage/src/providers/aliyun/index.ts
@@ -97,15 +97,12 @@ export class AliyunStorage implements IStorageProvider {
         'x-oss-object-acl': isPublic ? 'public-read' : 'private',
       },
     });
-    ConduitGrpcSdk.Metrics?.increment('files_total');
-    ConduitGrpcSdk.Metrics?.increment('storage_size_bytes_total', data.byteLength);
     return true;
   }
 
   async delete(fileName: string): Promise<boolean | Error> {
     await this._ossClient.delete(fileName);
     ConduitGrpcSdk.Metrics?.decrement('files_total');
-    // ConduitGrpcSdk.Metrics?.decrement('storage_size_bytes_total', fileSize); TODO: get file size from oss client
     return true;
   }
 

--- a/modules/storage/src/providers/aws/index.ts
+++ b/modules/storage/src/providers/aws/index.ts
@@ -54,8 +54,6 @@ export class AWSS3Storage implements IStorageProvider {
           : undefined,
       }),
     );
-    ConduitGrpcSdk.Metrics?.increment('files_total');
-    ConduitGrpcSdk.Metrics?.increment('storage_size_bytes_total', data.byteLength);
     return true;
   }
 
@@ -169,26 +167,12 @@ export class AWSS3Storage implements IStorageProvider {
   }
 
   async delete(fileName: string): Promise<boolean | Error> {
-    let fileSize = 0;
-    try {
-      fileSize = (
-        (await this._storage.send(
-          new HeadObjectCommand({
-            Bucket: this._activeContainer,
-            Key: fileName,
-          }),
-        )) as any
-      ).ContentLength;
-      console.log(fileSize);
-    } catch (e) {}
     await this._storage.send(
       new DeleteObjectCommand({
         Bucket: this._activeContainer,
         Key: fileName,
       }),
     );
-    ConduitGrpcSdk.Metrics?.increment('files_total');
-    ConduitGrpcSdk.Metrics?.increment('storage_size_bytes_total', fileSize);
     return true;
   }
 

--- a/modules/storage/src/providers/aws/index.ts
+++ b/modules/storage/src/providers/aws/index.ts
@@ -54,8 +54,8 @@ export class AWSS3Storage implements IStorageProvider {
           : undefined,
       }),
     );
-    ConduitGrpcSdk.Metrics.increment('files_total');
-    ConduitGrpcSdk.Metrics.increment('storage_size_bytes_total', data.byteLength);
+    ConduitGrpcSdk.Metrics?.increment('files_total');
+    ConduitGrpcSdk.Metrics?.increment('storage_size_bytes_total', data.byteLength);
     return true;
   }
 
@@ -86,7 +86,7 @@ export class AWSS3Storage implements IStorageProvider {
         Body: 'DO NOT DELETE',
       }),
     );
-    ConduitGrpcSdk.Metrics.increment('folders_total');
+    ConduitGrpcSdk.Metrics?.increment('folders_total');
     return true;
   }
 
@@ -118,7 +118,7 @@ export class AWSS3Storage implements IStorageProvider {
       }),
     );
     this._activeContainer = name;
-    ConduitGrpcSdk.Metrics.increment('containers_total');
+    ConduitGrpcSdk.Metrics?.increment('containers_total');
     return true;
   }
 
@@ -145,7 +145,7 @@ export class AWSS3Storage implements IStorageProvider {
         Bucket: name,
       }),
     );
-    ConduitGrpcSdk.Metrics.decrement('containers_total');
+    ConduitGrpcSdk.Metrics?.decrement('containers_total');
     return true;
   }
 
@@ -164,7 +164,7 @@ export class AWSS3Storage implements IStorageProvider {
       ConduitGrpcSdk.Logger.log(file.Key!);
     }
     ConduitGrpcSdk.Logger.log(`${i} files deleted.`);
-    ConduitGrpcSdk.Metrics.decrement('folders_total');
+    ConduitGrpcSdk.Metrics?.decrement('folders_total');
     return true;
   }
 
@@ -187,8 +187,8 @@ export class AWSS3Storage implements IStorageProvider {
         Key: fileName,
       }),
     );
-    ConduitGrpcSdk.Metrics.increment('files_total');
-    ConduitGrpcSdk.Metrics.increment('storage_size_bytes_total', fileSize);
+    ConduitGrpcSdk.Metrics?.increment('files_total');
+    ConduitGrpcSdk.Metrics?.increment('storage_size_bytes_total', fileSize);
     return true;
   }
 

--- a/modules/storage/src/providers/azure/index.ts
+++ b/modules/storage/src/providers/azure/index.ts
@@ -89,21 +89,10 @@ export class AzureStorage implements IStorageProvider {
   }
 
   async delete(fileName: string): Promise<boolean | Error> {
-    let fileSize = 0;
-    try {
-      fileSize = (
-        await this._storage
-          .getContainerClient(this._activeContainer)
-          .getBlockBlobClient(fileName)
-          .getProperties()
-      ).contentLength as number;
-    } catch (e) {}
     await this._storage
       .getContainerClient(this._activeContainer)
       .getBlockBlobClient(fileName)
       .deleteIfExists();
-    ConduitGrpcSdk.Metrics?.increment('files_total');
-    ConduitGrpcSdk.Metrics?.increment('storage_size_bytes_total', fileSize);
     return true;
   }
 
@@ -164,8 +153,6 @@ export class AzureStorage implements IStorageProvider {
       .getContainerClient(this._activeContainer)
       .getBlockBlobClient(fileName)
       .upload(data, Buffer.byteLength(data));
-    ConduitGrpcSdk.Metrics?.increment('files_total');
-    ConduitGrpcSdk.Metrics?.increment('storage_size_bytes_total', data.byteLength);
     return true;
   }
 

--- a/modules/storage/src/providers/azure/index.ts
+++ b/modules/storage/src/providers/azure/index.ts
@@ -21,7 +21,7 @@ export class AzureStorage implements IStorageProvider {
 
   async deleteContainer(name: string): Promise<boolean | Error> {
     const t = await this._storage.getContainerClient(name).deleteIfExists();
-    ConduitGrpcSdk.Metrics.decrement('containers_total');
+    ConduitGrpcSdk.Metrics?.decrement('containers_total');
     return t.succeeded;
   }
 
@@ -44,7 +44,7 @@ export class AzureStorage implements IStorageProvider {
       }
     }
     ConduitGrpcSdk.Logger.log(`${i} blobs deleted.`);
-    ConduitGrpcSdk.Metrics.increment('folders_total');
+    ConduitGrpcSdk.Metrics?.increment('folders_total');
     return true;
   }
 
@@ -64,7 +64,7 @@ export class AzureStorage implements IStorageProvider {
     await containerClient
       .getBlockBlobClient(name + '.keep.txt')
       .uploadData(Buffer.from('DO NOT DELETE'));
-    ConduitGrpcSdk.Metrics.increment('folders_total');
+    ConduitGrpcSdk.Metrics?.increment('folders_total');
     return true;
   }
 
@@ -102,8 +102,8 @@ export class AzureStorage implements IStorageProvider {
       .getContainerClient(this._activeContainer)
       .getBlockBlobClient(fileName)
       .deleteIfExists();
-    ConduitGrpcSdk.Metrics.increment('files_total');
-    ConduitGrpcSdk.Metrics.increment('storage_size_bytes_total', fileSize);
+    ConduitGrpcSdk.Metrics?.increment('files_total');
+    ConduitGrpcSdk.Metrics?.increment('storage_size_bytes_total', fileSize);
     return true;
   }
 
@@ -164,8 +164,8 @@ export class AzureStorage implements IStorageProvider {
       .getContainerClient(this._activeContainer)
       .getBlockBlobClient(fileName)
       .upload(data, Buffer.byteLength(data));
-    ConduitGrpcSdk.Metrics.increment('files_total');
-    ConduitGrpcSdk.Metrics.increment('storage_size_bytes_total', data.byteLength);
+    ConduitGrpcSdk.Metrics?.increment('files_total');
+    ConduitGrpcSdk.Metrics?.increment('storage_size_bytes_total', data.byteLength);
     return true;
   }
 
@@ -200,7 +200,7 @@ export class AzureStorage implements IStorageProvider {
   async createContainer(name: string): Promise<boolean | Error> {
     await this._storage.getContainerClient(name).createIfNotExists();
     this._activeContainer = name;
-    ConduitGrpcSdk.Metrics.increment('containers_total');
+    ConduitGrpcSdk.Metrics?.increment('containers_total');
     return true;
   }
 

--- a/modules/storage/src/providers/google/index.ts
+++ b/modules/storage/src/providers/google/index.ts
@@ -27,7 +27,7 @@ export class GoogleCloudStorage implements IStorageProvider {
     // Creates the new bucket
     await this._storage.createBucket(name);
     this._activeBucket = name;
-    ConduitGrpcSdk.Metrics.increment('containers_total');
+    ConduitGrpcSdk.Metrics?.increment('containers_total');
     return true;
   }
 
@@ -79,7 +79,7 @@ export class GoogleCloudStorage implements IStorageProvider {
       return true;
     }
     await bucket.file(name + '/keep.txt').save(Buffer.from('DO NOT DELETE'));
-    ConduitGrpcSdk.Metrics.increment('folders_total');
+    ConduitGrpcSdk.Metrics?.increment('folders_total');
     return true;
   }
 
@@ -104,8 +104,8 @@ export class GoogleCloudStorage implements IStorageProvider {
       console.log(fileSize);
     } catch (e) {}
     await this._storage.bucket(this._activeBucket).file(fileName).delete();
-    ConduitGrpcSdk.Metrics.decrement('files_total');
-    ConduitGrpcSdk.Metrics.decrement('storage_size_bytes_total', fileSize);
+    ConduitGrpcSdk.Metrics?.decrement('files_total');
+    ConduitGrpcSdk.Metrics?.decrement('storage_size_bytes_total', fileSize);
     return true;
   }
 
@@ -162,8 +162,8 @@ export class GoogleCloudStorage implements IStorageProvider {
     if (isPublic) {
       await this._storage.bucket(this._activeBucket).file(fileName).makePublic();
     }
-    ConduitGrpcSdk.Metrics.increment('files_total');
-    ConduitGrpcSdk.Metrics.increment('storage_size_bytes_total', data.byteLength);
+    ConduitGrpcSdk.Metrics?.increment('files_total');
+    ConduitGrpcSdk.Metrics?.increment('storage_size_bytes_total', data.byteLength);
     return true;
   }
 

--- a/modules/storage/src/providers/google/index.ts
+++ b/modules/storage/src/providers/google/index.ts
@@ -96,16 +96,7 @@ export class GoogleCloudStorage implements IStorageProvider {
   }
 
   async delete(fileName: string): Promise<boolean | Error> {
-    let fileSize = 0;
-    try {
-      fileSize = (
-        await this._storage.bucket(this._activeBucket).file(fileName).getMetadata()
-      )[0].size; //TODO: check if this is the correct way to get the file size
-      console.log(fileSize);
-    } catch (e) {}
     await this._storage.bucket(this._activeBucket).file(fileName).delete();
-    ConduitGrpcSdk.Metrics?.decrement('files_total');
-    ConduitGrpcSdk.Metrics?.decrement('storage_size_bytes_total', fileSize);
     return true;
   }
 
@@ -162,8 +153,6 @@ export class GoogleCloudStorage implements IStorageProvider {
     if (isPublic) {
       await this._storage.bucket(this._activeBucket).file(fileName).makePublic();
     }
-    ConduitGrpcSdk.Metrics?.increment('files_total');
-    ConduitGrpcSdk.Metrics?.increment('storage_size_bytes_total', data.byteLength);
     return true;
   }
 

--- a/modules/storage/src/providers/local/index.ts
+++ b/modules/storage/src/providers/local/index.ts
@@ -54,8 +54,8 @@ export class LocalStorage implements IStorageProvider {
     return new Promise(function (res, reject) {
       try {
         rmSync(resolve(path), { recursive: true });
-        ConduitGrpcSdk.Metrics.decrement('folders_total');
-        ConduitGrpcSdk.Metrics.decrement('containers_total');
+        ConduitGrpcSdk.Metrics?.decrement('folders_total');
+        ConduitGrpcSdk.Metrics?.decrement('containers_total');
         res(true);
       } catch (e) {
         reject(e);
@@ -94,8 +94,8 @@ export class LocalStorage implements IStorageProvider {
       writeFile(resolve(path), data, function (err) {
         if (err) reject(err);
         else {
-          ConduitGrpcSdk.Metrics.increment('files_total');
-          ConduitGrpcSdk.Metrics.increment('storage_size_bytes_total', data.byteLength);
+          ConduitGrpcSdk.Metrics?.increment('files_total');
+          ConduitGrpcSdk.Metrics?.increment('storage_size_bytes_total', data.byteLength);
           res(true);
         }
       });
@@ -119,8 +119,8 @@ export class LocalStorage implements IStorageProvider {
           else res(true);
         });
       }
-      ConduitGrpcSdk.Metrics.increment('folders_total');
-      ConduitGrpcSdk.Metrics.increment('containers_total');
+      ConduitGrpcSdk.Metrics?.increment('folders_total');
+      ConduitGrpcSdk.Metrics?.increment('containers_total');
       res(true);
     });
   }
@@ -151,8 +151,8 @@ export class LocalStorage implements IStorageProvider {
       unlink(resolve(path), function (err) {
         if (err) reject(err);
         else {
-          ConduitGrpcSdk.Metrics.decrement('files_total');
-          ConduitGrpcSdk.Metrics.decrement('storage_size_bytes_total', fileSize);
+          ConduitGrpcSdk.Metrics?.decrement('files_total');
+          ConduitGrpcSdk.Metrics?.decrement('storage_size_bytes_total', fileSize);
           res(true);
         }
       });

--- a/modules/storage/src/providers/local/index.ts
+++ b/modules/storage/src/providers/local/index.ts
@@ -94,8 +94,6 @@ export class LocalStorage implements IStorageProvider {
       writeFile(resolve(path), data, function (err) {
         if (err) reject(err);
         else {
-          ConduitGrpcSdk.Metrics?.increment('files_total');
-          ConduitGrpcSdk.Metrics?.increment('storage_size_bytes_total', data.byteLength);
           res(true);
         }
       });
@@ -146,13 +144,10 @@ export class LocalStorage implements IStorageProvider {
     if (fileName !== self._activeContainer) {
       path += fileName;
     }
-    let fileSize = statSync(path).size;
     return new Promise(function (res, reject) {
       unlink(resolve(path), function (err) {
         if (err) reject(err);
         else {
-          ConduitGrpcSdk.Metrics?.decrement('files_total');
-          ConduitGrpcSdk.Metrics?.decrement('storage_size_bytes_total', fileSize);
           res(true);
         }
       });

--- a/packages/admin/src/routes/Login.route.ts
+++ b/packages/admin/src/routes/Login.route.ts
@@ -1,13 +1,12 @@
-import { ConduitCommons } from '@conduitplatform/commons';
 import { Admin } from '../models';
 import { isNil } from 'lodash';
 import { comparePasswords, signToken } from '../utils/auth';
-import ConduitGrpcSdk, {
+import {
   ConduitError,
   ConduitRouteActions,
-  ConfigController,
   ConduitRouteParameters,
   ConduitString,
+  ConfigController,
 } from '@conduitplatform/grpc-sdk';
 import { ConduitRoute, ConduitRouteReturnDefinition } from '@conduitplatform/hermes';
 

--- a/packages/admin/src/routes/Login.route.ts
+++ b/packages/admin/src/routes/Login.route.ts
@@ -2,7 +2,7 @@ import { ConduitCommons } from '@conduitplatform/commons';
 import { Admin } from '../models';
 import { isNil } from 'lodash';
 import { comparePasswords, signToken } from '../utils/auth';
-import {
+import ConduitGrpcSdk, {
   ConduitError,
   ConduitRouteActions,
   ConfigController,
@@ -50,7 +50,6 @@ export function getLoginRoute() {
         tokenSecret,
         tokenExpirationTime,
       );
-
       return { result: { token } }; // unnested from result in Rest.addConduitRoute, grpc routes avoid this using wrapRouterGrpcFunction
     },
   );

--- a/packages/core/src/GrpcServer.ts
+++ b/packages/core/src/GrpcServer.ts
@@ -59,6 +59,7 @@ export class GrpcServer {
           await this.commons.getConfigManager().initialize(this.server);
           await this.bootstrapSdkComponents();
           this.server.start();
+          this.initializeMetrics();
           await this.commons.getAdmin().subscribeToBusEvents();
           ConduitGrpcSdk.Logger.log(`gRPC server listening on: ${_url}`);
         });
@@ -95,6 +96,12 @@ export class GrpcServer {
 
     this._initialized = true;
     this.serviceHealthState = HealthCheckStatus.SERVING;
+  }
+
+  private initializeMetrics() {
+    if (process.env['METRICS_PORT']) {
+      this.grpcSdk.initializeDefaultMetrics();
+    }
   }
 
   private getServiceHealthState(service: string) {

--- a/packages/core/src/GrpcServer.ts
+++ b/packages/core/src/GrpcServer.ts
@@ -121,7 +121,7 @@ export class GrpcServer {
       this.events.emit('grpc-health-change:Core', state);
     }
     this._serviceHealthState = state;
-    ConduitGrpcSdk.Metrics.set(
+    ConduitGrpcSdk.Metrics?.set(
       'module_health_state',
       state === HealthCheckStatus.SERVING ? 1 : 0,
     );

--- a/packages/core/src/GrpcServer.ts
+++ b/packages/core/src/GrpcServer.ts
@@ -129,7 +129,7 @@ export class GrpcServer {
     }
     this._serviceHealthState = state;
     ConduitGrpcSdk.Metrics.set(
-      'health_state',
+      'module_health_state',
       state === HealthCheckStatus.SERVING ? 1 : 0,
     );
   }

--- a/packages/core/src/GrpcServer.ts
+++ b/packages/core/src/GrpcServer.ts
@@ -77,13 +77,6 @@ export class GrpcServer {
     this.commons.registerAdmin(new AdminModule(this.commons, this._grpcSdk));
     this.initializeMetrics();
     this._grpcSdk
-      .waitForExistence('router')
-      .then(() => Core.getInstance().httpServer.initialize(this.grpcSdk, this.server))
-      .catch(e => {
-        ConduitGrpcSdk.Logger.error(e.message);
-      });
-
-    this._grpcSdk
       .waitForExistence('database')
       .then(() => this.commons.getConfigManager().registerAppConfig())
       .catch(e => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3715,6 +3715,11 @@ bin-links@^3.0.0:
     rimraf "^3.0.0"
     write-file-atomic "^4.0.0"
 
+bintrees@1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/bintrees/-/bintrees-1.0.2.tgz#49f896d6e858a4a499df85c38fb399b9aff840f8"
+  integrity sha512-VOMgTMwjAaUG580SXn3LacVgjurrbMme7ZZNYGSSV7mmtY6QQRh0Eg3pwIcntQ77DErK1L0NxkbetjcoXzVwKw==
+
 bl@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/bl/-/bl-2.2.1.tgz#8c11a7b730655c5d56898cdc871224f40fd901d5"
@@ -5243,7 +5248,7 @@ express-winston@^4.2.0:
     chalk "^2.4.2"
     lodash "^4.17.21"
 
-express@^4.17.1, express@~4.18.1:
+express@^4.17.1, express@^4.18.1, express@~4.18.1:
   version "4.18.1"
   resolved "https://registry.yarnpkg.com/express/-/express-4.18.1.tgz#7797de8b9c72c857b9cd0e14a5eea80666267caf"
   integrity sha512-zZBcOX9TfehHQhtupq57OF8lFZ3UZi08Y97dwFCkD8p9d/d2Y3M+ykKcwaMDEL+4qyUolgBDX6AblpR3fL212Q==
@@ -8900,6 +8905,13 @@ progress@^2.0.3:
   resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.3.tgz#7e8cf8d8f5b8f239c1bc68beb4eb78567d572ef8"
   integrity sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==
 
+prom-client@^14.0.1:
+  version "14.0.1"
+  resolved "https://registry.yarnpkg.com/prom-client/-/prom-client-14.0.1.tgz#bdd9583e02ec95429677c0e013712d42ef1f86a8"
+  integrity sha512-HxTArb6fkOntQHoRGvv4qd/BkorjliiuO2uSWC2KC17MUTKYttWdDoXX/vxOhQdkoECEM9BBH0pj2l8G8kev6w==
+  dependencies:
+    tdigest "^0.1.1"
+
 promise-all-reject-late@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/promise-all-reject-late/-/promise-all-reject-late-1.0.1.tgz#f8ebf13483e5ca91ad809ccc2fcf25f26f8643c2"
@@ -10291,6 +10303,13 @@ tar@^6.0.2, tar@^6.1.0, tar@^6.1.11, tar@^6.1.2:
     minizlib "^2.1.1"
     mkdirp "^1.0.3"
     yallist "^4.0.0"
+
+tdigest@^0.1.1:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/tdigest/-/tdigest-0.1.2.tgz#96c64bac4ff10746b910b0e23b515794e12faced"
+  integrity sha512-+G0LLgjjo9BZX2MfdvPfH+MKLCrxlXSYec5DaPYP1fe6Iyhf0/fSmJ0bFiZ1F8BT6cGXl2LpltQptzjXKWEkKA==
+  dependencies:
+    bintrees "1.0.2"
 
 teeny-request@^8.0.0:
   version "8.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3120,6 +3120,11 @@ abort-controller-x@^0.2.4:
   dependencies:
     node-abort-controller "^1.2.1 || ^2.0.0"
 
+abort-controller-x@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/abort-controller-x/-/abort-controller-x-0.4.0.tgz#fde25da52548c7ff3d8b3b32dffc943452874d5f"
+  integrity sha512-cuNbw3c/SvEOkWkgxoWOOS3QzcTCC6YXCFH6oTZ/jvjZPBhkjaoUyCLwdAViRRhYmluJPD7vGaTLkHCp67xQVQ==
+
 abort-controller@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/abort-controller/-/abort-controller-3.0.0.tgz#eaf54d53b62bae4138e809ca225c8439a6efb392"
@@ -7949,6 +7954,22 @@ nice-grpc-common@^1.1.0:
   dependencies:
     node-abort-controller "^2.0.0"
     ts-error "^1.0.6"
+
+nice-grpc-common@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/nice-grpc-common/-/nice-grpc-common-2.0.0.tgz#36c9b9cdc38d3b4aa8ad7abf120fd4737eff70ea"
+  integrity sha512-8h/QraeDmScnbKLd5ImS+e7uUDxumvByBo6ILj1jLHjKlIa74WKHNSn54u7RmnJ5tFAYE70iTm8VWyvbTv82yg==
+  dependencies:
+    ts-error "^1.0.6"
+
+nice-grpc-prometheus@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/nice-grpc-prometheus/-/nice-grpc-prometheus-0.1.0.tgz#4db2a1ea745f5129288dc2783c2178ae0b53704e"
+  integrity sha512-jrHKeAgLN6RNmlUhhG8zKzF5ESTVLc3xxhyuWUYfy7+F1sKDXZN6p61dJL9IuS3uV1/OZEzepsOVqGpoA9mj2Q==
+  dependencies:
+    abort-controller-x "^0.4.0"
+    nice-grpc-common "^2.0.0"
+    prom-client "^14.0.1"
 
 nice-grpc@^1.2.0:
   version "1.2.0"


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/ConduitPlatform/Conduit/blob/main/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** <!--(check at least one)-->
This PR adds support for metrics collection. Each module collects a variety of default metrics (e.g. request latencies, gRPC errors, admin/client requests etc.). In addition to these defaults every module also records and collects some custom metrics regarding its function. For instance the authentication module records any login requests that have been sent.

Each module exposes a Prometheus compatible endpoint ```/metrics```, providing support for Prometheus scraping. To enable metrics, each module must be provided with a ```METRICS_PORT``` env key for the Express server port.

Metrics collection is totally optional and can be enabled to some or all of the modules.

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other (please describe)

**Does this PR introduce a breaking change?** <!-- (check one) -->

- [ ] Yes
- [x] No

<!-- If yes, please describe the impact and migration path for existing applications. -->

**The PR fulfills these requirements:**

- [x] It's submitted to the `main` branch
- [ ] When resolving a specific issue, it's referenced in the PR's description  (e.g. `fix #xxx`, where "xxx" is the issue number)
