### PR TITLE
refactor(grpc-sdk): add prefix to metric names

### DIFF
--- a/libraries/grpc-sdk/src/index.ts
+++ b/libraries/grpc-sdk/src/index.ts
@@ -411,6 +411,7 @@ export default class ConduitGrpcSdk {
   }
 
   registerMetric(type: MetricType, config: MetricConfiguration) {
+    config.name = `conduit_${config.name}`;
     switch (type) {
       case MetricType.Counter:
         ConduitGrpcSdk.Metrics?.createCounter(config as CounterConfiguration<any>);

--- a/libraries/grpc-sdk/src/metrics/index.ts
+++ b/libraries/grpc-sdk/src/metrics/index.ts
@@ -60,7 +60,7 @@ export class ConduitMetrics {
   }
 
   increment(metric: string, increment: number = 1, labels?: LabelValues<any>) {
-    const metricInstance = this.Registry.getSingleMetric(metric);
+    const metricInstance = this.Registry.getSingleMetric(this.addPrefix(metric));
     if (
       !(metricInstance instanceof client.Counter) &&
       !(metricInstance instanceof client.Gauge)
@@ -73,7 +73,7 @@ export class ConduitMetrics {
   }
 
   decrement(metric: string, decrement: number = 1, labels?: LabelValues<any>) {
-    const metricInstance = this.Registry.getSingleMetric(metric);
+    const metricInstance = this.Registry.getSingleMetric(this.addPrefix(metric));
     if (!(metricInstance instanceof client.Gauge)) {
       throw new Error(`Metric ${metric} is not a decrementable metric`);
     }
@@ -83,7 +83,7 @@ export class ConduitMetrics {
   }
 
   set(metric: string, value: number, labels?: LabelValues<any>) {
-    const metricInstance = this.Registry.getSingleMetric(metric);
+    const metricInstance = this.Registry.getSingleMetric(this.addPrefix(metric));
     if (!(metricInstance instanceof client.Gauge)) {
       throw new Error(`Metric ${metric} is not a Gauge`);
     }
@@ -93,7 +93,7 @@ export class ConduitMetrics {
   }
 
   observe(metric: string, value: number, labels?: LabelValues<any>) {
-    const metricInstance = this.Registry.getSingleMetric(metric);
+    const metricInstance = this.Registry.getSingleMetric(this.addPrefix(metric));
     if (
       !(metricInstance instanceof client.Histogram) &&
       !(metricInstance instanceof client.Summary)
@@ -103,5 +103,9 @@ export class ConduitMetrics {
     return labels
       ? metricInstance.labels({ ...labels }).observe(value)
       : metricInstance.observe(value);
+  }
+
+  private addPrefix(metric: string) {
+    return `conduit_${metric}`;
   }
 }


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/ConduitPlatform/Conduit/blob/main/.github/CONTRIBUTING.md#pull-request-guidelines
-->
This PR adds the 'conduit_' prefix to all metric names for better grouping.
<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** <!--(check at least one)-->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [x] Refactor
- [ ] Build-related changes
- [ ] Other (please describe)

**Does this PR introduce a breaking change?** <!-- (check one) -->

- [ ] Yes
- [x] No

<!-- If yes, please describe the impact and migration path for existing applications. -->

**The PR fulfills these requirements:**

- [x] It's submitted to the `main` branch
- [ ] When resolving a specific issue, it's referenced in the PR's description  (e.g. `fix #xxx`, where "xxx" is the issue number)

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature <!-- to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it -->

**Other information:**
