### PR TITLE
fix(database): DeclaredSchema compiledFields extension field and custom endpoint generation

### DIFF
--- a/modules/database/src/adapters/DatabaseAdapter.ts
+++ b/modules/database/src/adapters/DatabaseAdapter.ts
@@ -1,4 +1,5 @@
 import ConduitGrpcSdk, {
+  ConduitModel,
   ConduitModelOptions,
   ConduitSchema,
   GrpcError,
@@ -12,6 +13,7 @@ import { ConduitDatabaseSchema } from '../interfaces/ConduitDatabaseSchema';
 type _ConduitSchema = Omit<ConduitSchema, 'schemaOptions'> & {
   modelOptions: ConduitModelOptions;
   extensions: DeclaredSchemaExtension[];
+  compiledFields: ConduitModel;
 } & {
   -readonly [k in keyof ConduitSchema]: ConduitSchema[k];
 };
@@ -176,10 +178,11 @@ export abstract class DatabaseAdapter<T extends Schema> {
         JSON.stringify({
           name: schema.name,
           fields: schema.fields,
+          extensions: (schema as ConduitDatabaseSchema).extensions,
+          compiledFields: (schema as ConduitDatabaseSchema).compiledFields,
           modelOptions: schema.schemaOptions,
           ownerModule: schema.ownerModule,
           collectionName: schema.collectionName,
-          extensions: (schema as ConduitDatabaseSchema).extensions,
         }),
         true,
       );
@@ -188,10 +191,11 @@ export abstract class DatabaseAdapter<T extends Schema> {
         JSON.stringify({
           name: schema.name,
           fields: schema.fields,
+          extensions: (schema as ConduitDatabaseSchema).extensions,
+          compiledFields: (schema as ConduitDatabaseSchema).compiledFields,
           modelOptions: schema.schemaOptions,
           ownerModule: schema.ownerModule,
           collectionName: schema.collectionName,
-          extensions: (schema as ConduitDatabaseSchema).extensions,
         }),
       );
     }
@@ -209,6 +213,7 @@ export abstract class DatabaseAdapter<T extends Schema> {
         );
         schema.ownerModule = model.ownerModule;
         (schema as ConduitDatabaseSchema).extensions = model.extensions;
+        (schema as ConduitDatabaseSchema).compiledFields = model.compiledFields;
         return schema;
       })
       .map((model: ConduitSchema) => {

--- a/modules/database/src/adapters/DatabaseAdapter.ts
+++ b/modules/database/src/adapters/DatabaseAdapter.ts
@@ -51,6 +51,7 @@ export abstract class DatabaseAdapter<T extends Schema> {
    * Should accept a JSON schema and output a .ts interface for the adapter
    * @param {ConduitSchema} schema
    * @param {boolean} imported Whether schema is an introspected schema
+   * @param {boolean} cndPrefix Whether to prefix the schema's collection name with 'cnd_'
    */
   async createSchemaFromAdapter(
     schema: ConduitSchema,

--- a/modules/database/src/adapters/mongoose-adapter/index.ts
+++ b/modules/database/src/adapters/mongoose-adapter/index.ts
@@ -7,6 +7,7 @@ import ConduitGrpcSdk, {
   GrpcError,
   Indexable,
 } from '@conduitplatform/grpc-sdk';
+import { ConduitDatabaseSchema } from '../../interfaces/ConduitDatabaseSchema';
 import { systemRequiredValidator } from '../utils/validateSchemas';
 import { DatabaseAdapter } from '../DatabaseAdapter';
 import { stitchSchema } from '../utils/extensions';
@@ -220,8 +221,9 @@ export class MongooseAdapter extends DatabaseAdapter<MongooseSchema> {
     }
 
     this.addSchemaPermissions(schema);
-    const original = JSON.parse(JSON.stringify(schema));
+    const original: ConduitDatabaseSchema = JSON.parse(JSON.stringify(schema));
     stitchSchema(schema);
+    original.compiledFields = schema.fields;
     const newSchema = schemaConverter(schema);
 
     this.registeredSchemas.set(schema.name, schema);

--- a/modules/database/src/adapters/sequelize-adapter/index.ts
+++ b/modules/database/src/adapters/sequelize-adapter/index.ts
@@ -7,6 +7,7 @@ import ConduitGrpcSdk, {
   GrpcError,
   Indexable,
 } from '@conduitplatform/grpc-sdk';
+import { ConduitDatabaseSchema } from '../../interfaces/ConduitDatabaseSchema';
 import { systemRequiredValidator } from '../utils/validateSchemas';
 import { DatabaseAdapter } from '../DatabaseAdapter';
 import { stitchSchema } from '../utils/extensions';
@@ -157,11 +158,9 @@ export class SequelizeAdapter extends DatabaseAdapter<SequelizeSchema> {
   }
 
   getCollectionName(schema: ConduitSchema) {
-    const collectionName =
-      schema.collectionName && schema.collectionName !== ''
-        ? schema.collectionName
-        : schema.name;
-    return collectionName;
+    return schema.collectionName && schema.collectionName !== ''
+      ? schema.collectionName
+      : schema.name;
   }
 
   protected async _createSchemaFromAdapter(
@@ -182,8 +181,9 @@ export class SequelizeAdapter extends DatabaseAdapter<SequelizeSchema> {
     }
 
     this.addSchemaPermissions(schema);
-    const original: ConduitSchema = JSON.parse(JSON.stringify(schema));
+    const original: ConduitDatabaseSchema = JSON.parse(JSON.stringify(schema));
     stitchSchema(schema);
+    original.compiledFields = schema.fields;
     const newSchema = schemaConverter(schema);
 
     this.registeredSchemas.set(schema.name, schema);

--- a/modules/database/src/admin/customEndpoints/customEndpoints.admin.ts
+++ b/modules/database/src/admin/customEndpoints/customEndpoints.admin.ts
@@ -126,7 +126,7 @@ export class CustomEndpointsAdmin {
         );
       }
       findSchema = await this.database.getSchema(selectedSchemaName);
-      findSchema.fields = findSchema.modelSchema;
+      findSchema.compiledFields = findSchema.modelSchema;
     }
 
     if (isNil(findSchema)) {
@@ -274,7 +274,7 @@ export class CustomEndpointsAdmin {
         );
       }
       findSchema = await this.database.getSchema(selectedSchemaName);
-      findSchema.fields = findSchema.modelSchema;
+      findSchema.compiledFields = findSchema.modelSchema;
     }
 
     if (isNil(findSchema)) {

--- a/modules/database/src/admin/customEndpoints/utils.ts
+++ b/modules/database/src/admin/customEndpoints/utils.ts
@@ -91,7 +91,7 @@ function _queryValidation(
     return 'comparisonField cannot be empty and should contain type and value';
   }
 
-  if (!Object.keys(findSchema.fields).includes(schemaField)) {
+  if (!Object.keys(findSchema.compiledFields).includes(schemaField)) {
     return 'schemaField is not present in selected schema!';
   }
 
@@ -100,7 +100,7 @@ function _queryValidation(
   }
 
   if (comparisonField.type === 'Schema') {
-    if (!Object.keys(findSchema.fields).includes(comparisonField.value)) {
+    if (!Object.keys(findSchema.compiledFields).includes(comparisonField.value)) {
       return 'comparisonField value is not present in selected schema!';
     }
   } else if (comparisonField.type === 'Input') {
@@ -193,7 +193,7 @@ export function assignmentValidation(
     return 'assignmentField cannot be empty and should contain type and value';
   }
 
-  if (!Object.keys(findSchema.fields).includes(schemaField)) {
+  if (!Object.keys(findSchema.compiledFields).includes(schemaField)) {
     return 'schemaField is not present in selected schema!';
   }
 
@@ -207,7 +207,7 @@ export function assignmentValidation(
   }
 
   if (action === 3 || action === 4) {
-    if (!Array.isArray(findSchema.fields[schemaField].type)) {
+    if (!Array.isArray(findSchema.compiledFields[schemaField].type)) {
       return 'append and remove actions are valid only for array schema fields';
     }
   }

--- a/modules/database/src/interfaces/ConduitDatabaseSchema.ts
+++ b/modules/database/src/interfaces/ConduitDatabaseSchema.ts
@@ -9,6 +9,7 @@ import { MultiDocQuery, ParsedQuery, Schema, SchemaAdapter } from './SchemaAdapt
 export class ConduitDatabaseSchema extends ConduitSchema {
   private readonly model: SchemaAdapter<Schema>;
   extensions: DeclaredSchemaExtension[];
+  compiledFields: ConduitModel;
 
   constructor(
     model: SchemaAdapter<Schema>,

--- a/modules/database/src/models/DeclaredSchema.schema.ts
+++ b/modules/database/src/models/DeclaredSchema.schema.ts
@@ -27,6 +27,10 @@ export const DeclaredSchema = new ConduitSchema(
         updatedAt: TYPE.Date,
       },
     ],
+    compiledFields: {
+      type: TYPE.JSON,
+      required: true,
+    },
     modelOptions: {
       type: TYPE.JSON,
       required: true,


### PR DESCRIPTION
This PR makes it so that Database's CMS custom endpoints functionality may now utilize schema extensions.
It also introduces a `compiledFields` field for `DeclaredSchema` so as to facilitate custom endpoint creation in `Conduit-UI` and complement db type registration of router types (to be addressed in a followup PR).

**What kind of change does this PR introduce?** <!--(check at least one)-->

- [X] Bugfix
- [X] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other (please describe)

**Does this PR introduce a breaking change?** <!-- (check one) -->

- [ ] Yes
- [X] No

<!-- If yes, please describe the impact and migration path for existing applications. -->

**The PR fulfills these requirements:**

- [X] It's submitted to the `main` branch
- [ ] When resolving a specific issue, it's referenced in the PR's description  (e.g. `fix #xxx`, where "xxx" is the issue number)

If adding a **new feature**, the PR's description includes:

- [X] A convincing reason for adding this feature <!-- to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it -->
