### PR TITLE
fix(hermes): not throwing an error on unavaibable route middlewares

### DIFF
--- a/libraries/hermes/src/GraphQl/utils/Request.utils.ts
+++ b/libraries/hermes/src/GraphQl/utils/Request.utils.ts
@@ -1,7 +1,8 @@
 import { ApolloError } from 'apollo-server-express';
-import { ConduitError } from '@conduitplatform/grpc-sdk';
+import ConduitGrpcSdk, { ConduitError } from '@conduitplatform/grpc-sdk';
 
 export const errorHandler = (err: Error | ConduitError | any) => {
+  ConduitGrpcSdk.Logger.error(err);
   if (err.hasOwnProperty('status')) {
     throw new ApolloError(err.message, (err as ConduitError).status.toString(), err);
   } else if (err.hasOwnProperty('code')) {

--- a/libraries/hermes/src/Router.ts
+++ b/libraries/hermes/src/Router.ts
@@ -78,13 +78,12 @@ export abstract class ConduitRouter {
     let primaryPromise = new Promise(resolve => {
       resolve({});
     });
-    const self = this;
-    if (this._middlewares && middlewares) {
-      middlewares.forEach(m => {
-        if (!this._middlewares?.hasOwnProperty(m))
-          primaryPromise = Promise.reject('Middleware does not exist');
+    middlewares?.forEach(m => {
+      if (!this._middlewares?.hasOwnProperty(m)) {
+        primaryPromise = Promise.reject('Middleware does not exist');
+      } else {
         primaryPromise = primaryPromise.then(r => {
-          return this._middlewares![m].executeRequest.bind(self._middlewares![m])(
+          return this._middlewares![m].executeRequest.bind(this._middlewares![m])(
             params,
           ).then((p: any) => {
             if (p.result) {
@@ -93,8 +92,8 @@ export abstract class ConduitRouter {
             return r;
           });
         });
-      });
-    }
+      }
+    });
     return primaryPromise;
   }
 

--- a/libraries/hermes/src/Socket/Socket.ts
+++ b/libraries/hermes/src/Socket/Socket.ts
@@ -111,6 +111,7 @@ export class SocketController extends ConduitRouter {
           this.handleResponse(res, socket);
         })
         .catch(e => {
+          ConduitGrpcSdk.Logger.error(e);
           socket.emit('conduit_error', e);
         });
 
@@ -127,6 +128,7 @@ export class SocketController extends ConduitRouter {
             this.handleResponse(res, socket);
           })
           .catch(e => {
+            ConduitGrpcSdk.Logger.error(e);
             socket.emit('conduit_error', e);
           });
       });
@@ -143,6 +145,7 @@ export class SocketController extends ConduitRouter {
             this.handleResponse(res, socket);
           })
           .catch(e => {
+            ConduitGrpcSdk.Logger.error(e);
             socket.emit('conduit_error', e);
           });
       });


### PR DESCRIPTION
This PR resolves a bug that previously resulted in an unavailable route middlewares not throwing an
error while no other middlewares are currently registered in the API.
Also fixed GraphQL and WebSockets not logging on error catch.

To reproduce, clear your Router's Redis cache and bring up `Core`, `Database`, `Router`, but not `Authentication` or any other
module providing client middlewares.
Register a custom schema through the CMS and enable authentication in any of its auto-generated CRUD endpoints.
Now perform the aforementioned client request without providing an authorization header.
Notice how the missing `userAuth` middleware does not prevent the request from going through.

The scope of this vulnerability is limited.
`Admin` comes with an initial middleware ootb, meaning it's not exploitable at all.
Even with no other client middlewares available, bringing up `Authentication` once will populate the recoverable `Router` state in Redis.

Long story short, this should only be exploitable through the `Router`'s client API, in deployments where no client middleware has been registered ever since the original deployment (or Redis wipe) and where a client middleware is somehow expected to be available.

**What kind of change does this PR introduce?** <!--(check at least one)-->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other (please describe)

**Does this PR introduce a breaking change?** <!-- (check one) -->

- [ ] Yes
- [X] No

**The PR fulfills these requirements:**

- [X] It's submitted to the `main` branch
- [ ] When resolving a specific issue, it's referenced in the PR's description  (e.g. `fix #xxx`, where "xxx" is the issue number)