### PR TITLE
fix(grpc-sdk,database): crash on unconditional Sequelize metrics

### DIFF
--- a/libraries/grpc-sdk/src/index.ts
+++ b/libraries/grpc-sdk/src/index.ts
@@ -73,7 +73,7 @@ export default class ConduitGrpcSdk {
   private readonly _serviceHealthStatusGetter: Function;
   private readonly _grpcToken?: string;
   private _initialized: boolean = false;
-  static Metrics: ConduitMetrics;
+  static Metrics?: ConduitMetrics;
   static readonly Logger: ConduitLogger = new ConduitLogger([
     new winston.transports.File({
       filename: path.join(__dirname, '.logs/combined.log'),

--- a/modules/database/src/adapters/sequelize-adapter/SequelizeSchema.ts
+++ b/modules/database/src/adapters/sequelize-adapter/SequelizeSchema.ts
@@ -21,7 +21,7 @@ import ConduitGrpcSdk, { ConduitSchema, Indexable } from '@conduitplatform/grpc-
 const deepdash = require('deepdash/standalone');
 
 const incrementDbQueries = () =>
-  ConduitGrpcSdk.Metrics.increment('database_queries_total');
+  ConduitGrpcSdk.Metrics?.increment('database_queries_total');
 
 export class SequelizeSchema implements SchemaAdapter<ModelCtor<any>> {
   model: ModelCtor<any>;


### PR DESCRIPTION
Fixes a crash where Sequelize would unconditionally attempt to make use of metrics while the feature is disabled.
Fixes `grpc-sdk`'s static `metrics` member being required.

**What kind of change does this PR introduce?** <!--(check at least one)-->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other (please describe)

**Does this PR introduce a breaking change?** <!-- (check one) -->

- [ ] Yes
- [X] No

<!-- If yes, please describe the impact and migration path for existing applications. -->

**The PR fulfills these requirements:**

- [X] It's submitted to the `main` branch
- [ ] When resolving a specific issue, it's referenced in the PR's description  (e.g. `fix #xxx`, where "xxx" is the issue number)