### PR TITLE
fix: invalid config updates polluting Convict config object

### DIFF
--- a/modules/authentication/src/Authentication.ts
+++ b/modules/authentication/src/Authentication.ts
@@ -30,7 +30,7 @@ import {
 import { runMigrations } from './migrations';
 
 export default class Authentication extends ManagedModule<Config> {
-  config = AppConfigSchema;
+  configSchema = AppConfigSchema;
   service = {
     protoPath: path.resolve(__dirname, 'authentication.proto'),
     protoDescription: 'authentication.Authentication',

--- a/modules/authentication/src/config/index.ts
+++ b/modules/authentication/src/config/index.ts
@@ -4,4 +4,4 @@ import AppConfigSchema from './config';
 const config = convict(AppConfigSchema);
 const configProperties = config.getProperties();
 export type Config = typeof configProperties;
-export default config;
+export default AppConfigSchema;

--- a/modules/chat/src/Chat.ts
+++ b/modules/chat/src/Chat.ts
@@ -27,7 +27,7 @@ import {
 } from './protoTypes/chat';
 
 export default class Chat extends ManagedModule<Config> {
-  config = AppConfigSchema;
+  configSchema = AppConfigSchema;
   service = {
     protoPath: path.resolve(__dirname, 'chat.proto'),
     protoDescription: 'chat.Chat',

--- a/modules/chat/src/config/index.ts
+++ b/modules/chat/src/config/index.ts
@@ -4,4 +4,4 @@ import AppConfigSchema from './config';
 const config = convict(AppConfigSchema);
 const configProperties = config.getProperties();
 export type Config = typeof configProperties;
-export default config;
+export default AppConfigSchema;

--- a/modules/database/src/Database.ts
+++ b/modules/database/src/Database.ts
@@ -37,7 +37,7 @@ import { status } from '@grpc/grpc-js';
 import path from 'path';
 
 export default class DatabaseModule extends ManagedModule<void> {
-  config = undefined;
+  configSchema = undefined;
   service = {
     protoPath: path.resolve(__dirname, 'database.proto'),
     protoDescription: 'database.DatabaseProvider',

--- a/modules/email/src/Email.ts
+++ b/modules/email/src/Email.ts
@@ -24,7 +24,7 @@ import {
 } from './protoTypes/email';
 
 export default class Email extends ManagedModule<Config> {
-  config = AppConfigSchema;
+  configSchema = AppConfigSchema;
   service = {
     protoPath: path.resolve(__dirname, 'email.proto'),
     protoDescription: 'email.Email',

--- a/modules/email/src/config/index.ts
+++ b/modules/email/src/config/index.ts
@@ -4,4 +4,4 @@ import AppConfigSchema from './config';
 const config = convict(AppConfigSchema);
 const configProperties = config.getProperties();
 export type Config = typeof configProperties;
-export default config;
+export default AppConfigSchema;

--- a/modules/forms/src/Forms.ts
+++ b/modules/forms/src/Forms.ts
@@ -14,7 +14,7 @@ import path from 'path';
 import { runMigrations } from './migrations';
 
 export default class Forms extends ManagedModule<Config> {
-  config = AppConfigSchema;
+  configSchema = AppConfigSchema;
   service = {
     protoPath: path.resolve(__dirname, 'forms.proto'),
     protoDescription: 'forms.Forms',

--- a/modules/forms/src/config/index.ts
+++ b/modules/forms/src/config/index.ts
@@ -4,4 +4,4 @@ import AppConfigSchema from './config';
 const config = convict(AppConfigSchema);
 const configProperties = config.getProperties();
 export type Config = typeof configProperties;
-export default config;
+export default AppConfigSchema;

--- a/modules/push-notifications/src/PushNotifications.ts
+++ b/modules/push-notifications/src/PushNotifications.ts
@@ -26,7 +26,7 @@ import { ISendNotification } from './interfaces/ISendNotification';
 import { runMigrations } from './migrations';
 
 export default class PushNotifications extends ManagedModule<Config> {
-  config = AppConfigSchema;
+  configSchema = AppConfigSchema;
   service = {
     protoPath: path.resolve(__dirname, 'push-notifications.proto'),
     protoDescription: 'pushnotifications.PushNotifications',

--- a/modules/push-notifications/src/config/index.ts
+++ b/modules/push-notifications/src/config/index.ts
@@ -4,4 +4,4 @@ import AppConfigSchema from './config';
 const config = convict(AppConfigSchema);
 const configProperties = config.getProperties();
 export type Config = typeof configProperties;
-export default config;
+export default AppConfigSchema;

--- a/modules/router/src/Router.ts
+++ b/modules/router/src/Router.ts
@@ -72,7 +72,7 @@ const swaggerRouterMetadata: SwaggerRouterMetadata = {
 };
 
 export default class ConduitDefaultRouter extends ManagedModule<Config> {
-  config = AppConfigSchema;
+  configSchema = AppConfigSchema;
   service = {
     protoPath: path.resolve(__dirname, 'router.proto'),
     protoDescription: 'router.Router',

--- a/modules/router/src/config/index.ts
+++ b/modules/router/src/config/index.ts
@@ -4,4 +4,4 @@ import AppConfigSchema from './config';
 const config = convict(AppConfigSchema);
 const configProperties = config.getProperties();
 export type Config = typeof configProperties;
-export default config;
+export default AppConfigSchema;

--- a/modules/sms/src/Sms.ts
+++ b/modules/sms/src/Sms.ts
@@ -22,7 +22,7 @@ import {
 } from './protoTypes/sms';
 
 export default class Sms extends ManagedModule<Config> {
-  config = AppConfigSchema;
+  configSchema = AppConfigSchema;
   service = {
     protoPath: path.resolve(__dirname, 'sms.proto'),
     protoDescription: 'sms.Sms',

--- a/modules/sms/src/config/index.ts
+++ b/modules/sms/src/config/index.ts
@@ -4,4 +4,4 @@ import AppConfigSchema from './config';
 const config = convict(AppConfigSchema);
 const configProperties = config.getProperties();
 export type Config = typeof configProperties;
-export default config;
+export default AppConfigSchema;

--- a/modules/storage/src/Storage.ts
+++ b/modules/storage/src/Storage.ts
@@ -21,10 +21,8 @@ import { IStorageProvider } from './interfaces';
 import { createStorageProvider } from './providers';
 import { getAwsAccountId } from './utils';
 
-type Callback = (arg1: { code: number; message: string }) => void;
-
 export default class Storage extends ManagedModule<Config> {
-  config = AppConfigSchema;
+  configSchema = AppConfigSchema;
   service = {
     protoPath: path.resolve(__dirname, 'storage.proto'),
     protoDescription: 'storage.Storage',

--- a/modules/storage/src/config/index.ts
+++ b/modules/storage/src/config/index.ts
@@ -4,4 +4,4 @@ import AppConfigSchema from './config';
 const config = convict(AppConfigSchema);
 const configProperties = config.getProperties();
 export type Config = typeof configProperties;
-export default config;
+export default AppConfigSchema;

--- a/packages/admin/src/config/index.ts
+++ b/packages/admin/src/config/index.ts
@@ -4,4 +4,4 @@ import AppConfigSchema from './config';
 const config = convict(AppConfigSchema);
 const configProperties = config.getProperties();
 export type Config = typeof configProperties;
-export default config;
+export default AppConfigSchema;

--- a/packages/core/src/Core.ts
+++ b/packages/core/src/Core.ts
@@ -8,7 +8,7 @@ import convict from 'convict';
 export class Core extends IConduitCore {
   private static _instance: Core;
   private readonly _grpcServer: GrpcServer;
-  readonly config: convict.Config<ConfigSchema> = AppConfigSchema;
+  readonly config: convict.Config<ConfigSchema> = convict(AppConfigSchema);
 
   get grpcServer() {
     return this._grpcServer;
@@ -43,6 +43,7 @@ export class Core extends IConduitCore {
       });
       config = this.config.getProperties();
     } catch (e) {
+      (this.config as unknown) = convict(AppConfigSchema);
       this.config.load(previousConfig);
       throw new ConduitError('INVALID_ARGUMENT', 400, (e as Error).message);
     }

--- a/packages/core/src/GrpcServer.ts
+++ b/packages/core/src/GrpcServer.ts
@@ -8,10 +8,11 @@ import ConduitGrpcSdk, {
 import AdminModule from '@conduitplatform/admin';
 import { EventEmitter } from 'events';
 import path from 'path';
-import convict from './config';
+import AppConfigSchema from './config';
 import CoreConfigSchema from './config/config';
 import { ServerWritableStream } from '@grpc/grpc-js';
 import ConfigManager from './config-manager';
+import convict from 'convict';
 
 const CORE_SERVICES = ['Config', 'Admin'];
 
@@ -83,7 +84,11 @@ export class GrpcServer {
       });
     await this.commons
       .getConfigManager()
-      .configurePackage('core', convict.getProperties(), CoreConfigSchema);
+      .configurePackage(
+        'core',
+        convict(AppConfigSchema).getProperties(),
+        CoreConfigSchema,
+      );
 
     await this.commons.getAdmin().initialize(this.server);
     this.commons.getConfigManager().initConfigAdminRoutes();

--- a/packages/core/src/config/index.ts
+++ b/packages/core/src/config/index.ts
@@ -4,4 +4,4 @@ import AppConfigSchema from './config';
 const config = convict(AppConfigSchema);
 const configProperties = config.getProperties();
 export type Config = typeof configProperties;
-export default convict(AppConfigSchema);
+export default AppConfigSchema;


### PR DESCRIPTION
This PR resolves a bug where config update requests containing extra unknown fields would pollute Convict config objects and result in all subsequent update requests failing for that particular module/Core/Admin until restarting it.

To be precise, that was due to Convict's `load()` function merging JSON objects on top of its existing config instead of replacing it with the incoming object.

**What kind of change does this PR introduce?** <!--(check at least one)-->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other (please describe)

**Does this PR introduce a breaking change?** <!-- (check one) -->

- [ ] Yes
- [X] No

<!-- If yes, please describe the impact and migration path for existing applications. -->

**The PR fulfills these requirements:**

- [X] It's submitted to the `main` branch
- [ ] When resolving a specific issue, it's referenced in the PR's description  (e.g. `fix #xxx`, where "xxx" is the issue number)