### PR TITLE
fix(database): getSchemas filters, declared schema collectionName uniqueness constraint

### DIFF
--- a/modules/database/src/admin/schema.admin.ts
+++ b/modules/database/src/admin/schema.admin.ts
@@ -43,7 +43,7 @@ export class SchemaAdmin {
     const skip = call.request.params.skip ?? 0;
     const limit = call.request.params.limit ?? 25;
     let query: ParsedQuery = {};
-    if (owner?.length !== 0) {
+    if (owner && owner?.length !== 0) {
       query = {
         $and: [query, { ownerModule: { $in: owner } }],
       };
@@ -56,6 +56,7 @@ export class SchemaAdmin {
     if (!isNil(enabled)) {
       const enabledQuery = {
         $or: [
+          { name: { $in: this.database.systemSchemas } },
           { ownerModule: { $ne: 'database' } },
           { 'modelOptions.conduit.cms.enabled': true },
         ],

--- a/modules/database/src/models/DeclaredSchema.schema.ts
+++ b/modules/database/src/models/DeclaredSchema.schema.ts
@@ -41,6 +41,7 @@ export const DeclaredSchema = new ConduitSchema(
     },
     collectionName: {
       type: TYPE.String,
+      unique: true,
       required: true,
     },
     createdAt: TYPE.Date,


### PR DESCRIPTION
Fixes getSchemas()'s `owner` and `enabled` filters.
Introduces a db level uniqueness constraint on `DeclaredSchema`'s `collectionName` field.

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** <!--(check at least one)-->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other (please describe)

**Does this PR introduce a breaking change?** <!-- (check one) -->

- [ ] Yes
- [X] No

<!-- If yes, please describe the impact and migration path for existing applications. -->

**The PR fulfills these requirements:**

- [X] It's submitted to the `main` branch
- [ ] When resolving a specific issue, it's referenced in the PR's description  (e.g. `fix #xxx`, where "xxx" is the issue number)
