### PR TITLE
fix(database): modelOptions cms validation, unrebased modelSchema reference

### DIFF
--- a/modules/database/src/admin/customEndpoints/customEndpoints.admin.ts
+++ b/modules/database/src/admin/customEndpoints/customEndpoints.admin.ts
@@ -354,7 +354,7 @@ export class CustomEndpointsAdmin {
         );
       }
       findSchema = await this.database.getSchema(selectedSchemaName);
-      findSchema.compiledFields = findSchema.modelSchema;
+      findSchema.compiledFields = findSchema.fields;
     }
     return findSchema;
   }

--- a/modules/database/src/utils/utilities.ts
+++ b/modules/database/src/utils/utilities.ts
@@ -57,11 +57,12 @@ export function validateSchemaInput(
       optionsValidationError = 'Model options must be an object';
     }
     Object.keys(modelOptions).forEach(key => {
-      if (key === 'timestamps' && !isBoolean(modelOptions[key])) {
+      if (key !== 'conduit' && key !== 'timestamps') {
+        optionsValidationError = "Only 'conduit' and 'timestamps' options allowed";
+      } else if (key === 'timestamps' && !isBoolean(modelOptions[key])) {
         optionsValidationError = "Option 'timestamps' must be of type Boolean";
-      }
-      if (key !== 'timestamps') {
-        optionsValidationError = "Only 'timestamps' option is allowed";
+      } else if (key === 'conduit' && !isObject(modelOptions[key])) {
+        optionsValidationError = "Option 'conduit' must be of type Object";
       }
     });
     if (!isNil(optionsValidationError)) return optionsValidationError;


### PR DESCRIPTION
This PR provides the following fixes:
- Unrebased reference to `ConduitSchema.modelSchema` (now `fields`)
- CMS schema creation/modification failing during `modelOptions` input validation

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** <!--(check at least one)-->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other (please describe)

**Does this PR introduce a breaking change?** <!-- (check one) -->

- [ ] Yes
- [X] No

<!-- If yes, please describe the impact and migration path for existing applications. -->

**The PR fulfills these requirements:**

- [X] It's submitted to the `main` branch
- [ ] When resolving a specific issue, it's referenced in the PR's description  (e.g. `fix #xxx`, where "xxx" is the issue number)