### PR TITLE
refactor: rename schemaOptions, modelSchema to modelOptions, fields

### DIFF
--- a/libraries/grpc-sdk/src/classes/ConduitActiveSchema.ts
+++ b/libraries/grpc-sdk/src/classes/ConduitActiveSchema.ts
@@ -10,10 +10,10 @@ export class ConduitActiveSchema<T> extends ConduitSchema {
     dbInstance: DatabaseProvider,
     name: string,
     fields?: ConduitModel,
-    options?: ConduitSchemaOptions,
+    modelOptions?: ConduitSchemaOptions,
     collectionName?: string,
   ) {
-    super(name, fields ?? {}, options, collectionName);
+    super(name, fields ?? {}, modelOptions, collectionName);
     this.dbInstance = dbInstance;
   }
 

--- a/libraries/grpc-sdk/src/classes/ConduitActiveSchema.ts
+++ b/libraries/grpc-sdk/src/classes/ConduitActiveSchema.ts
@@ -1,4 +1,4 @@
-import { ConduitModel, ConduitModelOptions } from '../interfaces';
+import { ConduitModel, ConduitSchemaOptions } from '../interfaces';
 import { ConduitSchema } from './ConduitSchema';
 import { DatabaseProvider } from '../modules';
 import { Query } from '../interfaces';
@@ -10,10 +10,10 @@ export class ConduitActiveSchema<T> extends ConduitSchema {
     dbInstance: DatabaseProvider,
     name: string,
     fields?: ConduitModel,
-    schemaOptions?: ConduitModelOptions,
+    options?: ConduitSchemaOptions,
     collectionName?: string,
   ) {
-    super(name, fields ?? {}, schemaOptions, collectionName);
+    super(name, fields ?? {}, options, collectionName);
     this.dbInstance = dbInstance;
   }
 

--- a/libraries/grpc-sdk/src/classes/ConduitSchema.ts
+++ b/libraries/grpc-sdk/src/classes/ConduitSchema.ts
@@ -1,21 +1,21 @@
-import { ConduitModel, ConduitModelOptions } from '../interfaces';
+import { ConduitModel, ConduitSchemaOptions } from '../interfaces';
 
 export class ConduitSchema {
   readonly name: string;
   readonly fields: ConduitModel;
   readonly collectionName: string | ''; // '' on implicit name, updated in createSchemaFromAdapter()
-  readonly schemaOptions: ConduitModelOptions;
+  readonly options: ConduitSchemaOptions;
   ownerModule: string = 'unknown';
 
   constructor(
     name: string,
     fields: ConduitModel,
-    schemaOptions?: ConduitModelOptions,
+    options?: ConduitSchemaOptions,
     collectionName?: string,
   ) {
     this.name = name;
     this.fields = fields;
-    this.schemaOptions = schemaOptions ?? {};
+    this.options = options ?? {};
     this.collectionName = collectionName && collectionName !== '' ? collectionName : '';
   }
 

--- a/libraries/grpc-sdk/src/classes/ConduitSchema.ts
+++ b/libraries/grpc-sdk/src/classes/ConduitSchema.ts
@@ -18,8 +18,4 @@ export class ConduitSchema {
     this.options = options ?? {};
     this.collectionName = collectionName && collectionName !== '' ? collectionName : '';
   }
-
-  get modelSchema(): ConduitModel {
-    return this.fields;
-  }
 }

--- a/libraries/grpc-sdk/src/classes/ConduitSchema.ts
+++ b/libraries/grpc-sdk/src/classes/ConduitSchema.ts
@@ -4,18 +4,18 @@ export class ConduitSchema {
   readonly name: string;
   readonly fields: ConduitModel;
   readonly collectionName: string | ''; // '' on implicit name, updated in createSchemaFromAdapter()
-  readonly options: ConduitSchemaOptions;
+  readonly modelOptions: ConduitSchemaOptions;
   ownerModule: string = 'unknown';
 
   constructor(
     name: string,
     fields: ConduitModel,
-    options?: ConduitSchemaOptions,
+    modelOptions?: ConduitSchemaOptions,
     collectionName?: string,
   ) {
     this.name = name;
     this.fields = fields;
-    this.options = options ?? {};
+    this.modelOptions = modelOptions ?? {};
     this.collectionName = collectionName && collectionName !== '' ? collectionName : '';
   }
 }

--- a/libraries/grpc-sdk/src/classes/ConduitSchemaExtension.ts
+++ b/libraries/grpc-sdk/src/classes/ConduitSchemaExtension.ts
@@ -8,8 +8,4 @@ export class ConduitSchemaExtension {
     this.name = name;
     this.fields = fields;
   }
-
-  get modelSchema(): ConduitModel {
-    return this.fields;
-  }
 }

--- a/libraries/grpc-sdk/src/interfaces/Model.ts
+++ b/libraries/grpc-sdk/src/interfaces/Model.ts
@@ -37,7 +37,7 @@ export const ConduitModelOptionsPermModifyType = [
   'ExtensionOnly',
 ];
 
-export interface ConduitModelOptions {
+export interface ConduitSchemaOptions {
   timestamps?: boolean;
   _id?: boolean;
   conduit?: {

--- a/libraries/grpc-sdk/src/modules/database/index.ts
+++ b/libraries/grpc-sdk/src/modules/database/index.ts
@@ -3,6 +3,7 @@ import { ConduitSchema, ConduitSchemaExtension } from '../../classes';
 import {
   DatabaseProviderDefinition,
   DropCollectionResponse,
+  Schema,
 } from '../../protoUtils/database';
 import { Query } from '../../interfaces';
 
@@ -17,21 +18,21 @@ export class DatabaseProvider extends ConduitModule<typeof DatabaseProviderDefin
   ): Promise<{ name: string; modelSchema: any; modelOptions: any }> {
     return this.client!.getSchema({ schemaName: schemaName }).then(res => {
       return {
-        name: res.schema!.name,
-        modelSchema: JSON.parse(res.schema!.modelSchema),
-        modelOptions: JSON.parse(res.schema!.modelOptions),
+        name: res.name,
+        modelSchema: JSON.parse(res.fields),
+        modelOptions: JSON.parse(res.options),
       };
     });
   }
 
-  getSchemas(): Promise<any> {
+  getSchemas(): Promise<{ name: string; modelSchema: any; modelOptions: any }[]> {
     return this.client!.getSchemas({}).then(res => {
       return res.schemas.map(
-        (schema: { name: string; modelSchema: string; modelOptions: string }) => {
+        (schema: { name: string; fields: string; options: string }) => {
           return {
             name: schema.name,
-            modelSchema: JSON.parse(schema.modelSchema),
-            modelOptions: JSON.parse(schema.modelOptions),
+            modelSchema: JSON.parse(schema.fields),
+            modelOptions: JSON.parse(schema.options),
           };
         },
       );
@@ -42,36 +43,34 @@ export class DatabaseProvider extends ConduitModule<typeof DatabaseProviderDefin
     return this.client!.deleteSchema({ schemaName, deleteData });
   }
 
-  createSchemaFromAdapter(schema: ConduitSchema): Promise<any> {
+  createSchemaFromAdapter(schema: ConduitSchema): Promise<Schema> {
     return this.client!.createSchemaFromAdapter({
-      schema: {
-        name: schema.name,
-        modelSchema: JSON.stringify(schema.fields ?? schema.modelSchema),
-        modelOptions: JSON.stringify(schema.schemaOptions),
-        collectionName: schema.collectionName,
-      },
+      name: schema.name,
+      fields: JSON.stringify(schema.fields),
+      options: JSON.stringify(schema.options),
+      collectionName: schema.collectionName,
     }).then(res => {
       return {
-        name: res.schema!.name,
-        modelSchema: JSON.parse(res.schema!.modelSchema),
-        modelOptions: JSON.parse(res.schema!.modelOptions),
-        collectionName: res.schema!.collectionName,
+        name: res.name,
+        fields: JSON.parse(res.fields),
+        options: JSON.parse(res.options),
+        collectionName: res.collectionName,
       };
     });
   }
 
-  setSchemaExtension(extension: ConduitSchemaExtension): Promise<any> {
+  setSchemaExtension(extension: ConduitSchemaExtension): Promise<Schema> {
     return this.client!.setSchemaExtension({
       extension: {
         name: extension.name,
-        modelSchema: JSON.stringify(extension.fields ?? extension.modelSchema),
+        fields: JSON.stringify(extension.fields ?? extension.modelSchema),
       },
     }).then(res => {
       return {
-        name: res.schema!.name,
-        modelSchema: JSON.parse(res.schema!.modelSchema),
-        modelOptions: JSON.parse(res.schema!.modelOptions),
-        collectionName: res.schema!.collectionName,
+        name: res.name,
+        fields: JSON.parse(res.fields),
+        options: JSON.parse(res.options),
+        collectionName: res.collectionName,
       };
     });
   }

--- a/libraries/grpc-sdk/src/modules/database/index.ts
+++ b/libraries/grpc-sdk/src/modules/database/index.ts
@@ -15,23 +15,23 @@ export class DatabaseProvider extends ConduitModule<typeof DatabaseProviderDefin
 
   getSchema(
     schemaName: string,
-  ): Promise<{ name: string; modelSchema: any; modelOptions: any }> {
+  ): Promise<{ name: string; fields: any; modelOptions: any }> {
     return this.client!.getSchema({ schemaName: schemaName }).then(res => {
       return {
         name: res.name,
-        modelSchema: JSON.parse(res.fields),
+        fields: JSON.parse(res.fields),
         modelOptions: JSON.parse(res.options),
       };
     });
   }
 
-  getSchemas(): Promise<{ name: string; modelSchema: any; modelOptions: any }[]> {
+  getSchemas(): Promise<{ name: string; fields: any; modelOptions: any }[]> {
     return this.client!.getSchemas({}).then(res => {
       return res.schemas.map(
         (schema: { name: string; fields: string; options: string }) => {
           return {
             name: schema.name,
-            modelSchema: JSON.parse(schema.fields),
+            fields: JSON.parse(schema.fields),
             modelOptions: JSON.parse(schema.options),
           };
         },
@@ -63,7 +63,7 @@ export class DatabaseProvider extends ConduitModule<typeof DatabaseProviderDefin
     return this.client!.setSchemaExtension({
       extension: {
         name: extension.name,
-        fields: JSON.stringify(extension.fields ?? extension.modelSchema),
+        fields: JSON.stringify(extension.fields ?? extension.fields),
       },
     }).then(res => {
       return {

--- a/libraries/grpc-sdk/src/modules/database/index.ts
+++ b/libraries/grpc-sdk/src/modules/database/index.ts
@@ -20,7 +20,7 @@ export class DatabaseProvider extends ConduitModule<typeof DatabaseProviderDefin
       return {
         name: res.name,
         fields: JSON.parse(res.fields),
-        modelOptions: JSON.parse(res.options),
+        modelOptions: JSON.parse(res.modelOptions),
       };
     });
   }
@@ -28,11 +28,11 @@ export class DatabaseProvider extends ConduitModule<typeof DatabaseProviderDefin
   getSchemas(): Promise<{ name: string; fields: any; modelOptions: any }[]> {
     return this.client!.getSchemas({}).then(res => {
       return res.schemas.map(
-        (schema: { name: string; fields: string; options: string }) => {
+        (schema: { name: string; fields: string; modelOptions: string }) => {
           return {
             name: schema.name,
             fields: JSON.parse(schema.fields),
-            modelOptions: JSON.parse(schema.options),
+            modelOptions: JSON.parse(schema.modelOptions),
           };
         },
       );
@@ -47,13 +47,13 @@ export class DatabaseProvider extends ConduitModule<typeof DatabaseProviderDefin
     return this.client!.createSchemaFromAdapter({
       name: schema.name,
       fields: JSON.stringify(schema.fields),
-      options: JSON.stringify(schema.options),
+      modelOptions: JSON.stringify(schema.modelOptions),
       collectionName: schema.collectionName,
     }).then(res => {
       return {
         name: res.name,
         fields: JSON.parse(res.fields),
-        options: JSON.parse(res.options),
+        modelOptions: JSON.parse(res.modelOptions),
         collectionName: res.collectionName,
       };
     });
@@ -69,7 +69,7 @@ export class DatabaseProvider extends ConduitModule<typeof DatabaseProviderDefin
       return {
         name: res.name,
         fields: JSON.parse(res.fields),
-        options: JSON.parse(res.options),
+        modelOptions: JSON.parse(res.modelOptions),
         collectionName: res.collectionName,
       };
     });

--- a/libraries/hermes/src/Rest/util.ts
+++ b/libraries/hermes/src/Rest/util.ts
@@ -4,12 +4,12 @@ import {
   TYPE,
   Indexable,
   Params,
-  ConduitModelOptions,
+  ConduitSchemaOptions,
 } from '@conduitplatform/grpc-sdk';
 import { isArray, isNil, isObject } from 'lodash';
 
 export function extractRequestData(req: Request) {
-  const context = (req as ConduitModelOptions).conduit || {};
+  const context = (req as ConduitSchemaOptions).conduit || {};
   const params: any = {};
   const headers = req.headers;
   if (req.query) {

--- a/modules/authentication/src/models/AccessToken.schema.ts
+++ b/modules/authentication/src/models/AccessToken.schema.ts
@@ -23,7 +23,7 @@ const schema = {
   createdAt: TYPE.Date,
   updatedAt: TYPE.Date,
 };
-const schemaOptions = {
+const modelOptions = {
   timestamps: true,
   conduit: {
     permissions: {
@@ -47,7 +47,7 @@ export class AccessToken extends ConduitActiveSchema<AccessToken> {
   updatedAt: Date;
 
   private constructor(database: DatabaseProvider) {
-    super(database, AccessToken.name, schema, schemaOptions, collectionName);
+    super(database, AccessToken.name, schema, modelOptions, collectionName);
   }
 
   static getInstance(database?: DatabaseProvider) {

--- a/modules/authentication/src/models/RefreshToken.schema.ts
+++ b/modules/authentication/src/models/RefreshToken.schema.ts
@@ -27,7 +27,7 @@ const schema = {
   createdAt: TYPE.Date,
   updatedAt: TYPE.Date,
 };
-const schemaOptions = {
+const modelOptions = {
   timestamps: true,
   conduit: {
     permissions: {
@@ -55,7 +55,7 @@ export class RefreshToken extends ConduitActiveSchema<RefreshToken> {
   updatedAt: Date;
 
   private constructor(database: DatabaseProvider) {
-    super(database, RefreshToken.name, schema, schemaOptions, collectionName);
+    super(database, RefreshToken.name, schema, modelOptions, collectionName);
   }
 
   static getInstance(database?: DatabaseProvider) {

--- a/modules/authentication/src/models/Service.schema.ts
+++ b/modules/authentication/src/models/Service.schema.ts
@@ -19,7 +19,7 @@ const schema = {
   createdAt: TYPE.Date,
   updatedAt: TYPE.Date,
 };
-const schemaOptions = {
+const modelOptions = {
   timestamps: true,
   conduit: {
     permissions: {
@@ -41,7 +41,7 @@ export class Service extends ConduitActiveSchema<Service> {
   updatedAt: Date;
 
   private constructor(database: DatabaseProvider) {
-    super(database, Service.name, schema, schemaOptions, collectionName);
+    super(database, Service.name, schema, modelOptions, collectionName);
   }
 
   static getInstance(database?: DatabaseProvider) {

--- a/modules/authentication/src/models/Token.schema.ts
+++ b/modules/authentication/src/models/Token.schema.ts
@@ -22,7 +22,7 @@ const schema = {
   createdAt: TYPE.Date,
   updatedAt: TYPE.Date,
 };
-const schemaOptions = {
+const modelOptions = {
   timestamps: true,
   conduit: {
     permissions: {
@@ -46,7 +46,7 @@ export class Token extends ConduitActiveSchema<Token> {
   updatedAt: Date;
 
   constructor(database: DatabaseProvider) {
-    super(database, Token.name, schema, schemaOptions, collectionName);
+    super(database, Token.name, schema, modelOptions, collectionName);
   }
 
   static getInstance(database?: DatabaseProvider) {

--- a/modules/authentication/src/models/TwoFactorSecret.schema.ts
+++ b/modules/authentication/src/models/TwoFactorSecret.schema.ts
@@ -24,7 +24,7 @@ const schema = {
   updatedAt: TYPE.Date,
 };
 
-const schemaOptions = {
+const modelOptions = {
   timestamps: true,
   conduit: {
     permissions: {
@@ -48,7 +48,7 @@ export class TwoFactorSecret extends ConduitActiveSchema<TwoFactorSecret> {
   updatedAt: Date;
 
   constructor(database: DatabaseProvider) {
-    super(database, TwoFactorSecret.name, schema, schemaOptions, collectionName);
+    super(database, TwoFactorSecret.name, schema, modelOptions, collectionName);
   }
 
   static getInstance(database?: DatabaseProvider) {

--- a/modules/authentication/src/models/User.schema.ts
+++ b/modules/authentication/src/models/User.schema.ts
@@ -147,7 +147,7 @@ const schema = {
   createdAt: TYPE.Date,
   updatedAt: TYPE.Date,
 };
-const schemaOptions = {
+const modelOptions = {
   timestamps: true,
   conduit: {
     permissions: {
@@ -225,7 +225,7 @@ export class User extends ConduitActiveSchema<User> {
   updatedAt: Date;
 
   constructor(database: DatabaseProvider) {
-    super(database, User.name, schema, schemaOptions, collectionName);
+    super(database, User.name, schema, modelOptions, collectionName);
   }
 
   static getInstance(database?: DatabaseProvider) {

--- a/modules/chat/src/models/ChatRoom.schema.ts
+++ b/modules/chat/src/models/ChatRoom.schema.ts
@@ -17,7 +17,7 @@ const schema = {
   createdAt: TYPE.Date,
   updatedAt: TYPE.Date,
 };
-const schemaOptions = {
+const modelOptions = {
   timestamps: true,
   conduit: {
     permissions: {
@@ -39,7 +39,7 @@ export class ChatRoom extends ConduitActiveSchema<ChatRoom> {
   updatedAt!: Date;
 
   private constructor(database: DatabaseProvider) {
-    super(database, ChatRoom.name, schema, schemaOptions, collectionName);
+    super(database, ChatRoom.name, schema, modelOptions, collectionName);
   }
 
   static getInstance(database?: DatabaseProvider) {

--- a/modules/chat/src/models/InvitationToken.schema.ts
+++ b/modules/chat/src/models/InvitationToken.schema.ts
@@ -26,7 +26,7 @@ const schema = {
   createdAt: TYPE.Date,
   updatedAt: TYPE.Date,
 };
-const schemaOptions = {
+const modelOptions = {
   timestamps: true,
   conduit: {
     permissions: {
@@ -50,7 +50,7 @@ export class InvitationToken extends ConduitActiveSchema<InvitationToken> {
   updatedAt: Date;
 
   constructor(database: DatabaseProvider) {
-    super(database, InvitationToken.name, schema, schemaOptions, collectionName);
+    super(database, InvitationToken.name, schema, modelOptions, collectionName);
   }
 
   static getInstance(database?: DatabaseProvider) {

--- a/modules/chat/src/models/Message.schema.ts
+++ b/modules/chat/src/models/Message.schema.ts
@@ -28,7 +28,7 @@ const schema = {
   createdAt: TYPE.Date,
   updatedAt: TYPE.Date,
 };
-const schemaOptions = {
+const modelOptions = {
   timestamps: true,
   conduit: {
     permissions: {
@@ -52,7 +52,7 @@ export class ChatMessage extends ConduitActiveSchema<ChatMessage> {
   updatedAt!: Date;
 
   private constructor(database: DatabaseProvider) {
-    super(database, ChatMessage.name, schema, schemaOptions, collectionName);
+    super(database, ChatMessage.name, schema, modelOptions, collectionName);
   }
 
   static getInstance(database?: DatabaseProvider) {

--- a/modules/database/src/Database.ts
+++ b/modules/database/src/Database.ts
@@ -116,7 +116,7 @@ export default class DatabaseModule extends ManagedModule<void> {
           const schema = new ConduitSchema(
             receivedSchema.name,
             receivedSchema.fields,
-            receivedSchema.options,
+            receivedSchema.modelOptions,
             receivedSchema.collectionName,
           );
           schema.ownerModule = receivedSchema.ownerModule;
@@ -192,7 +192,7 @@ export default class DatabaseModule extends ManagedModule<void> {
     const schema = new ConduitSchema(
       call.request.name,
       JSON.parse(call.request.fields),
-      JSON.parse(call.request.options),
+      JSON.parse(call.request.modelOptions),
       call.request.collectionName,
     );
     if (schema.name.indexOf('-') >= 0 || schema.name.indexOf(' ') >= 0) {
@@ -207,15 +207,15 @@ export default class DatabaseModule extends ManagedModule<void> {
       .then((schemaAdapter: Schema) => {
         this.publishSchema({
           name: call.request.name,
-          fields: JSON.parse(call.request.options),
-          options: JSON.parse(call.request.options),
+          fields: JSON.parse(call.request.fields),
+          modelOptions: JSON.parse(call.request.modelOptions),
           collectionName: call.request.collectionName,
           owner: schema.ownerModule,
         });
         callback(null, {
           name: schemaAdapter.originalSchema.name,
           fields: JSON.stringify(schemaAdapter.originalSchema.fields),
-          options: JSON.stringify(schemaAdapter.originalSchema.options),
+          modelOptions: JSON.stringify(schemaAdapter.originalSchema.modelOptions),
           collectionName: schemaAdapter.originalSchema.collectionName,
         });
       })
@@ -238,7 +238,7 @@ export default class DatabaseModule extends ManagedModule<void> {
       callback(null, {
         name: schemaAdapter.name,
         fields: JSON.stringify(schemaAdapter.fields),
-        options: JSON.stringify(schemaAdapter.options),
+        modelOptions: JSON.stringify(schemaAdapter.modelOptions),
         collectionName: schemaAdapter.collectionName,
       });
     } catch (err) {
@@ -257,7 +257,7 @@ export default class DatabaseModule extends ManagedModule<void> {
           return {
             name: schema.name,
             fields: JSON.stringify(schema.fields),
-            options: JSON.stringify(schema.options),
+            modelOptions: JSON.stringify(schema.modelOptions),
             collectionName: schema.collectionName,
           };
         }),
@@ -309,14 +309,14 @@ export default class DatabaseModule extends ManagedModule<void> {
           this.publishSchema({
             name: call.request.extension.name,
             schema: schemaAdapter.model,
-            options: schemaAdapter.originalSchema.options,
+            modelOptions: schemaAdapter.originalSchema.modelOptions,
             collectionName: schemaAdapter.originalSchema.collectionName,
             owner: schemaAdapter.originalSchema.ownerModule,
           });
           callback(null, {
             name: schemaAdapter.originalSchema.name,
             fields: JSON.stringify(schemaAdapter.originalSchema.fields),
-            options: JSON.stringify(schemaAdapter.originalSchema.options),
+            modelOptions: JSON.stringify(schemaAdapter.originalSchema.modelOptions),
             collectionName: schemaAdapter.originalSchema.collectionName,
           });
         })

--- a/modules/database/src/Database.ts
+++ b/modules/database/src/Database.ts
@@ -10,7 +10,7 @@ import { AdminHandlers } from './admin';
 import { DatabaseRoutes } from './routes';
 import * as models from './models';
 import {
-  CreateSchemaRequest,
+  Schema as SchemaDto,
   DropCollectionRequest,
   DropCollectionResponse,
   FindOneRequest,
@@ -188,15 +188,12 @@ export default class DatabaseModule extends ManagedModule<void> {
    * @param call
    * @param callback
    */
-  async createSchemaFromAdapter(
-    call: GrpcRequest<CreateSchemaRequest>,
-    callback: SchemaResponse,
-  ) {
+  async createSchemaFromAdapter(call: GrpcRequest<SchemaDto>, callback: SchemaResponse) {
     const schema = new ConduitSchema(
-      call.request.schema!.name,
-      JSON.parse(call.request.schema!.modelSchema),
-      JSON.parse(call.request.schema!.modelOptions),
-      call.request.schema!.collectionName,
+      call.request.name,
+      JSON.parse(call.request.fields),
+      JSON.parse(call.request.options),
+      call.request.collectionName,
     );
     if (schema.name.indexOf('-') >= 0 || schema.name.indexOf(' ') >= 0) {
       return callback({
@@ -211,14 +208,14 @@ export default class DatabaseModule extends ManagedModule<void> {
         const originalSchema = {
           name: schemaAdapter.originalSchema.name,
           modelSchema: JSON.stringify(schemaAdapter.originalSchema.modelSchema),
-          modelOptions: JSON.stringify(schemaAdapter.originalSchema.schemaOptions),
+          modelOptions: JSON.stringify(schemaAdapter.originalSchema.options),
           collectionName: schemaAdapter.originalSchema.collectionName,
         };
         this.publishSchema({
-          name: call.request.schema!.name,
-          modelSchema: JSON.parse(call.request.schema!.modelSchema),
-          modelOptions: JSON.parse(call.request.schema!.modelOptions),
-          collectionName: call.request.schema!.collectionName,
+          name: call.request.name,
+          modelSchema: JSON.parse(call.request.options),
+          modelOptions: JSON.parse(call.request.options),
+          collectionName: call.request.collectionName,
           owner: schema.ownerModule,
         });
         callback(null, {
@@ -245,7 +242,7 @@ export default class DatabaseModule extends ManagedModule<void> {
         schema: {
           name: schemaAdapter.name,
           modelSchema: JSON.stringify(schemaAdapter.modelSchema),
-          modelOptions: JSON.stringify(schemaAdapter.schemaOptions),
+          modelOptions: JSON.stringify(schemaAdapter.options),
           collectionName: schemaAdapter.collectionName,
         },
       });
@@ -265,7 +262,7 @@ export default class DatabaseModule extends ManagedModule<void> {
           return {
             name: schema.name,
             modelSchema: JSON.stringify(schema.modelSchema),
-            modelOptions: JSON.stringify(schema.schemaOptions),
+            modelOptions: JSON.stringify(schema.options),
             collectionName: schema.collectionName,
           };
         }),
@@ -317,13 +314,13 @@ export default class DatabaseModule extends ManagedModule<void> {
           const originalSchema = {
             name: schemaAdapter.originalSchema.name,
             modelSchema: JSON.stringify(schemaAdapter.originalSchema.modelSchema),
-            modelOptions: JSON.stringify(schemaAdapter.originalSchema.schemaOptions),
+            modelOptions: JSON.stringify(schemaAdapter.originalSchema.options),
             collectionName: schemaAdapter.originalSchema.collectionName,
           };
           this.publishSchema({
             name: call.request.extension.name,
             modelSchema: schemaAdapter.model,
-            modelOptions: schemaAdapter.originalSchema.schemaOptions,
+            modelOptions: schemaAdapter.originalSchema.options,
             collectionName: schemaAdapter.originalSchema.collectionName,
             owner: schemaAdapter.originalSchema.ownerModule,
           });

--- a/modules/database/src/Database.ts
+++ b/modules/database/src/Database.ts
@@ -115,8 +115,8 @@ export default class DatabaseModule extends ManagedModule<void> {
         if (receivedSchema.name) {
           const schema = new ConduitSchema(
             receivedSchema.name,
-            receivedSchema.modelSchema,
-            receivedSchema.modelOptions,
+            receivedSchema.fields,
+            receivedSchema.options,
             receivedSchema.collectionName,
           );
           schema.ownerModule = receivedSchema.ownerModule;
@@ -207,8 +207,8 @@ export default class DatabaseModule extends ManagedModule<void> {
       .then((schemaAdapter: Schema) => {
         this.publishSchema({
           name: call.request.name,
-          modelSchema: JSON.parse(call.request.options),
-          modelOptions: JSON.parse(call.request.options),
+          fields: JSON.parse(call.request.options),
+          options: JSON.parse(call.request.options),
           collectionName: call.request.collectionName,
           owner: schema.ownerModule,
         });

--- a/modules/database/src/adapters/DatabaseAdapter.ts
+++ b/modules/database/src/adapters/DatabaseAdapter.ts
@@ -1,6 +1,6 @@
 import ConduitGrpcSdk, {
   ConduitModel,
-  ConduitModelOptions,
+  ConduitSchemaOptions,
   ConduitSchema,
   GrpcError,
 } from '@conduitplatform/grpc-sdk';
@@ -11,7 +11,7 @@ import { isNil } from 'lodash';
 import { ConduitDatabaseSchema } from '../interfaces/ConduitDatabaseSchema';
 
 type _ConduitSchema = Omit<ConduitSchema, 'schemaOptions'> & {
-  modelOptions: ConduitModelOptions;
+  modelOptions: ConduitSchemaOptions;
   extensions: DeclaredSchemaExtension[];
   compiledFields: ConduitModel;
 } & {
@@ -189,7 +189,7 @@ export abstract class DatabaseAdapter<T extends Schema> {
           fields: schema.fields,
           extensions: (schema as ConduitDatabaseSchema).extensions,
           compiledFields: (schema as ConduitDatabaseSchema).compiledFields,
-          modelOptions: schema.schemaOptions,
+          modelOptions: schema.options,
           ownerModule: schema.ownerModule,
           collectionName: schema.collectionName,
         }),
@@ -202,7 +202,7 @@ export abstract class DatabaseAdapter<T extends Schema> {
           fields: schema.fields,
           extensions: (schema as ConduitDatabaseSchema).extensions,
           compiledFields: (schema as ConduitDatabaseSchema).compiledFields,
-          modelOptions: schema.schemaOptions,
+          modelOptions: schema.options,
           ownerModule: schema.ownerModule,
           collectionName: schema.collectionName,
         }),
@@ -242,9 +242,9 @@ export abstract class DatabaseAdapter<T extends Schema> {
     extFields: ConduitSchema['fields'],
   ): Promise<Schema> {
     if (
-      !schema.schemaOptions.conduit ||
-      !schema.schemaOptions.conduit.permissions ||
-      !schema.schemaOptions.conduit.permissions.extendable
+      !schema.options.conduit ||
+      !schema.options.conduit.permissions ||
+      !schema.options.conduit.permissions.extendable
     ) {
       throw new GrpcError(status.INVALID_ARGUMENT, 'Schema is not extendable');
     }
@@ -289,12 +289,12 @@ export abstract class DatabaseAdapter<T extends Schema> {
       canModify: 'Everything',
       canDelete: true,
     } as const;
-    if (isNil(schema.schemaOptions.conduit)) schema.schemaOptions.conduit = {};
-    if (isNil(schema.schemaOptions.conduit.permissions)) {
-      schema.schemaOptions.conduit!.permissions = defaultPermissions;
+    if (isNil(schema.options.conduit)) schema.options.conduit = {};
+    if (isNil(schema.options.conduit.permissions)) {
+      schema.options.conduit!.permissions = defaultPermissions;
     } else {
       Object.keys(defaultPermissions).forEach(perm => {
-        if (!schema.schemaOptions.conduit!.permissions!.hasOwnProperty(perm)) {
+        if (!schema.options.conduit!.permissions!.hasOwnProperty(perm)) {
           // @ts-ignore
           schema.schemaOptions.conduit!.permissions![perm] =
             defaultPermissions[perm as keyof typeof defaultPermissions];

--- a/modules/database/src/adapters/DatabaseAdapter.ts
+++ b/modules/database/src/adapters/DatabaseAdapter.ts
@@ -10,7 +10,7 @@ import { status } from '@grpc/grpc-js';
 import { isNil } from 'lodash';
 import { ConduitDatabaseSchema } from '../interfaces/ConduitDatabaseSchema';
 
-type _ConduitSchema = Omit<ConduitSchema, 'schemaOptions'> & {
+type _ConduitSchema = Omit<ConduitSchema, 'modelOptions'> & {
   modelOptions: ConduitSchemaOptions;
   extensions: DeclaredSchemaExtension[];
   compiledFields: ConduitModel;
@@ -189,7 +189,7 @@ export abstract class DatabaseAdapter<T extends Schema> {
           fields: schema.fields,
           extensions: (schema as ConduitDatabaseSchema).extensions,
           compiledFields: (schema as ConduitDatabaseSchema).compiledFields,
-          modelOptions: schema.options,
+          modelOptions: schema.modelOptions,
           ownerModule: schema.ownerModule,
           collectionName: schema.collectionName,
         }),
@@ -202,7 +202,7 @@ export abstract class DatabaseAdapter<T extends Schema> {
           fields: schema.fields,
           extensions: (schema as ConduitDatabaseSchema).extensions,
           compiledFields: (schema as ConduitDatabaseSchema).compiledFields,
-          modelOptions: schema.options,
+          modelOptions: schema.modelOptions,
           ownerModule: schema.ownerModule,
           collectionName: schema.collectionName,
         }),
@@ -242,9 +242,9 @@ export abstract class DatabaseAdapter<T extends Schema> {
     extFields: ConduitSchema['fields'],
   ): Promise<Schema> {
     if (
-      !schema.options.conduit ||
-      !schema.options.conduit.permissions ||
-      !schema.options.conduit.permissions.extendable
+      !schema.modelOptions.conduit ||
+      !schema.modelOptions.conduit.permissions ||
+      !schema.modelOptions.conduit.permissions.extendable
     ) {
       throw new GrpcError(status.INVALID_ARGUMENT, 'Schema is not extendable');
     }
@@ -289,14 +289,14 @@ export abstract class DatabaseAdapter<T extends Schema> {
       canModify: 'Everything',
       canDelete: true,
     } as const;
-    if (isNil(schema.options.conduit)) schema.options.conduit = {};
-    if (isNil(schema.options.conduit.permissions)) {
-      schema.options.conduit!.permissions = defaultPermissions;
+    if (isNil(schema.modelOptions.conduit)) schema.modelOptions.conduit = {};
+    if (isNil(schema.modelOptions.conduit.permissions)) {
+      schema.modelOptions.conduit!.permissions = defaultPermissions;
     } else {
       Object.keys(defaultPermissions).forEach(perm => {
-        if (!schema.options.conduit!.permissions!.hasOwnProperty(perm)) {
+        if (!schema.modelOptions.conduit!.permissions!.hasOwnProperty(perm)) {
           // @ts-ignore
-          schema.schemaOptions.conduit!.permissions![perm] =
+          schema.modelOptions.conduit!.permissions![perm] =
             defaultPermissions[perm as keyof typeof defaultPermissions];
         }
       });

--- a/modules/database/src/adapters/mongoose-adapter/MongooseSchema.ts
+++ b/modules/database/src/adapters/mongoose-adapter/MongooseSchema.ts
@@ -37,7 +37,7 @@ export class MongooseSchema implements SchemaAdapter<Model<any>> {
     } else {
       (schema as Indexable).collectionName = schema.name; //restore collectionName
     }
-    const mongooseSchema = new Schema(schema.modelSchema, schema.options);
+    const mongooseSchema = new Schema(schema.fields, schema.options);
     mongooseSchema.plugin(deepPopulate, {});
     this.model = mongoose.model(schema.name, mongooseSchema);
   }
@@ -148,7 +148,7 @@ export class MongooseSchema implements SchemaAdapter<Model<any>> {
         r = final.split('.');
         let controlBool = true;
         while (controlBool) {
-          if (this.originalSchema.modelSchema[r[0]]) {
+          if (this.originalSchema.fields[r[0]]) {
             controlBool = false;
           } else if (r[0] === undefined || r[0].length === 0 || r[0] === '') {
             throw new Error("Failed populating '" + final + "'");

--- a/modules/database/src/adapters/mongoose-adapter/MongooseSchema.ts
+++ b/modules/database/src/adapters/mongoose-adapter/MongooseSchema.ts
@@ -33,11 +33,11 @@ export class MongooseSchema implements SchemaAdapter<Model<any>> {
     this.originalSchema = originalSchema;
 
     if (!isNil(schema.collectionName)) {
-      (schema.options as _ConduitSchemaOptions).collection = schema.collectionName;
+      (schema.modelOptions as _ConduitSchemaOptions).collection = schema.collectionName;
     } else {
       (schema as Indexable).collectionName = schema.name; //restore collectionName
     }
-    const mongooseSchema = new Schema(schema.fields, schema.options);
+    const mongooseSchema = new Schema(schema.fields, schema.modelOptions);
     mongooseSchema.plugin(deepPopulate, {});
     this.model = mongoose.model(schema.name, mongooseSchema);
   }

--- a/modules/database/src/adapters/mongoose-adapter/MongooseSchema.ts
+++ b/modules/database/src/adapters/mongoose-adapter/MongooseSchema.ts
@@ -7,13 +7,17 @@ import {
   SingleDocQuery,
 } from '../../interfaces';
 import { MongooseAdapter } from './index';
-import { ConduitModelOptions, ConduitSchema, Indexable } from '@conduitplatform/grpc-sdk';
+import {
+  ConduitSchemaOptions,
+  ConduitSchema,
+  Indexable,
+} from '@conduitplatform/grpc-sdk';
 import { createWithPopulations } from './utils';
 import { isNil } from 'lodash';
 
 const EJSON = require('mongodb-extended-json');
 
-type _ConduitModelOptions = ConduitModelOptions & { collection: string };
+type _ConduitSchemaOptions = ConduitSchemaOptions & { collection: string };
 
 export class MongooseSchema implements SchemaAdapter<Model<any>> {
   model: Model<any>;
@@ -29,11 +33,11 @@ export class MongooseSchema implements SchemaAdapter<Model<any>> {
     this.originalSchema = originalSchema;
 
     if (!isNil(schema.collectionName)) {
-      (schema.schemaOptions as _ConduitModelOptions).collection = schema.collectionName;
+      (schema.options as _ConduitSchemaOptions).collection = schema.collectionName;
     } else {
       (schema as Indexable).collectionName = schema.name; //restore collectionName
     }
-    const mongooseSchema = new Schema(schema.modelSchema, schema.schemaOptions);
+    const mongooseSchema = new Schema(schema.modelSchema, schema.options);
     mongooseSchema.plugin(deepPopulate, {});
     this.model = mongoose.model(schema.name, mongooseSchema);
   }

--- a/modules/database/src/adapters/mongoose-adapter/SchemaConverter.ts
+++ b/modules/database/src/adapters/mongoose-adapter/SchemaConverter.ts
@@ -9,11 +9,11 @@ const deepdash = require('deepdash/standalone');
  */
 export function schemaConverter(jsonSchema: ConduitSchema) {
   const copy = cloneDeep(jsonSchema);
-  if (copy.modelSchema.hasOwnProperty('_id')) {
-    delete copy.modelSchema['_id'];
+  if (copy.fields.hasOwnProperty('_id')) {
+    delete copy.fields['_id'];
   }
 
-  deepdash.eachDeep(copy.modelSchema, convert);
+  deepdash.eachDeep(copy.fields, convert);
 
   return copy;
 }
@@ -28,7 +28,7 @@ function convert(value: any, key: any, parentValue: any, context: any) {
       _id: false,
       timestamps: false,
     });
-    parentValue[key] = schemaConverter(typeSchema).modelSchema;
+    parentValue[key] = schemaConverter(typeSchema).fields;
     return true;
   }
 

--- a/modules/database/src/adapters/mongoose-adapter/index.ts
+++ b/modules/database/src/adapters/mongoose-adapter/index.ts
@@ -18,7 +18,7 @@ import { mongoSchemaConverter } from '../../introspection/mongoose/utils';
 const parseSchema = require('mongodb-schema');
 let deepPopulate = require('mongoose-deep-populate');
 
-type _ConduitSchema = Omit<ConduitSchema, 'schemaOptions'> & {
+type _ConduitSchema = Omit<ConduitSchema, 'modelOptions'> & {
   modelOptions: ConduitSchemaOptions;
 };
 
@@ -119,7 +119,7 @@ export class MongooseAdapter extends DatabaseAdapter<MongooseSchema> {
   async introspectDatabase(): Promise<ConduitSchema[]> {
     const introspectedSchemas: ConduitSchema[] = [];
     const db = this.mongoose.connection.db;
-    const schemaOptions = {
+    const modelOptions = {
       timestamps: true,
       conduit: {
         noSync: true,
@@ -183,7 +183,7 @@ export class MongooseAdapter extends DatabaseAdapter<MongooseSchema> {
             const schema = new ConduitSchema(
               collectionName,
               originalSchema,
-              schemaOptions,
+              modelOptions,
               collectionName,
             );
             schema.ownerModule = 'database';

--- a/modules/database/src/adapters/mongoose-adapter/index.ts
+++ b/modules/database/src/adapters/mongoose-adapter/index.ts
@@ -163,7 +163,7 @@ export class MongooseAdapter extends DatabaseAdapter<MongooseSchema> {
     // Update Collection Names and Find Introspectable Schemas
     const importedSchemas: string[] = [];
     (declaredSchemas as unknown as ConduitSchema[]).forEach((schema: ConduitSchema) => {
-      if ((schema as unknown as _ConduitSchema).modelOptions.conduit!.imported) {
+      if (schema.modelOptions.conduit!.imported) {
         importedSchemas.push(schema.collectionName);
       }
     });

--- a/modules/database/src/adapters/mongoose-adapter/index.ts
+++ b/modules/database/src/adapters/mongoose-adapter/index.ts
@@ -2,7 +2,6 @@ import { ConnectOptions, Mongoose } from 'mongoose';
 import { MongooseSchema } from './MongooseSchema';
 import { schemaConverter } from './SchemaConverter';
 import ConduitGrpcSdk, {
-  ConduitSchemaOptions,
   ConduitSchema,
   GrpcError,
   Indexable,
@@ -17,10 +16,6 @@ import { mongoSchemaConverter } from '../../introspection/mongoose/utils';
 
 const parseSchema = require('mongodb-schema');
 let deepPopulate = require('mongoose-deep-populate');
-
-type _ConduitSchema = Omit<ConduitSchema, 'modelOptions'> & {
-  modelOptions: ConduitSchemaOptions;
-};
 
 export class MongooseAdapter extends DatabaseAdapter<MongooseSchema> {
   connected: boolean = false;

--- a/modules/database/src/adapters/mongoose-adapter/index.ts
+++ b/modules/database/src/adapters/mongoose-adapter/index.ts
@@ -2,7 +2,7 @@ import { ConnectOptions, Mongoose } from 'mongoose';
 import { MongooseSchema } from './MongooseSchema';
 import { schemaConverter } from './SchemaConverter';
 import ConduitGrpcSdk, {
-  ConduitModelOptions,
+  ConduitSchemaOptions,
   ConduitSchema,
   GrpcError,
   Indexable,
@@ -19,7 +19,7 @@ const parseSchema = require('mongodb-schema');
 let deepPopulate = require('mongoose-deep-populate');
 
 type _ConduitSchema = Omit<ConduitSchema, 'schemaOptions'> & {
-  modelOptions: ConduitModelOptions;
+  modelOptions: ConduitSchemaOptions;
 };
 
 export class MongooseAdapter extends DatabaseAdapter<MongooseSchema> {

--- a/modules/database/src/adapters/sequelize-adapter/SchemaConverter.ts
+++ b/modules/database/src/adapters/sequelize-adapter/SchemaConverter.ts
@@ -10,11 +10,11 @@ import { isBoolean, isNumber, isString, isArray, isObject } from 'lodash';
 export function schemaConverter(jsonSchema: ConduitSchema) {
   const copy = _.cloneDeep(jsonSchema) as any;
 
-  if (copy.modelSchema.hasOwnProperty('_id')) {
-    delete copy.modelSchema['_id'];
+  if (copy.fields.hasOwnProperty('_id')) {
+    delete copy.fields['_id'];
   }
 
-  iterDeep(jsonSchema.modelSchema, copy.modelSchema);
+  iterDeep(jsonSchema.fields, copy.fields);
 
   return copy;
 }

--- a/modules/database/src/adapters/sequelize-adapter/SequelizeSchema.ts
+++ b/modules/database/src/adapters/sequelize-adapter/SequelizeSchema.ts
@@ -43,7 +43,7 @@ export class SequelizeSchema implements SchemaAdapter<ModelCtor<any>> {
     let idField: string = '';
 
     deepdash.eachDeep(
-      this.originalSchema.modelSchema,
+      this.originalSchema.fields,
       (value: Indexable, key: string, parentValue: Indexable, context: Indexable) => {
         if (!parentValue?.hasOwnProperty(key!)) {
           return true;
@@ -79,13 +79,13 @@ export class SequelizeSchema implements SchemaAdapter<ModelCtor<any>> {
       },
     );
     if (!primaryKeyExists) {
-      schema.modelSchema._id = {
+      schema.fields._id = {
         type: DataTypes.UUID,
         defaultValue: DataTypes.UUIDV4,
         primaryKey: true,
       };
     } else {
-      schema.modelSchema._id = {
+      schema.fields._id = {
         type: DataTypes.VIRTUAL,
         get() {
           return `${this[idField]}`;
@@ -93,7 +93,7 @@ export class SequelizeSchema implements SchemaAdapter<ModelCtor<any>> {
       };
     }
     incrementDbQueries();
-    this.model = sequelize.define(schema.collectionName, schema.modelSchema, {
+    this.model = sequelize.define(schema.collectionName, schema.fields, {
       ...schema.modelOptions,
       freezeTableName: true,
     });

--- a/modules/database/src/adapters/sequelize-adapter/index.ts
+++ b/modules/database/src/adapters/sequelize-adapter/index.ts
@@ -80,7 +80,7 @@ export class SequelizeAdapter extends DatabaseAdapter<SequelizeSchema> {
     // Update Collection Names and Find Introspectable Schemas
     const importedSchemas: string[] = [];
     declaredSchemas.forEach((schema: ConduitSchema) => {
-      if ((schema as Indexable).modelOptions.conduit.imported) {
+      if (schema.modelOptions.conduit!.imported) {
         importedSchemas.push(schema.collectionName);
       }
     });

--- a/modules/database/src/adapters/sequelize-adapter/index.ts
+++ b/modules/database/src/adapters/sequelize-adapter/index.ts
@@ -194,7 +194,7 @@ export class SequelizeAdapter extends DatabaseAdapter<SequelizeSchema> {
       this,
     );
 
-    const noSync = this.models[schema.name].originalSchema.schemaOptions.conduit!.noSync;
+    const noSync = this.models[schema.name].originalSchema.options.conduit!.noSync;
     if (isNil(noSync) || !noSync) {
       await this.models[schema.name].sync();
     }

--- a/modules/database/src/adapters/sequelize-adapter/index.ts
+++ b/modules/database/src/adapters/sequelize-adapter/index.ts
@@ -194,7 +194,7 @@ export class SequelizeAdapter extends DatabaseAdapter<SequelizeSchema> {
       this,
     );
 
-    const noSync = this.models[schema.name].originalSchema.options.conduit!.noSync;
+    const noSync = this.models[schema.name].originalSchema.modelOptions.conduit!.noSync;
     if (isNil(noSync) || !noSync) {
       await this.models[schema.name].sync();
     }

--- a/modules/database/src/adapters/utils/validateSchemas.ts
+++ b/modules/database/src/adapters/utils/validateSchemas.ts
@@ -36,8 +36,8 @@ export function systemRequiredValidator(
 
   // validate types
   validateSchemaFields(
-    oldSchema.fields ?? oldSchema.modelSchema,
-    newSchema.fields ?? newSchema.modelSchema,
+    oldSchema.fields ?? oldSchema.fields,
+    newSchema.fields ?? newSchema.fields,
   );
 
   return newSchema;

--- a/modules/database/src/admin/customEndpoints/customEndpoints.admin.ts
+++ b/modules/database/src/admin/customEndpoints/customEndpoints.admin.ts
@@ -126,7 +126,7 @@ export class CustomEndpointsAdmin {
         );
       }
       findSchema = await this.database.getSchema(selectedSchemaName);
-      findSchema.compiledFields = findSchema.modelSchema;
+      findSchema.compiledFields = findSchema.fields;
     }
 
     if (isNil(findSchema)) {
@@ -274,7 +274,7 @@ export class CustomEndpointsAdmin {
         );
       }
       findSchema = await this.database.getSchema(selectedSchemaName);
-      findSchema.compiledFields = findSchema.modelSchema;
+      findSchema.compiledFields = findSchema.fields;
     }
 
     if (isNil(findSchema)) {

--- a/modules/database/src/admin/schema.admin.ts
+++ b/modules/database/src/admin/schema.admin.ts
@@ -454,7 +454,7 @@ export class SchemaAdmin {
     );
     const base = await this.database.getBaseSchema(requestedSchema.name);
     await this.database
-      .setSchemaExtension(base, 'database', extension.modelSchema)
+      .setSchemaExtension(base, 'database', extension.fields)
       .catch((e: Error) => {
         throw new GrpcError(status.INTERNAL, e.message);
       });

--- a/modules/database/src/controllers/cms/schema.controller.ts
+++ b/modules/database/src/controllers/cms/schema.controller.ts
@@ -1,5 +1,5 @@
 import ConduitGrpcSdk, {
-  ConduitModelOptions,
+  ConduitSchemaOptions,
   ConduitSchema as ConduitSchema,
 } from '@conduitplatform/grpc-sdk';
 import { DatabaseRoutes } from '../../routes';
@@ -12,7 +12,7 @@ import { CmsHandlers } from '../../handlers/cms.handler';
 import { ParsedQuery } from '../../interfaces';
 
 type _ConduitSchema = Omit<ConduitSchema, 'schemaOptions'> & {
-  modelOptions: ConduitModelOptions;
+  modelOptions: ConduitSchemaOptions;
 };
 
 export class SchemaController {

--- a/modules/database/src/controllers/cms/schema.controller.ts
+++ b/modules/database/src/controllers/cms/schema.controller.ts
@@ -11,7 +11,7 @@ import { SequelizeSchema } from '../../adapters/sequelize-adapter/SequelizeSchem
 import { CmsHandlers } from '../../handlers/cms.handler';
 import { ParsedQuery } from '../../interfaces';
 
-type _ConduitSchema = Omit<ConduitSchema, 'schemaOptions'> & {
+type _ConduitSchema = Omit<ConduitSchema, 'modelOptions'> & {
   modelOptions: ConduitSchemaOptions;
 };
 

--- a/modules/database/src/controllers/cms/utils.ts
+++ b/modules/database/src/controllers/cms/utils.ts
@@ -1,7 +1,6 @@
 import {
   ConduitModel,
   ConduitModelField,
-  ConduitSchemaOptions,
   ConduitRouteActions,
   ConduitSchema,
   Indexable,
@@ -10,10 +9,6 @@ import {
 } from '@conduitplatform/grpc-sdk';
 import { CmsHandlers } from '../../handlers/cms.handler';
 import { ConduitBuiltRoute } from '../../interfaces/ConduitBuiltRoute';
-
-type _ConduitSchema = Omit<ConduitSchema, 'modelOptions'> & {
-  modelOptions: ConduitSchemaOptions;
-};
 
 export function compareFunction(schemaA: ConduitModel, schemaB: ConduitModel): number {
   const hasA = [];
@@ -79,7 +74,7 @@ function removeRequiredFields(fields: ConduitModel) {
 
 export function getOps(
   schemaName: string,
-  actualSchema: _ConduitSchema,
+  actualSchema: ConduitSchema,
   handlers: CmsHandlers,
 ) {
   const routesArray: ConduitBuiltRoute[] = [];

--- a/modules/database/src/controllers/cms/utils.ts
+++ b/modules/database/src/controllers/cms/utils.ts
@@ -11,7 +11,7 @@ import {
 import { CmsHandlers } from '../../handlers/cms.handler';
 import { ConduitBuiltRoute } from '../../interfaces/ConduitBuiltRoute';
 
-type _ConduitSchema = Omit<ConduitSchema, 'schemaOptions'> & {
+type _ConduitSchema = Omit<ConduitSchema, 'modelOptions'> & {
   modelOptions: ConduitSchemaOptions;
 };
 

--- a/modules/database/src/controllers/cms/utils.ts
+++ b/modules/database/src/controllers/cms/utils.ts
@@ -1,7 +1,7 @@
 import {
   ConduitModel,
   ConduitModelField,
-  ConduitModelOptions,
+  ConduitSchemaOptions,
   ConduitRouteActions,
   ConduitSchema,
   Indexable,
@@ -12,7 +12,7 @@ import { CmsHandlers } from '../../handlers/cms.handler';
 import { ConduitBuiltRoute } from '../../interfaces/ConduitBuiltRoute';
 
 type _ConduitSchema = Omit<ConduitSchema, 'schemaOptions'> & {
-  modelOptions: ConduitModelOptions;
+  modelOptions: ConduitSchemaOptions;
 };
 
 export function compareFunction(schemaA: ConduitModel, schemaB: ConduitModel): number {
@@ -30,8 +30,8 @@ export function compareFunction(schemaA: ConduitModel, schemaB: ConduitModel): n
       hasB.push((fieldsB[k] as ConduitModelField).model);
     }
   }
-  const schemaAName = ((schemaA as unknown) as ConduitSchema).name;
-  const schemaBName = ((schemaB as unknown) as ConduitSchema).name;
+  const schemaAName = (schemaA as unknown as ConduitSchema).name;
+  const schemaBName = (schemaB as unknown as ConduitSchema).name;
 
   if (hasA.length === 0 && hasB.length === 0) {
     return 0;
@@ -83,10 +83,10 @@ export function getOps(
   handlers: CmsHandlers,
 ) {
   const routesArray: ConduitBuiltRoute[] = [];
-  const authenticatedRead = actualSchema.modelOptions.conduit!.cms.crudOperations.read
-    .authenticated;
-  const readIsEnabled = actualSchema.modelOptions.conduit!.cms.crudOperations.read
-    .enabled;
+  const authenticatedRead =
+    actualSchema.modelOptions.conduit!.cms.crudOperations.read.authenticated;
+  const readIsEnabled =
+    actualSchema.modelOptions.conduit!.cms.crudOperations.read.enabled;
   if (readIsEnabled) {
     let route = new RouteBuilder()
       .path(`/${schemaName}/:id`)
@@ -116,10 +116,10 @@ export function getOps(
     if (authenticatedRead) route.middleware('authMiddleware');
     routesArray.push(route.build());
   }
-  const authenticatedCreate = actualSchema.modelOptions.conduit!.cms.crudOperations.create
-    .authenticated;
-  const createIsEnabled = actualSchema.modelOptions.conduit!.cms.crudOperations.create
-    .enabled;
+  const authenticatedCreate =
+    actualSchema.modelOptions.conduit!.cms.crudOperations.create.authenticated;
+  const createIsEnabled =
+    actualSchema.modelOptions.conduit!.cms.crudOperations.create.enabled;
 
   const assignableFields = Object.assign({}, actualSchema.fields);
   delete assignableFields._id;
@@ -149,10 +149,10 @@ export function getOps(
     routesArray.push(route.build());
   }
 
-  const authenticatedUpdate = actualSchema.modelOptions.conduit!.cms.crudOperations.update
-    .authenticated;
-  const updateIsEnabled = actualSchema.modelOptions.conduit!.cms.crudOperations.update
-    .enabled;
+  const authenticatedUpdate =
+    actualSchema.modelOptions.conduit!.cms.crudOperations.update.authenticated;
+  const updateIsEnabled =
+    actualSchema.modelOptions.conduit!.cms.crudOperations.update.enabled;
   if (updateIsEnabled) {
     let route = new RouteBuilder()
       .path(`/${schemaName}/many`)
@@ -212,9 +212,9 @@ export function getOps(
         id: { type: TYPE.String, required: true },
       })
       .bodyParams(
-        (removeRequiredFields(
+        removeRequiredFields(
           Object.assign({}, assignableFields),
-        ) as unknown) as ConduitModel,
+        ) as unknown as ConduitModel,
       )
       .return(`patch${schemaName}`, actualSchema.fields)
       .handler(handlers.patchDocument.bind(handlers));
@@ -222,10 +222,10 @@ export function getOps(
 
     routesArray.push(route.build());
   }
-  const authenticatedDelete = actualSchema.modelOptions.conduit!.cms.crudOperations.delete
-    .authenticated;
-  const deleteIsEnabled = actualSchema.modelOptions.conduit!.cms.crudOperations.delete
-    .enabled;
+  const authenticatedDelete =
+    actualSchema.modelOptions.conduit!.cms.crudOperations.delete.authenticated;
+  const deleteIsEnabled =
+    actualSchema.modelOptions.conduit!.cms.crudOperations.delete.enabled;
   if (deleteIsEnabled) {
     const route = new RouteBuilder()
       .path(`/${schemaName}/:id`)

--- a/modules/database/src/database.proto
+++ b/modules/database/src/database.proto
@@ -1,28 +1,12 @@
 syntax = 'proto3';
 package database;
 
-message CreateSchemaRequest {
-    Schema schema = 1;
-}
-
-message CreateSchemaResponse {
-    Schema schema = 1;
-}
-
 message SetSchemaExtensionRequest {
     SchemaExtension extension = 1;
 }
 
-message SetSchemaExtensionResponse {
-    Schema schema = 1;
-}
-
 message GetSchemaRequest {
     string schemaName = 1;
-}
-
-message GetSchemaResponse {
-    Schema schema = 1;
 }
 
 message GetSchemasRequest {
@@ -37,14 +21,14 @@ message DropCollectionResponse{
 
 message Schema {
     string name = 1;
-    string modelSchema = 2;
-    string modelOptions = 3;
+    string fields = 2;
+    string options = 3;
     string collectionName = 4;
 }
 
 message SchemaExtension {
     string name = 1;
-    string modelSchema = 2;
+    string fields = 2;
 }
 
 message FindOneRequest {
@@ -94,11 +78,11 @@ message DropCollectionRequest{
 }
 
 service DatabaseProvider {
-    rpc CreateSchemaFromAdapter(CreateSchemaRequest) returns (CreateSchemaResponse);
-    rpc GetSchema (GetSchemaRequest) returns (GetSchemaResponse);
+    rpc CreateSchemaFromAdapter(Schema) returns (Schema);
+    rpc GetSchema (GetSchemaRequest) returns (Schema);
     rpc GetSchemas(GetSchemasRequest) returns (GetSchemasResponse);
     rpc DeleteSchema(DropCollectionRequest) returns (DropCollectionResponse);
-    rpc SetSchemaExtension(SetSchemaExtensionRequest) returns (CreateSchemaResponse);
+    rpc SetSchemaExtension(SetSchemaExtensionRequest) returns (Schema);
     // Database queries
     rpc findOne (FindOneRequest) returns (QueryResponse);
     rpc findMany (FindRequest) returns (QueryResponse);

--- a/modules/database/src/database.proto
+++ b/modules/database/src/database.proto
@@ -22,7 +22,7 @@ message DropCollectionResponse{
 message Schema {
     string name = 1;
     string fields = 2;
-    string options = 3;
+    string modelOptions = 3;
     string collectionName = 4;
 }
 

--- a/modules/database/src/interfaces/ConduitDatabaseSchema.ts
+++ b/modules/database/src/interfaces/ConduitDatabaseSchema.ts
@@ -1,6 +1,6 @@
 import {
   ConduitModel,
-  ConduitModelOptions,
+  ConduitSchemaOptions,
   ConduitSchema,
 } from '@conduitplatform/grpc-sdk';
 import { DeclaredSchemaExtension } from './DeclaredSchemaExtension';
@@ -17,7 +17,7 @@ export class ConduitDatabaseSchema extends ConduitSchema {
     ownerModule: string,
     extensions: DeclaredSchemaExtension[] = [],
     fields?: ConduitModel,
-    modelOptions?: ConduitModelOptions,
+    modelOptions?: ConduitSchemaOptions,
     collectionName?: string,
   ) {
     super(name, fields ?? {}, modelOptions, collectionName);

--- a/modules/database/src/interfaces/DeclaredSchema.ts
+++ b/modules/database/src/interfaces/DeclaredSchema.ts
@@ -1,4 +1,4 @@
-import { ConduitModelOptions } from '@conduitplatform/grpc-sdk';
+import { ConduitSchemaOptions } from '@conduitplatform/grpc-sdk';
 import { DeclaredSchemaExtension } from './DeclaredSchemaExtension';
 
 export interface IDeclaredSchema {
@@ -6,7 +6,7 @@ export interface IDeclaredSchema {
   name: string;
   fields: any;
   extensions: DeclaredSchemaExtension[];
-  modelOptions: ConduitModelOptions;
+  modelOptions: ConduitSchemaOptions;
   createdAt: Date;
   updatedAt: Date;
 }

--- a/modules/database/src/migrations/crudOperations.migration.ts
+++ b/modules/database/src/migrations/crudOperations.migration.ts
@@ -4,7 +4,7 @@ import { SequelizeSchema } from '../adapters/sequelize-adapter/SequelizeSchema';
 import { ConduitSchemaOptions, ConduitSchema } from '@conduitplatform/grpc-sdk';
 import { isBoolean } from 'lodash';
 
-type _ConduitSchema = Omit<ConduitSchema, 'schemaOptions'> & {
+type _ConduitSchema = Omit<ConduitSchema, 'modelOptions'> & {
   modelOptions: ConduitSchemaOptions;
 };
 export async function migrateCrudOperations(

--- a/modules/database/src/migrations/crudOperations.migration.ts
+++ b/modules/database/src/migrations/crudOperations.migration.ts
@@ -1,11 +1,11 @@
 import { DatabaseAdapter } from '../adapters/DatabaseAdapter';
 import { MongooseSchema } from '../adapters/mongoose-adapter/MongooseSchema';
 import { SequelizeSchema } from '../adapters/sequelize-adapter/SequelizeSchema';
-import { ConduitModelOptions, ConduitSchema } from '@conduitplatform/grpc-sdk';
+import { ConduitSchemaOptions, ConduitSchema } from '@conduitplatform/grpc-sdk';
 import { isBoolean } from 'lodash';
 
 type _ConduitSchema = Omit<ConduitSchema, 'schemaOptions'> & {
-  modelOptions: ConduitModelOptions;
+  modelOptions: ConduitSchemaOptions;
 };
 export async function migrateCrudOperations(
   adapter: DatabaseAdapter<MongooseSchema | SequelizeSchema>,

--- a/modules/database/src/migrations/crudOperations.migration.ts
+++ b/modules/database/src/migrations/crudOperations.migration.ts
@@ -1,18 +1,15 @@
+import { ConduitSchema } from '@conduitplatform/grpc-sdk';
 import { DatabaseAdapter } from '../adapters/DatabaseAdapter';
 import { MongooseSchema } from '../adapters/mongoose-adapter/MongooseSchema';
 import { SequelizeSchema } from '../adapters/sequelize-adapter/SequelizeSchema';
-import { ConduitSchemaOptions, ConduitSchema } from '@conduitplatform/grpc-sdk';
 import { isBoolean } from 'lodash';
 
-type _ConduitSchema = Omit<ConduitSchema, 'modelOptions'> & {
-  modelOptions: ConduitSchemaOptions;
-};
 export async function migrateCrudOperations(
   adapter: DatabaseAdapter<MongooseSchema | SequelizeSchema>,
 ) {
   const model = adapter.getSchemaModel('_DeclaredSchema').model;
   const declaredSchemas = await model.findMany({});
-  const cmsSchemas = declaredSchemas.filter((schema: _ConduitSchema) =>
+  const cmsSchemas = declaredSchemas.filter((schema: ConduitSchema) =>
     isBoolean(schema.modelOptions.conduit?.cms),
   );
   for (const schema of cmsSchemas) {

--- a/modules/database/src/permissions/index.ts
+++ b/modules/database/src/permissions/index.ts
@@ -5,7 +5,7 @@ export async function canCreate(moduleName: string, schema: Schema) {
     return true;
   return (
     schema.originalSchema.ownerModule === moduleName ||
-    schema.originalSchema.options.conduit!.permissions!.extendable
+    schema.originalSchema.modelOptions.conduit!.permissions!.extendable
   );
 }
 
@@ -14,7 +14,7 @@ export async function canModify(moduleName: string, schema: Schema) {
     return true;
   return (
     schema.originalSchema.ownerModule === moduleName ||
-    schema.originalSchema.options.conduit!.permissions!.canModify === 'Everything'
+    schema.originalSchema.modelOptions.conduit!.permissions!.canModify === 'Everything'
     // TODO: Handle 'ExtensionOnly' once we get extensions
   );
 }
@@ -24,6 +24,6 @@ export async function canDelete(moduleName: string, schema: Schema) {
     return true;
   return (
     schema.originalSchema.ownerModule === moduleName ||
-    schema.originalSchema.options.conduit!.permissions!.canDelete
+    schema.originalSchema.modelOptions.conduit!.permissions!.canDelete
   );
 }

--- a/modules/database/src/permissions/index.ts
+++ b/modules/database/src/permissions/index.ts
@@ -5,7 +5,7 @@ export async function canCreate(moduleName: string, schema: Schema) {
     return true;
   return (
     schema.originalSchema.ownerModule === moduleName ||
-    schema.originalSchema.schemaOptions.conduit!.permissions!.extendable
+    schema.originalSchema.options.conduit!.permissions!.extendable
   );
 }
 
@@ -14,7 +14,7 @@ export async function canModify(moduleName: string, schema: Schema) {
     return true;
   return (
     schema.originalSchema.ownerModule === moduleName ||
-    schema.originalSchema.schemaOptions.conduit!.permissions!.canModify === 'Everything'
+    schema.originalSchema.options.conduit!.permissions!.canModify === 'Everything'
     // TODO: Handle 'ExtensionOnly' once we get extensions
   );
 }
@@ -24,6 +24,6 @@ export async function canDelete(moduleName: string, schema: Schema) {
     return true;
   return (
     schema.originalSchema.ownerModule === moduleName ||
-    schema.originalSchema.schemaOptions.conduit!.permissions!.canDelete
+    schema.originalSchema.options.conduit!.permissions!.canDelete
   );
 }

--- a/modules/database/src/types.ts
+++ b/modules/database/src/types.ts
@@ -1,37 +1,25 @@
 import { GrpcRequest, GrpcResponse } from '@conduitplatform/grpc-sdk';
+import {
+  Schema as SchemaDto,
+  SchemaExtension as SchemaExtensionDto,
+} from './protoTypes/database';
 
-type Schema = {
-  name: string;
-  modelSchema: string;
-  modelOptions: string;
-  collectionName?: string;
-};
-
-type SchemaExtension = {
-  name: string;
-  modelSchema: string;
-};
-
-export type CreateSchemaRequest = GrpcRequest<{
-  schema: Schema;
-}>;
+export type CreateSchemaRequest = GrpcRequest<SchemaDto>;
 
 export type CreateSchemaExtensionRequest = GrpcRequest<{
-  extension: SchemaExtension;
+  extension: SchemaExtensionDto;
 }>;
 
 export type GetSchemaRequest = GrpcRequest<{
   schemaName: string;
 }>;
 
-export type SchemaResponse = GrpcResponse<{
-  schema: Schema;
-}>;
+export type SchemaResponse = GrpcResponse<SchemaDto>;
 
 export type GetSchemasRequest = GrpcRequest<{}>;
 
 export type SchemasResponse = GrpcResponse<{
-  schemas: Schema[];
+  schemas: SchemaDto[];
 }>;
 
 export type FindOneRequest = GrpcRequest<{

--- a/modules/database/src/utils/utilities.ts
+++ b/modules/database/src/utils/utilities.ts
@@ -10,7 +10,7 @@ import {
 } from 'lodash';
 import {
   ConduitModel,
-  ConduitModelOptions,
+  ConduitSchemaOptions,
   Indexable,
   TYPE,
 } from '@conduitplatform/grpc-sdk';
@@ -42,7 +42,7 @@ export function wrongFields(schemaFields: string[], updateFields: string[]): boo
 export function validateSchemaInput(
   name: string,
   fields: ConduitModel,
-  modelOptions: ConduitModelOptions,
+  modelOptions: ConduitSchemaOptions,
   enabled?: boolean,
 ) {
   if (!isNil(enabled) && !isBoolean(enabled)) {

--- a/modules/email/src/models/EmailTemplate.schema.ts
+++ b/modules/email/src/models/EmailTemplate.schema.ts
@@ -29,7 +29,7 @@ const schema = {
   createdAt: TYPE.Date,
   updatedAt: TYPE.Date,
 };
-const schemaOptions = {
+const modelOptions = {
   timestamps: true,
   conduit: {
     permissions: {
@@ -56,7 +56,7 @@ export class EmailTemplate extends ConduitActiveSchema<EmailTemplate> {
   updatedAt: Date;
 
   private constructor(database: DatabaseProvider) {
-    super(database, EmailTemplate.name, schema, schemaOptions, collectionName);
+    super(database, EmailTemplate.name, schema, modelOptions, collectionName);
   }
 
   static getInstance(database?: DatabaseProvider) {

--- a/modules/forms/src/models/Forms.schema.ts
+++ b/modules/forms/src/models/Forms.schema.ts
@@ -28,7 +28,7 @@ const schema = {
   createdAt: TYPE.Date,
   updatedAt: TYPE.Date,
 };
-const schemaOptions = {
+const modelOptions = {
   timestamps: true,
   conduit: {
     permissions: {
@@ -53,7 +53,7 @@ export class Forms extends ConduitActiveSchema<Forms> {
   updatedAt: Date;
 
   private constructor(database: DatabaseProvider) {
-    super(database, Forms.name, schema, schemaOptions, collectionName);
+    super(database, Forms.name, schema, modelOptions, collectionName);
   }
 
   static getInstance(database?: DatabaseProvider) {

--- a/modules/forms/src/models/Replies.schema.ts
+++ b/modules/forms/src/models/Replies.schema.ts
@@ -20,7 +20,7 @@ const schema = {
   createdAt: TYPE.Date,
   updatedAt: TYPE.Date,
 };
-const schemaOptions = {
+const modelOptions = {
   timestamps: true,
   conduit: {
     permissions: {
@@ -43,7 +43,7 @@ export class FormReplies extends ConduitActiveSchema<FormReplies> {
   updatedAt: Date;
 
   private constructor(database: DatabaseProvider) {
-    super(database, FormReplies.name, schema, schemaOptions, collectionName);
+    super(database, FormReplies.name, schema, modelOptions, collectionName);
   }
 
   static getInstance(database?: DatabaseProvider) {

--- a/modules/push-notifications/src/models/NotificationToken.schema.ts
+++ b/modules/push-notifications/src/models/NotificationToken.schema.ts
@@ -25,7 +25,7 @@ const schema = {
   createdAt: TYPE.Date,
   updatedAt: TYPE.Date,
 };
-const schemaOptions = {
+const modelOptions = {
   timestamps: true,
   conduit: {
     permissions: {
@@ -48,7 +48,7 @@ export class NotificationToken extends ConduitActiveSchema<NotificationToken> {
   updatedAt!: Date;
 
   private constructor(database: DatabaseProvider) {
-    super(database, NotificationToken.name, schema, schemaOptions, collectionName);
+    super(database, NotificationToken.name, schema, modelOptions, collectionName);
   }
 
   static getInstance(database?: DatabaseProvider) {

--- a/modules/router/src/models/Client.schema.ts
+++ b/modules/router/src/models/Client.schema.ts
@@ -38,7 +38,7 @@ const schema = {
   createdAt: TYPE.Date,
   updatedAt: TYPE.Date,
 };
-const schemaOptions = {
+const modelOptions = {
   timestamps: true,
   conduit: {
     permissions: {
@@ -64,7 +64,7 @@ export class Client extends ConduitActiveSchema<Client> {
   updatedAt!: Date;
 
   private constructor(database: DatabaseProvider) {
-    super(database, Client.name, schema, schemaOptions, collectionName);
+    super(database, Client.name, schema, modelOptions, collectionName);
   }
 
   static getInstance(database?: DatabaseProvider) {

--- a/modules/storage/src/models/Container.schema.ts
+++ b/modules/storage/src/models/Container.schema.ts
@@ -14,7 +14,7 @@ const schema = {
   createdAt: TYPE.Date,
   updatedAt: TYPE.Date,
 };
-const schemaOptions = {
+const modelOptions = {
   timestamps: true,
   conduit: {
     permissions: {
@@ -36,7 +36,7 @@ export class _StorageContainer extends ConduitActiveSchema<_StorageContainer> {
   updatedAt!: Date;
 
   private constructor(database: DatabaseProvider) {
-    super(database, _StorageContainer.name, schema, schemaOptions, collectionName);
+    super(database, _StorageContainer.name, schema, modelOptions, collectionName);
   }
 
   static getInstance(database?: DatabaseProvider) {

--- a/modules/storage/src/models/File.schema.ts
+++ b/modules/storage/src/models/File.schema.ts
@@ -27,7 +27,7 @@ const schema = {
   createdAt: TYPE.Date,
   updatedAt: TYPE.Date,
 };
-const schemaOptions = {
+const modelOptions = {
   timestamps: true,
   conduit: {
     permissions: {
@@ -54,7 +54,7 @@ export class File extends ConduitActiveSchema<File> {
   updatedAt!: Date;
 
   private constructor(database: DatabaseProvider) {
-    super(database, File.name, schema, schemaOptions, collectionName);
+    super(database, File.name, schema, modelOptions, collectionName);
   }
 
   static getInstance(database?: DatabaseProvider) {

--- a/modules/storage/src/models/Folder.schema.ts
+++ b/modules/storage/src/models/Folder.schema.ts
@@ -18,7 +18,7 @@ const schema = {
   createdAt: TYPE.Date,
   updatedAt: TYPE.Date,
 };
-const schemaOptions = {
+const modelOptions = {
   timestamps: true,
   conduit: {
     permissions: {
@@ -42,7 +42,7 @@ export class _StorageFolder extends ConduitActiveSchema<_StorageFolder> {
   updatedAt!: Date;
 
   private constructor(database: DatabaseProvider) {
-    super(database, _StorageFolder.name, schema, schemaOptions, collectionName);
+    super(database, _StorageFolder.name, schema, modelOptions, collectionName);
   }
 
   static getInstance(database?: DatabaseProvider) {

--- a/packages/admin/src/models/Admin.schema.ts
+++ b/packages/admin/src/models/Admin.schema.ts
@@ -13,7 +13,7 @@ const schema = {
   createdAt: TYPE.Date,
   updatedAt: TYPE.Date,
 };
-const schemaOptions = {
+const modelOptions = {
   timestamps: true,
   conduit: {
     permissions: {
@@ -35,7 +35,7 @@ export class Admin extends ConduitActiveSchema<Admin> {
   updatedAt!: Date;
 
   private constructor(database: DatabaseProvider) {
-    super(database, Admin.name, schema, schemaOptions, collectionName);
+    super(database, Admin.name, schema, modelOptions, collectionName);
   }
 
   static getInstance(database?: DatabaseProvider) {

--- a/packages/core/src/config-manager/models/Config.schema.ts
+++ b/packages/core/src/config-manager/models/Config.schema.ts
@@ -8,7 +8,7 @@ const schema = {
     required: true,
   },
 };
-const schemaOptions = {
+const modelOptions = {
   timestamps: true,
   conduit: {
     permissions: {
@@ -27,7 +27,7 @@ export class Config extends ConduitActiveSchema<Config> {
   moduleConfigs!: any;
 
   private constructor(database: DatabaseProvider) {
-    super(database, Config.name, schema, schemaOptions, collectionName);
+    super(database, Config.name, schema, modelOptions, collectionName);
   }
 
   static getInstance(database?: DatabaseProvider) {

--- a/packages/core/src/config-manager/models/Config.schema.ts
+++ b/packages/core/src/config-manager/models/Config.schema.ts
@@ -38,13 +38,4 @@ export class Config extends ConduitActiveSchema<Config> {
     Config._instance = new Config(database);
     return Config._instance;
   }
-
-  static getPlainSchema() {
-    return {
-      name: Config.getInstance().name,
-      fields: Config.getInstance().fields,
-      schemaOptions: Config.getInstance().schemaOptions,
-      collectionName: Config.getInstance().collectionName,
-    };
-  }
 }


### PR DESCRIPTION
This PR simplifies schema types, renaming certain fields for consistency and readability.
Notably, `modelOptions` and `schemaOptions` are finally using the same field name 🎉.
Ideally, we'd simply use `options`, but we're sticking with `modelOptions` (for now?) due to a complication with Sequelize migrations.

`modelSchema` has also been renamed to `fields` for readability.

This is technically a Breaking Change as `Database`'s gRPC definitions have been slightly altered because of the above.
Routing APIs shouldn't be affected by this.

This **does not resolve all schema related type issues**.
We still need to work on type anys and invalid type usages (eg `ConduitSchema`-like types with stringified fields being advertised as `ConduitSchema`) etc.

**What kind of change does this PR introduce?** <!--(check at least one)-->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [X] Refactor
- [ ] Build-related changes
- [ ] Other (please describe)

**Does this PR introduce a breaking change?** <!-- (check one) -->

- [X] Yes
- [ ] No

<!-- If yes, please describe the impact and migration path for existing applications. -->

**The PR fulfills these requirements:**

- [X] It's submitted to the `main` branch
- [ ] When resolving a specific issue, it's referenced in the PR's description  (e.g. `fix #xxx`, where "xxx" is the issue number)