### PR TITLE
chore(core,admin,router,authentication): deprecate legacy compat options

### DIFF
--- a/libraries/hermes/src/Socket/Socket.ts
+++ b/libraries/hermes/src/Socket/Socket.ts
@@ -47,7 +47,7 @@ export class SocketController extends ConduitRouter {
     this.pubClient = new IORedis(redisDetails.port, redisDetails.host);
     this.subClient = this.pubClient.duplicate();
     this.io.adapter(createAdapter(this.pubClient, this.subClient));
-    this.httpServer.listen(process.env.SOCKET_PORT || this.port);
+    this.httpServer.listen(this.port);
     this._registeredNamespaces = new Map();
     this.globalMiddlewares = [];
   }

--- a/modules/authentication/src/routes/index.ts
+++ b/modules/authentication/src/routes/index.ts
@@ -142,11 +142,16 @@ export class AuthenticationRoutes {
       throw new GrpcError(status.UNAUTHENTICATED, 'No authorization header present');
     }
     const args = header.split(' ');
-
-    if (args[0] !== 'Bearer' || isNil(args[1])) {
+    if (args.length !== 2) {
       throw new GrpcError(status.UNAUTHENTICATED, 'Authorization header malformed');
     }
 
+    if (args[0] !== 'Bearer') {
+      throw new GrpcError(
+        status.UNAUTHENTICATED,
+        "The Authorization header must be prefixed by 'Bearer '",
+      );
+    }
     const accessToken = await AccessToken.getInstance().findOne({
       token: args[1],
       clientId: context.clientId,

--- a/modules/router/src/Router.ts
+++ b/modules/router/src/Router.ts
@@ -189,7 +189,7 @@ export default class ConduitDefaultRouter extends ManagedModule<Config> {
   }
 
   private getHttpPort() {
-    const value = (process.env['CLIENT_HTTP_PORT'] || process.env['PORT']) ?? '3000'; // <=v13 compat (PORT)
+    const value = process.env['CLIENT_HTTP_PORT'] ?? '3000';
     const port = parseInt(value, 10);
     if (isNaN(port)) {
       ConduitGrpcSdk.Logger.error(`Invalid HTTP port value: ${port}`);

--- a/packages/admin/src/index.ts
+++ b/packages/admin/src/index.ts
@@ -98,7 +98,7 @@ export default class AdminModule extends IConduitAdmin {
   }
 
   private getHttpPort() {
-    const value = (process.env['ADMIN_HTTP_PORT'] || process.env['PORT']) ?? '3030'; // <=v13 compat (PORT)
+    const value = process.env['ADMIN_HTTP_PORT'] ?? '3030';
     const port = parseInt(value, 10);
     if (isNaN(port)) {
       ConduitGrpcSdk.Logger.error(`Invalid HTTP port value: ${port}`);

--- a/packages/admin/src/middleware/Auth.middleware.ts
+++ b/packages/admin/src/middleware/Auth.middleware.ts
@@ -55,12 +55,11 @@ export function getAuthMiddleware(grpcSdk: ConduitGrpcSdk, conduit: ConduitCommo
 
     const args = tokenHeader.split(' ');
     if (args.length !== 2) {
-      return res.status(401).json({ error: 'Invalid token' });
+      return res.status(401).json({ error: 'Authorization header malformed' });
     }
 
     const [prefix, token] = args;
-    if (prefix !== 'Bearer' && prefix !== 'JWT') {
-      // Compat (<=0.12.2): JWT
+    if (prefix !== 'Bearer') {
       return res
         .status(401)
         .json({ error: "The Authorization header must be prefixed by 'Bearer '" });

--- a/packages/admin/src/utils/config.ts
+++ b/packages/admin/src/utils/config.ts
@@ -11,7 +11,7 @@ export async function generateConfigDefaults(
     config.auth.tokenSecret = crypto.randomBytes(64).toString('base64');
   }
   if (hostUrlConfig === '' || isNil(hostUrlConfig)) {
-    const portValue = (process.env['ADMIN_HTTP_PORT'] || process.env['PORT']) ?? '3030'; // <=v13 compat (PORT)
+    const portValue = process.env['ADMIN_HTTP_PORT'] ?? '3030';
     config.hostUrl = `http://localhost:${portValue}`;
   }
   return config;

--- a/packages/commons/src/modules/Config/index.ts
+++ b/packages/commons/src/modules/Config/index.ts
@@ -4,7 +4,6 @@ export abstract class IConfigManager {
   abstract initialize(server: GrpcServer): Promise<void>;
   abstract initConfigAdminRoutes(): void;
   abstract registerAppConfig(): Promise<any>;
-  abstract registerModulesConfig(moduleName: string, moduleConfig: any): Promise<any>;
   abstract get(moduleName: string): Promise<any>;
   abstract set(moduleName: string, moduleConfig: any): Promise<any>;
   abstract addFieldsToModule(moduleName: string, moduleConfig: any): Promise<any>;

--- a/packages/core/src/config-manager/index.ts
+++ b/packages/core/src/config-manager/index.ts
@@ -223,10 +223,6 @@ export default class ConfigManager implements IConfigManager {
     }
   }
 
-  async registerModulesConfig(moduleName: string, moduleConfig: any) {
-    return this.set(moduleName, moduleConfig);
-  }
-
   async configureModule(
     call: GrpcRequest<UpdateRequest>,
     callback: GrpcCallback<UpdateResponse>,


### PR DESCRIPTION
This PR deprecates the following legacy compatibility options in preparation for `v0.15`:
-  Admin / Router http and socket env variables 
- `registerModulesConfig` config gRPC call
-  Admin / Router http and socket env variables 
-  Admin / Authentication (Router) Authorization header JWT-prefixed format (use `Bearer`)

Admin:  `PORT` -> `ADMIN_HTTP_PORT,  SOCKET_PORT` -> `ADMIN_SOCKET_PORT`
Router:  `PORT` -> `CLIENT_HTTP_PORT, SOCKET_PORT` -> `CLIENT_SOCKET_PORT`

**What kind of change does this PR introduce?** <!--(check at least one)-->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [X] Other

**Does this PR introduce a breaking change?** <!-- (check one) -->

- [X] Yes
- [ ] No

<!-- If yes, please describe the impact and migration path for existing applications. -->

**The PR fulfills these requirements:**

- [X] It's submitted to the `main` branch
- [ ] When resolving a specific issue, it's referenced in the PR's description  (e.g. `fix #xxx`, where "xxx" is the issue number)
