### PR TITLE
fix(database): admin create schema return type regression

### DIFF
--- a/modules/database/src/admin/documents.admin.ts
+++ b/modules/database/src/admin/documents.admin.ts
@@ -142,7 +142,7 @@ export class DocumentsAdmin {
     if (isNil(schema)) {
       throw new GrpcError(status.NOT_FOUND, 'Schema does not exist');
     }
-    await await this.database.getSchemaModel(schemaName).model.deleteOne({ _id: id });
+    await this.database.getSchemaModel(schemaName).model.deleteOne({ _id: id });
     return 'Ok';
   }
 }

--- a/modules/database/src/admin/schema.admin.ts
+++ b/modules/database/src/admin/schema.admin.ts
@@ -160,9 +160,10 @@ export class SchemaAdmin {
       : { ...modelOptions, conduit: { cms: { enabled, crudOperations } } };
     schemaOptions.conduit.permissions = permissions; // database sets missing perms to defaults
 
-    return this.schemaController.createSchema(
+    await this.schemaController.createSchema(
       new ConduitSchema(name, fields, schemaOptions),
     );
+    return await this.database.getSchemaModel('_DeclaredSchema').model.findOne({ name });
   }
 
   async patchSchema(call: ParsedRouterRequest): Promise<UnparsedRouterResponse> {

--- a/modules/database/src/admin/schema.admin.ts
+++ b/modules/database/src/admin/schema.admin.ts
@@ -78,10 +78,10 @@ export class SchemaAdmin {
       };
     }
 
-    const schemasPromise = await this.database
+    const schemasPromise = this.database
       .getSchemaModel('_DeclaredSchema')
       .model.findMany(query, skip, limit, undefined, sort);
-    const documentsCountPromise = await this.database
+    const documentsCountPromise = this.database
       .getSchemaModel('_DeclaredSchema')
       .model.countDocuments(query);
 

--- a/modules/database/src/permissions/index.ts
+++ b/modules/database/src/permissions/index.ts
@@ -1,4 +1,4 @@
-import { Schema, SchemaAdapter } from '../interfaces';
+import { Schema } from '../interfaces';
 
 export async function canCreate(moduleName: string, schema: Schema) {
   if (moduleName === 'database' && schema.originalSchema.name === '_DeclaredSchema')


### PR DESCRIPTION
Fixes Database's create schema admin route returning incorrect fields.

I'm not marking this as a Breaking Change as it restores the advertised return signature, which is mostly a superset of the regressed one, except for the `schemaOptions` -> `modelOptions` field name.

This also fixes a couple of promises being awaited twice.

**What kind of change does this PR introduce?** <!--(check at least one)-->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other (please describe)

**Does this PR introduce a breaking change?** <!-- (check one) -->

- [ ] Yes
- [X] No

<!-- If yes, please describe the impact and migration path for existing applications. -->

**The PR fulfills these requirements:**

- [X] It's submitted to the `main` branch
- [ ] When resolving a specific issue, it's referenced in the PR's description  (e.g. `fix #xxx`, where "xxx" is the issue number)
