### PR TITLE
fix(database): gRPC schema registration removing schema extensions from adapter models

### DIFF
--- a/modules/database/src/adapters/DatabaseAdapter.ts
+++ b/modules/database/src/adapters/DatabaseAdapter.ts
@@ -84,6 +84,14 @@ export abstract class DatabaseAdapter<T extends Schema> {
       }
       (schema as _ConduitSchema).collectionName = collectionName;
     }
+    if (schema.name !== '_DeclaredSchema') {
+      const schemaModel = await this.getSchemaModel('_DeclaredSchema').model.findOne({
+        name: schema.name,
+      });
+      if (schemaModel?.extensions?.length > 0) {
+        (schema as any).extensions = schemaModel.extensions;
+      }
+    }
     const createdSchema = this._createSchemaFromAdapter(schema);
     if (!this.registeredSchemas.has(schema.name)) {
       ConduitGrpcSdk.Metrics?.increment('registered_schemas_total', 1, {


### PR DESCRIPTION
This addresses a bug where incoming gRPC schema registrations would remove a schema's extensions from its adapter model, effectively dropping its extensions until the `Database` gets restarted and the adapters repopulated with the contents of `DeclaredSchema`.

To reproduce:
- Start `Core`
- Debug `Database` and set an extension in `createSchemaFromAdapter()` (or similar)
- Notice how any extended schemas coming from `DeclaredSchemas` list their extensions as expected
- Bring up a module owning an extended schema
- Notice how that same schema is reregistered without any extensions

I'm using a hacky type any cast for the schema object as the schema types are already messed up to the point where it wouldn't be worth attempting to retype this on the spot.
We'll have to clean these up properly.

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** <!--(check at least one)-->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other (please describe)

**Does this PR introduce a breaking change?** <!-- (check one) -->

- [ ] Yes
- [X] No

<!-- If yes, please describe the impact and migration path for existing applications. -->

**The PR fulfills these requirements:**

- [X] It's submitted to the `main` branch
- [ ] When resolving a specific issue, it's referenced in the PR's description  (e.g. `fix #xxx`, where "xxx" is the issue number)
