### PR TITLE
fix(admin): generated config values reset on partial config update

### DIFF
--- a/packages/admin/src/index.ts
+++ b/packages/admin/src/index.ts
@@ -1,4 +1,4 @@
-import { isNaN, isNil } from 'lodash';
+import { isNaN, isNil, merge } from 'lodash';
 import { status } from '@grpc/grpc-js';
 import ConduitGrpcSdk, {
   ConduitError,
@@ -130,10 +130,12 @@ export default class AdminModule extends IConduitAdmin {
   }
 
   async initialize(server: GrpcServer) {
-    const adminConfig = await generateConfigDefaults(this.config.getProperties());
+    const previousConfig =
+      (await this.commons.getConfigManager().get('admin')) ?? this.config.getProperties();
+    await generateConfigDefaults(previousConfig);
     ConfigController.getInstance().config = await this.commons
       .getConfigManager()
-      .configurePackage('admin', adminConfig, AdminConfigRawSchema);
+      .configurePackage('admin', previousConfig, AdminConfigRawSchema);
     await server.addService(
       path.resolve(__dirname, '../../core/src/core.proto'),
       'conduit.core.Admin',
@@ -473,9 +475,9 @@ export default class AdminModule extends IConduitAdmin {
   }
 
   async setConfig(moduleConfig: any): Promise<any> {
-    await generateConfigDefaults(moduleConfig);
     const previousConfig = await this.commons.getConfigManager().get('admin');
-    const config = { ...previousConfig, ...moduleConfig };
+    const config = merge(previousConfig, moduleConfig);
+    await generateConfigDefaults(config);
     try {
       this.config.load(config).validate({
         allowed: 'strict',

--- a/packages/admin/src/utils/config.ts
+++ b/packages/admin/src/utils/config.ts
@@ -2,9 +2,7 @@ import { Config as ConfigSchema } from '../config';
 import crypto from 'crypto';
 import { isNil } from 'lodash';
 
-export async function generateConfigDefaults(
-  config: ConfigSchema,
-): Promise<ConfigSchema> {
+export async function generateConfigDefaults(config: ConfigSchema) {
   const tokenSecretConfig = config.auth.tokenSecret;
   if (tokenSecretConfig === '' || isNil(tokenSecretConfig)) {
     config.auth.tokenSecret = crypto.randomBytes(64).toString('base64');
@@ -14,5 +12,4 @@ export async function generateConfigDefaults(
       process.env.__DEFAULT_HOST_URL ??
       `http://localhost:${process.env['ADMIN_HTTP_PORT'] ?? '3030'}`;
   }
-  return config;
 }


### PR DESCRIPTION
This PR introduces the following fixes for `Admin`:
- generated config values reset on partial config update
- `setConfig()` not deep merging config objects

**What kind of change does this PR introduce?** <!--(check at least one)-->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other (please describe)

**Does this PR introduce a breaking change?** <!-- (check one) -->

- [ ] Yes
- [X] No

<!-- If yes, please describe the impact and migration path for existing applications. -->

**The PR fulfills these requirements:**

- [X] It's submitted to the `main` branch
- [ ] When resolving a specific issue, it's referenced in the PR's description  (e.g. `fix #xxx`, where "xxx" is the issue number)