### PR TITLE
feat(grpc-sdk): gRPC retries for unavailable services

### DIFF
--- a/libraries/grpc-sdk/package.json
+++ b/libraries/grpc-sdk/package.json
@@ -26,6 +26,7 @@
     "ioredis": "^5.1.0",
     "lodash": "^4.17.21",
     "nice-grpc": "^1.2.0",
+    "nice-grpc-client-middleware-retry": "^1",
     "prom-client": "^14.0.1",
     "protobufjs": "^6.11.3",
     "winston": "^3.8.1",

--- a/libraries/grpc-sdk/src/classes/ConduitModule.ts
+++ b/libraries/grpc-sdk/src/classes/ConduitModule.ts
@@ -1,6 +1,7 @@
 import { getModuleNameInterceptor, getGrpcSignedTokenInterceptor } from '../interceptors';
 import { CompatServiceDefinition } from 'nice-grpc/lib/service-definitions';
 import { Channel, Client, createChannel, createClientFactory } from 'nice-grpc';
+import { retryMiddleware } from 'nice-grpc-client-middleware-retry';
 import { HealthDefinition, HealthCheckResponse } from '../protoUtils/grpc_health_check';
 import { EventEmitter } from 'events';
 
@@ -39,12 +40,20 @@ export class ConduitModule<T extends CompatServiceDefinition> {
       'grpc.max_receive_message_length': 1024 * 1024 * 100,
       'grpc.max_send_message_length': 1024 * 1024 * 100,
     });
-    const clientFactory = createClientFactory().use(
-      this._grpcToken
-        ? getGrpcSignedTokenInterceptor(this._grpcToken)
-        : getModuleNameInterceptor(this._clientName),
-    );
-    this._client = clientFactory.create(this.type!, this.channel);
+    const clientFactory = createClientFactory()
+      .use(
+        this._grpcToken
+          ? getGrpcSignedTokenInterceptor(this._grpcToken)
+          : getModuleNameInterceptor(this._clientName),
+      )
+      .use(retryMiddleware);
+    this._client = clientFactory.create(this.type!, this.channel, {
+      '*': {
+        retryableStatuses: [14], // unavailable
+        retryMaxAttempts: 5,
+        retry: true,
+      },
+    });
     this._healthClient = clientFactory.create(HealthDefinition, this.channel);
     this.active = true;
   }

--- a/libraries/grpc-sdk/src/classes/ConduitModule.ts
+++ b/libraries/grpc-sdk/src/classes/ConduitModule.ts
@@ -50,6 +50,7 @@ export class ConduitModule<T extends CompatServiceDefinition> {
     this._client = clientFactory.create(this.type!, this.channel, {
       '*': {
         retryableStatuses: [14], // unavailable
+        retryBaseDelayMs: 250,
         retryMaxAttempts: 5,
         retry: true,
       },

--- a/libraries/grpc-sdk/src/classes/GrpcServer.ts
+++ b/libraries/grpc-sdk/src/classes/GrpcServer.ts
@@ -9,6 +9,7 @@ export class GrpcServer {
   private startedOnce: boolean = false;
   private _serviceNames: string[] = [];
   private scheduledRestart: any;
+  private _postponeRequests = 0;
   private _useForce?: boolean;
   private _services: {
     protoFilePath: string;
@@ -21,7 +22,8 @@ export class GrpcServer {
   }
 
   private postponeRestart() {
-    if (!this.scheduledRestart) return;
+    if (!this.scheduledRestart || this._postponeRequests > 5) return;
+    this._postponeRequests++;
     this.scheduleRefresh();
   }
 
@@ -118,6 +120,7 @@ export class GrpcServer {
       ConduitGrpcSdk.Logger.log('Refresh complete');
       clearTimeout(self.scheduledRestart);
       self.scheduledRestart = undefined;
+      self._postponeRequests = 0;
     }, 2000);
   }
 

--- a/libraries/grpc-sdk/src/helpers/wrapGrpcFunctions.ts
+++ b/libraries/grpc-sdk/src/helpers/wrapGrpcFunctions.ts
@@ -46,8 +46,6 @@ export function wrapGrpcFunctions(
           code: status.INTERNAL,
           message: (error as Error).message,
         });
-      } finally {
-        postponeRestart();
       }
     };
   });

--- a/yarn.lock
+++ b/yarn.lock
@@ -3870,6 +3870,13 @@ abort-controller-x@^0.2.4:
   dependencies:
     node-abort-controller "^1.2.1 || ^2.0.0"
 
+abort-controller-x@^0.2.6:
+  version "0.2.7"
+  resolved "https://registry.yarnpkg.com/abort-controller-x/-/abort-controller-x-0.2.7.tgz#6fa9be5b278b9c533d4d078d0ba660d40683907e"
+  integrity sha512-hq/lt8yODKrwuZa69GhSTl2l2kcrus2khZ7OjD6Bmqmx6tbW6dnV8cVGnkkdLCWnjXpgSx8zjQo+HUc9mvoQ/w==
+  dependencies:
+    node-abort-controller "^1.2.1 || ^2.0.0"
+
 abort-controller-x@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/abort-controller-x/-/abort-controller-x-0.4.0.tgz#fde25da52548c7ff3d8b3b32dffc943452874d5f"
@@ -9529,6 +9536,15 @@ netmask@^2.0.2:
   version "2.0.2"
   resolved "https://registry.npmmirror.com/netmask/-/netmask-2.0.2.tgz#8b01a07644065d536383835823bc52004ebac5e7"
   integrity sha512-dBpDMdxv9Irdq66304OLfEmQ9tbNRFnFTuZiLo+bD+r332bBmMJ8GBLXklIXXgxd3+v9+KUnZaUR5PJMa75Gsg==
+
+nice-grpc-client-middleware-retry@^1:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/nice-grpc-client-middleware-retry/-/nice-grpc-client-middleware-retry-1.1.2.tgz#cb4e090aa27bb7160bc14ce115210fecc0f58f43"
+  integrity sha512-7RWHpQxQ6Dq++TTaP/S/GFd4MuSd1jjeQr8q41oQ6phyPRTZmNx8gdbVQg2Q70iATFjJ9eQfj4/QysfeQ3LURQ==
+  dependencies:
+    abort-controller-x "^0.2.6"
+    nice-grpc-common "^1.1.0"
+    node-abort-controller "^2.0.0"
 
 nice-grpc-common@^1.1.0:
   version "1.1.0"


### PR DESCRIPTION
This PR introduces gRPC client request retries.
Retries only occur on main service clients (that is to say, not health check clients) for `unavaliable` gRPC error types.

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** <!--(check at least one)-->

- [ ] Bugfix
- [X] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other (please describe)

**Does this PR introduce a breaking change?** <!-- (check one) -->

- [ ] Yes
- [X] No

<!-- If yes, please describe the impact and migration path for existing applications. -->

**The PR fulfills these requirements:**

- [X] It's submitted to the `main` branch
- [ ] When resolving a specific issue, it's referenced in the PR's description  (e.g. `fix #xxx`, where "xxx" is the issue number)