### PR TITLE
fix(database): startup model recovery, deleteSchema admin route

### DIFF
--- a/modules/database/src/Database.ts
+++ b/modules/database/src/Database.ts
@@ -92,16 +92,9 @@ export default class DatabaseModule extends ManagedModule<void> {
       !declaredSchemaExists,
     );
     await this._activeAdapter.retrieveForeignSchemas();
-    this.updateHealth(HealthCheckStatus.SERVING);
-    const modelPromises = Object.values(models).flatMap((model: ConduitSchema) => {
-      if (model.name === '_DeclaredSchema') return [];
-      return this._activeAdapter.createSchemaFromAdapter(model, false, true);
-    });
-
-    await Promise.all(modelPromises);
-    await runMigrations(this._activeAdapter);
-
     await this._activeAdapter.recoverSchemasFromDatabase();
+    await runMigrations(this._activeAdapter);
+    this.updateHealth(HealthCheckStatus.SERVING);
   }
 
   async onRegister() {

--- a/modules/database/src/adapters/DatabaseAdapter.ts
+++ b/modules/database/src/adapters/DatabaseAdapter.ts
@@ -217,7 +217,13 @@ export abstract class DatabaseAdapter<T extends Schema> {
         return schema;
       })
       .map((model: ConduitSchema) => {
-        return this.createSchemaFromAdapter(model);
+        return this.createSchemaFromAdapter(
+          model,
+          !!model.modelOptions.conduit?.imported,
+          true,
+          false,
+          false,
+        );
       });
 
     await Promise.all(models);

--- a/modules/database/src/admin/schema.admin.ts
+++ b/modules/database/src/admin/schema.admin.ts
@@ -253,17 +253,14 @@ export class SchemaAdmin {
       );
     }
 
-    await this.database
-      .getSchemaModel('_DeclaredSchema')
-      .model.deleteOne(requestedSchema);
-    await this.database
-      .getSchemaModel('CustomEndpoints')
-      .model.deleteMany({ selectedSchema: id });
     const message = await this.database.deleteSchema(
       requestedSchema.name,
       deleteData,
       'database',
     );
+    await this.database
+      .getSchemaModel('CustomEndpoints')
+      .model.deleteMany({ selectedSchema: id });
 
     this.schemaController.refreshRoutes();
     this.customEndpointController.refreshEndpoints();


### PR DESCRIPTION
Fixes the following bugs:
- Admin schema deletion route deleting schemas twice
- Database module recovering `DeclaredSchemas` twice and registering imported schemas with `imported=false`

**What kind of change does this PR introduce?** <!--(check at least one)-->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other (please describe)

**Does this PR introduce a breaking change?** <!-- (check one) -->

- [ ] Yes
- [X] No

<!-- If yes, please describe the impact and migration path for existing applications. -->

**The PR fulfills these requirements:**

- [X] It's submitted to the `main` branch
- [ ] When resolving a specific issue, it's referenced in the PR's description  (e.g. `fix #xxx`, where "xxx" is the issue number)
