### PR TITLE
fix(hermes): GraphQL mutation result nesting

### DIFF
--- a/libraries/hermes/src/GraphQl/GraphQL.ts
+++ b/libraries/hermes/src/GraphQl/GraphQL.ts
@@ -427,16 +427,18 @@ export class GraphQLController extends ConduitRouter {
             context.removeCookie = r.removeCookies;
           }
 
-          if (r.result && !(typeof route.returnTypeFields === 'string')) {
-            if (typeof r.result === 'string') {
-              // only grpc route data is stringified
-              result = JSON.parse(result);
+          try {
+            // Handle gRPC route responses
+            result = JSON.parse(result);
+          } catch {
+            if (typeof result === 'string') {
+              // Nest plain string responses
+              result = {
+                result: this.extractResult(route.returnTypeFields as string, result),
+              };
             }
-          } else {
-            result = {
-              result: this.extractResult(route.returnTypeFields as string, result),
-            };
           }
+
           return result;
         })
         .catch(errorHandler);

--- a/modules/email/src/admin/index.ts
+++ b/modules/email/src/admin/index.ts
@@ -236,7 +236,7 @@ export class AdminHandlers {
       throw new GrpcError(status.INTERNAL, e.message);
     });
 
-    return { result: { templateDocuments, count } };
+    return { templateDocuments, count };
   }
 
   async createTemplate(call: ParsedRouterRequest): Promise<UnparsedRouterResponse> {

--- a/modules/router/src/admin/router.ts
+++ b/modules/router/src/admin/router.ts
@@ -38,6 +38,6 @@ export class RouterAdmin {
         });
       });
     });
-    return { result: response }; // unnested from result in Rest.addConduitRoute, grpc routes avoid this using wrapRouterGrpcFunction
+    return response;
   }
 }

--- a/packages/admin/src/routes/ChangePassword.route.ts
+++ b/packages/admin/src/routes/ChangePassword.route.ts
@@ -51,7 +51,7 @@ export function changePasswordRoute() {
       await Admin.getInstance().findByIdAndUpdate(admin._id, {
         password: await hash(newPassword, hashRounds ?? 11),
       });
-      return { result: { message: 'OK' } };
+      return { message: 'OK' };
     },
   );
 }

--- a/packages/admin/src/routes/ChangeUsersPassword.route.ts
+++ b/packages/admin/src/routes/ChangeUsersPassword.route.ts
@@ -51,7 +51,7 @@ export function changeUsersPasswordRoute() {
         password: await hash(newPassword, hashRounds ?? 11),
       });
 
-      return { result: { message: 'OK' } };
+      return { message: 'OK' };
     },
   );
 }

--- a/packages/admin/src/routes/CreateAdmin.route.ts
+++ b/packages/admin/src/routes/CreateAdmin.route.ts
@@ -53,7 +53,7 @@ export function getCreateAdminRoute() {
       const pass = await hashPassword(password, hashRounds);
       await Admin.getInstance().create({ username: username, password: pass });
 
-      return { result: { message: 'OK' } }; // unnested from result in Rest.addConduitRoute, grpc routes avoid this using wrapRouterGrpcFunction
+      return { message: 'OK' };
     },
   );
 }

--- a/packages/admin/src/routes/DeleteAdminUser.route.ts
+++ b/packages/admin/src/routes/DeleteAdminUser.route.ts
@@ -42,7 +42,7 @@ export function deleteAdminUserRoute() {
         );
       }
       await Admin.getInstance().deleteOne({ _id: id });
-      return { result: { message: 'Admin deleted.' } };
+      return { message: 'Admin deleted.' };
     },
   );
 }

--- a/packages/admin/src/routes/Login.route.ts
+++ b/packages/admin/src/routes/Login.route.ts
@@ -58,7 +58,7 @@ export function getLoginRoute() {
           tokenSecret,
           60,
         );
-        return { result: { token } };
+        return { token };
       }
       const authConfig = ConfigController.getInstance().config.auth;
       const { tokenSecret, tokenExpirationTime } = authConfig;
@@ -67,7 +67,7 @@ export function getLoginRoute() {
         tokenSecret,
         tokenExpirationTime,
       );
-      return { result: { token } }; // unnested from result in Rest.addConduitRoute, grpc routes avoid this using wrapRouterGrpcFunction
+      return { token };
     },
   );
 }

--- a/packages/admin/src/routes/ToggleTwoFa.route.ts
+++ b/packages/admin/src/routes/ToggleTwoFa.route.ts
@@ -59,7 +59,7 @@ export function toggleTwoFaRoute() {
         });
         await AdminTwoFactorSecret.getInstance().deleteOne({ adminId: admin._id });
 
-        return { result: { message: 'OK' } };
+        return { message: 'OK' };
       }
     },
   );

--- a/packages/admin/src/routes/VerifyQrCode.route.ts
+++ b/packages/admin/src/routes/VerifyQrCode.route.ts
@@ -50,7 +50,7 @@ export function verifyQrCodeRoute() {
         hasTwoFA: true,
       });
 
-      return { result: { message: 'OK' } };
+      return { message: 'OK' };
     },
   );
 }

--- a/packages/admin/src/utils/auth.ts
+++ b/packages/admin/src/utils/auth.ts
@@ -42,8 +42,7 @@ export async function verify2Fa(admin: Admin, code: string) {
   }
   const authConfig = ConfigController.getInstance().config.auth;
   const { tokenSecret, tokenExpirationTime } = authConfig;
-  const token = signToken({ id: admin._id }, tokenSecret, tokenExpirationTime);
-  return { result: { token } };
+  return signToken({ id: admin._id }, tokenSecret, tokenExpirationTime);
 }
 
 export function generateSecret(options?: { name: string; account: string }) {

--- a/packages/core/src/config-manager/admin/routes/GetConfigRoute.ts
+++ b/packages/core/src/config-manager/admin/routes/GetConfigRoute.ts
@@ -29,7 +29,7 @@ export default function getConfigRoute(
       } else {
         finalConfig = JSON.parse(finalConfig);
       }
-      return { result: { config: finalConfig } };
+      return { config: finalConfig };
     },
   );
 }

--- a/packages/core/src/config-manager/admin/routes/GetModules.route.ts
+++ b/packages/core/src/config-manager/admin/routes/GetModules.route.ts
@@ -33,7 +33,7 @@ export function getModulesRoute(registeredModules: Map<string, RegisteredModule>
             serving: value.serving,
           });
         });
-        return { result: { modules } }; // unnested from result in Rest.addConduitRoute, grpc routes avoid this using wrapRouterGrpcFunction
+        return { modules };
       } else {
         throw new ConduitError('INTERNAL', 500, 'Modules not available yet');
       }

--- a/packages/core/src/config-manager/admin/routes/SetConfigRoute.ts
+++ b/packages/core/src/config-manager/admin/routes/SetConfigRoute.ts
@@ -64,7 +64,7 @@ export default function setConfigRoute(
           updatedConfig = JSON.parse(updatedConfig.updatedConfig);
       }
       await conduit.getConfigManager().set(moduleName, updatedConfig);
-      return { result: { config: updatedConfig } };
+      return { config: updatedConfig };
     },
   );
 }


### PR DESCRIPTION
This PR fixes GraphQL mutation result nesting (as fix in #331 only addressed queries).
It also removes any verbose route handler result-nesting where redundant.
The latter should not affect the actual response type or doc generation.

**What kind of change does this PR introduce?** <!--(check at least one)-->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other (please describe)

**Does this PR introduce a breaking change?** <!-- (check one) -->

- [ ] Yes
- [X] No

<!-- If yes, please describe the impact and migration path for existing applications. -->

**The PR fulfills these requirements:**

- [X] It's submitted to the `main` branch
- [ ] When resolving a specific issue, it's referenced in the PR's description  (e.g. `fix #xxx`, where "xxx" is the issue number)

If adding a **new feature**, the PR's description includes:
