### PR TITLE
fix(hermes): named route response types handled as string responses

### DIFF
--- a/libraries/hermes/src/GraphQl/GraphQL.ts
+++ b/libraries/hermes/src/GraphQl/GraphQL.ts
@@ -363,23 +363,22 @@ export class GraphQLController extends ConduitRouter {
           if (r.fromCache) {
             return r.data;
           } else {
-            result = r.result ? r.result : r;
+            result = r.result ?? r;
           }
-
-          if (r.result && !(typeof route.returnTypeFields === 'string')) {
-            if (typeof r.result === 'string') {
-              // only grpc route data is stringified
-              result = JSON.parse(result);
+          try {
+            // Handle gRPC route responses
+            result = JSON.parse(result);
+          } catch {
+            if (typeof result === 'string') {
+              // Nest plain string responses
+              result = {
+                result: this.extractResult(route.returnTypeFields as string, result),
+              };
             }
-          } else {
-            result = {
-              result: self.extractResult(route.returnTypeFields as string, result),
-            };
           }
           if (caching) {
             this.storeInCache(hashKey, result, cacheAge!);
           }
-
           return result;
         })
         .catch(errorHandler);

--- a/libraries/hermes/src/Rest/Rest.ts
+++ b/libraries/hermes/src/Rest/Rest.ts
@@ -177,17 +177,18 @@ export class RestController extends ConduitRouter {
             if (r.fromCache) {
               return res.status(200).json(r.data);
             } else {
-              result = r.result ? r.result : r;
+              result = r.result ?? r;
             }
-            if (r.result && !(typeof route.returnTypeFields === 'string')) {
-              if (typeof r.result === 'string') {
-                // only grpc route data is stringified
-                result = JSON.parse(result);
+            try {
+              // Handle gRPC route responses
+              result = JSON.parse(result);
+            } catch {
+              if (typeof result === 'string') {
+                // Nest plain string responses
+                result = {
+                  result: this.extractResult(route.returnTypeFields as string, result),
+                };
               }
-            } else {
-              result = {
-                result: this.extractResult(route.returnTypeFields as string, result),
-              };
             }
             if (r.setCookies && r.setCookies.length) {
               r.setCookies.forEach((cookie: Cookie) => {


### PR DESCRIPTION
Fixes a bug where named route response types where handled as string responses.

**What kind of change does this PR introduce?** <!--(check at least one)-->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other (please describe)

**Does this PR introduce a breaking change?** <!-- (check one) -->

- [ ] Yes
- [X] No

<!-- If yes, please describe the impact and migration path for existing applications. -->

**The PR fulfills these requirements:**

- [X] It's submitted to the `main` branch
- [ ] When resolving a specific issue, it's referenced in the PR's description  (e.g. `fix #xxx`, where "xxx" is the issue number)