### PR TITLE
feat(authentication): auth refactor additions

### DIFF
--- a/modules/authentication/src/handlers/common.ts
+++ b/modules/authentication/src/handlers/common.ts
@@ -78,13 +78,13 @@ export class CommonHandlers implements IAuthenticationStrategy {
     if (config.refreshTokens.enabled && config.refreshTokens.setCookie) {
       removeCookies.push({
         name: 'refreshToken',
-        options: { ...config.cookieOptions, ...config.refreshTokens.cookieOptions },
+        options: config.refreshTokens.cookieOptions,
       });
     }
     if (config.refreshTokens.enabled && config.refreshTokens.setCookie) {
       removeCookies.push({
         name: 'accessToken',
-        options: { ...config.cookieOptions, ...config.accessTokens.cookieOptions },
+        options: config.accessTokens.cookieOptions,
       });
     }
     if (removeCookies.length > 0) {

--- a/modules/authentication/src/handlers/common.ts
+++ b/modules/authentication/src/handlers/common.ts
@@ -20,9 +20,7 @@ export class CommonHandlers implements IAuthenticationStrategy {
   constructor(private readonly grpcSdk: ConduitGrpcSdk) {}
 
   async renewAuth(call: ParsedRouterRequest): Promise<UnparsedRouterResponse> {
-    const context = call.request.context;
-    const clientId = context.clientId;
-    const { refreshToken } = call.request.params;
+    const { refreshToken, clientId } = call.request.context;
     const config = ConfigController.getInstance().config;
 
     const oldRefreshToken: RefreshToken | null = await RefreshToken.getInstance().findOne(
@@ -125,7 +123,7 @@ export class CommonHandlers implements IAuthenticationStrategy {
     routingManager.route(
       {
         path: '/user',
-        description: `Deletes the authenticated user.`,
+        description: 'Deletes the authenticated user.',
         action: ConduitRouteActions.DELETE,
         middlewares: ['authMiddleware'],
       },
@@ -138,11 +136,10 @@ export class CommonHandlers implements IAuthenticationStrategy {
         {
           path: '/renew',
           action: ConduitRouteActions.POST,
-          description: `Renews the access and refresh tokens 
-              when provided with a valid refresh token.`,
-          bodyParams: {
-            refreshToken: ConduitString.Required,
-          },
+          description:
+            'Renews the access and refresh tokens. ' +
+            `Requires a valid refresh token provided in Authorization header/cookie. Format 'Bearer TOKEN'`,
+          middlewares: ['authMiddleware'],
         },
         new ConduitRouteReturnDefinition('RenewAuthenticationResponse', {
           accessToken: ConduitString.Required,
@@ -156,7 +153,7 @@ export class CommonHandlers implements IAuthenticationStrategy {
       {
         path: '/logout',
         action: ConduitRouteActions.POST,
-        description: `Logs out authenticated user.`,
+        description: 'Logs out authenticated user.',
         middlewares: ['authMiddleware'],
       },
       new ConduitRouteReturnDefinition('LogoutResponse', 'String'),

--- a/modules/authentication/src/handlers/tokenProvider.ts
+++ b/modules/authentication/src/handlers/tokenProvider.ts
@@ -152,10 +152,7 @@ export class TokenProvider {
   ) {
     const cookies: { accessToken?: Cookie; refreshToken?: Cookie } = {};
     if (tokenOptions.config.accessTokens.setCookie) {
-      const cookieOptions = {
-        ...tokenOptions.config.cookieOptions,
-        ...tokenOptions.config.accessTokens.cookieOptions,
-      };
+      const cookieOptions = tokenOptions.config.accessTokens.cookieOptions;
       cookies.accessToken = {
         name: 'accessToken',
         value: (tokens[0] as AccessToken).token,
@@ -164,10 +161,7 @@ export class TokenProvider {
     }
     if (!isNil(tokens[1]) && tokenOptions.config.refreshTokens.setCookie) {
       if (!isNil(tokens[1].token)) {
-        const cookieOptions = {
-          ...tokenOptions.config.cookieOptions,
-          ...tokenOptions.config.refreshTokens.cookieOptions,
-        };
+        const cookieOptions = tokenOptions.config.refreshTokens.cookieOptions;
         cookies.refreshToken = {
           name: 'refreshToken',
           value: (tokens[1] as RefreshToken).token,

--- a/modules/authentication/src/routes/middleware.ts
+++ b/modules/authentication/src/routes/middleware.ts
@@ -45,7 +45,10 @@ export default async function (
       'Token is expired or otherwise not valid',
     );
   }
-  if (!(payload as JwtPayload).authorized && call.request.path !== '/twoFa/verify') {
+  if (
+    !(payload as JwtPayload).authorized &&
+    call.request.path !== '/authentication/twoFa/verify'
+  ) {
     throw new GrpcError(status.UNAUTHENTICATED, '2FA is required');
   }
   const accessToken = await AccessToken.getInstance().findOne(

--- a/modules/authentication/src/routes/middleware.ts
+++ b/modules/authentication/src/routes/middleware.ts
@@ -36,7 +36,7 @@ export default async function (
     args[1],
     ConfigController.getInstance().config.accessTokens.jwtSecret,
   );
-  if (!payload || typeof payload === 'string' || !payload.exp) {
+  if (!payload || typeof payload === 'string') {
     throw new GrpcError(status.UNAUTHENTICATED, 'Invalid token');
   }
   if (moment().isAfter(moment().milliseconds(payload.exp!))) {

--- a/modules/authentication/src/routes/middleware.ts
+++ b/modules/authentication/src/routes/middleware.ts
@@ -3,6 +3,9 @@ import {
   GrpcError,
   ParsedRouterRequest,
   UnparsedRouterResponse,
+  Indexable,
+  Headers,
+  Cookies,
 } from '@conduitplatform/grpc-sdk';
 import { AuthUtils } from '../utils/auth';
 import { AccessToken } from '../models';
@@ -11,6 +14,15 @@ import { status } from '@grpc/grpc-js';
 import { JwtPayload } from 'jsonwebtoken';
 import moment from 'moment/moment';
 
+/*
+ * Expects access token in 'Authorization' header or 'accessToken' cookie
+ *
+ * Exception: '/authentication/renew' (token renewal)
+ * Expects refresh token in 'Authorization' header or 'refreshToken' cookie
+ *
+ * Headers are bearer-formatted (eg: 'Bearer your-token-str')
+ */
+
 export default async function (
   call: ParsedRouterRequest,
 ): Promise<UnparsedRouterResponse> {
@@ -18,31 +30,22 @@ export default async function (
   const headers = call.request.headers;
   const cookies = call.request.cookies;
 
-  const header = (headers['Authorization'] ||
-    headers['authorization'] ||
-    cookies['Authorization'] ||
-    cookies['authorization']) as string;
-  if (isNil(header)) {
-    throw new GrpcError(status.UNAUTHENTICATED, 'No authorization header/cookie present');
-  }
-  const args = header.split(' ');
-  if (args.length !== 2) {
-    throw new GrpcError(status.UNAUTHENTICATED, 'Authorization header/cookie malformed');
-  }
-
-  if (args[0] !== 'Bearer') {
-    throw new GrpcError(
-      status.UNAUTHENTICATED,
-      "The Authorization header/cookie must be prefixed by 'Bearer '",
-    );
-  }
-
   if (call.request.path === '/authentication/renew') {
-    return { refreshToken: args[1] };
+    return handleTokenRefresh(context, headers, cookies);
   }
 
+  return handleAuthentication(context, headers, cookies, call.request.path);
+}
+
+async function handleAuthentication(
+  context: Indexable,
+  headers: Headers,
+  cookies: Cookies,
+  path: string,
+) {
+  const token = getToken(headers, cookies, 'access');
   const payload: string | JwtPayload | null = AuthUtils.verify(
-    args[1],
+    token,
     ConfigController.getInstance().config.accessTokens.jwtSecret,
   );
   if (!payload || typeof payload === 'string') {
@@ -54,15 +57,12 @@ export default async function (
       'Token is expired or otherwise not valid',
     );
   }
-  if (
-    !(payload as JwtPayload).authorized &&
-    call.request.path !== '/authentication/twoFa/verify'
-  ) {
+  if (!(payload as JwtPayload).authorized && path !== '/authentication/twoFa/verify') {
     throw new GrpcError(status.UNAUTHENTICATED, '2FA is required');
   }
   const accessToken = await AccessToken.getInstance().findOne(
     {
-      token: args[1],
+      token,
       clientId: context.clientId,
     },
     undefined,
@@ -75,4 +75,34 @@ export default async function (
     );
   }
   return { user: accessToken.user, jwtPayload: payload };
+}
+
+function handleTokenRefresh(context: Indexable, headers: Headers, cookies: Cookies) {
+  const token = getToken(headers, cookies, 'refresh');
+  return { refreshToken: token };
+}
+
+function getToken(headers: Headers, cookies: Cookies, reqType: 'access' | 'refresh') {
+  const tokenHeader = (headers['Authorization'] || headers['authorization']) as string; // formatted token
+  const tokenCookie = cookies[`${reqType}Token`] as string; // token
+  if (isNil(tokenHeader) && isNil(tokenCookie)) {
+    throw new GrpcError(
+      status.UNAUTHENTICATED,
+      `No 'Authorization' header or '${reqType}Token' cookie present`,
+    );
+  }
+  let headerArgs: string[] = [];
+  if (tokenHeader) {
+    headerArgs = tokenHeader.split(' ');
+    if (headerArgs.length !== 2) {
+      throw new GrpcError(status.UNAUTHENTICATED, "'Authorization' header malformed");
+    }
+    if (headerArgs[0] !== 'Bearer') {
+      throw new GrpcError(
+        status.UNAUTHENTICATED,
+        "The 'Authorization' header must be prefixed by 'Bearer '",
+      );
+    }
+  }
+  return headerArgs[1] || tokenCookie;
 }


### PR DESCRIPTION
Provides support for user auth token renewal via a cookie refresh header.
Fixes `Authontication` builds after `cookieOptions` external config field removal.

Depends on #358.

BREAKING CHANGE:

Auth token renewal route now accepts a bearer-formatted refreshToken header or cookie, previously provided as a body param.

**What kind of change does this PR introduce?** <!--(check at least one)-->

- [ ] Bugfix
- [X] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other (please describe)

**Does this PR introduce a breaking change?** <!-- (check one) -->

- [X] Yes
- [ ] No

<!-- If yes, please describe the impact and migration path for existing applications. -->

If adding a **new feature**, the PR's description includes:

- [X] A convincing reason for adding this feature <!-- to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it -->
