### PR TITLE
fix(authentication): TokenProvider singleton init Router dependency

### DIFF
--- a/modules/authentication/src/Authentication.ts
+++ b/modules/authentication/src/Authentication.ts
@@ -58,6 +58,7 @@ export default class Authentication extends ManagedModule<Config> {
   async onServerStart() {
     await this.grpcSdk.waitForExistence('database');
     this.database = this.grpcSdk.database!;
+    TokenProvider.getInstance(this.grpcSdk);
     await this.registerSchemas();
     await runMigrations(this.grpcSdk);
   }
@@ -147,7 +148,7 @@ export default class Authentication extends ManagedModule<Config> {
     }
     const config = ConfigController.getInstance().config;
 
-    const tokens = await TokenProvider.getInstance()!.provideUserTokensInternal({
+    const tokens = await TokenProvider.getInstance().provideUserTokensInternal({
       user,
       clientId,
       config,

--- a/modules/authentication/src/handlers/common.ts
+++ b/modules/authentication/src/handlers/common.ts
@@ -44,7 +44,7 @@ export class CommonHandlers implements IAuthenticationStrategy {
     // delete the old refresh token
     await RefreshToken.getInstance().deleteOne({ _id: oldRefreshToken._id });
 
-    return TokenProvider.getInstance()!.provideUserTokens({
+    return TokenProvider.getInstance().provideUserTokens({
       user: oldRefreshToken.user as User,
       clientId,
       config,
@@ -61,7 +61,7 @@ export class CommonHandlers implements IAuthenticationStrategy {
     const authToken = call.request.headers.authorization;
     const clientConfig = config.clients;
     ConduitGrpcSdk.Metrics?.decrement('logged_in_users_total');
-    await TokenProvider.getInstance()!.logOutClientOperations(
+    await TokenProvider.getInstance().logOutClientOperations(
       this.grpcSdk,
       clientConfig,
       authToken,

--- a/modules/authentication/src/handlers/local.ts
+++ b/modules/authentication/src/handlers/local.ts
@@ -259,7 +259,7 @@ export class LocalHandlers implements IAuthenticationStrategy {
       throw new GrpcError(status.UNAUTHENTICATED, 'Invalid login credentials');
     await this._authenticateChecks(password, config, user);
     ConduitGrpcSdk.Metrics?.increment('logged_in_users_total');
-    return TokenProvider.getInstance()!.provideUserTokens({
+    return TokenProvider.getInstance().provideUserTokens({
       user,
       clientId,
       config,
@@ -340,7 +340,7 @@ export class LocalHandlers implements IAuthenticationStrategy {
     await User.getInstance().findByIdAndUpdate(user._id, user, true);
     await Token.getInstance().deleteOne(passwordResetTokenDoc);
 
-    await TokenProvider.getInstance()!.deleteUserTokens({
+    await TokenProvider.getInstance().deleteUserTokens({
       user: user._id,
     });
 

--- a/modules/authentication/src/handlers/magicLink.ts
+++ b/modules/authentication/src/handlers/magicLink.ts
@@ -132,7 +132,7 @@ export class MagicLinkHandlers implements IAuthenticationStrategy {
         ConduitGrpcSdk.Logger.error(e);
       });
 
-    return TokenProvider.getInstance()!.provideUserTokens(
+    return TokenProvider.getInstance().provideUserTokens(
       {
         user,
         clientId: token.data.clientId,

--- a/modules/authentication/src/handlers/oauth2/OAuth2.ts
+++ b/modules/authentication/src/handlers/oauth2/OAuth2.ts
@@ -133,7 +133,7 @@ export abstract class OAuth2<T, S extends OAuth2Settings>
     const config = ConfigController.getInstance().config;
     ConduitGrpcSdk.Metrics?.increment('logged_in_users_total');
 
-    return TokenProvider.getInstance()!.provideUserTokens(
+    return TokenProvider.getInstance().provideUserTokens(
       {
         user,
         clientId,
@@ -154,7 +154,7 @@ export abstract class OAuth2<T, S extends OAuth2Settings>
     const config = ConfigController.getInstance().config;
     ConduitGrpcSdk.Metrics?.increment('logged_in_users_total');
 
-    return TokenProvider.getInstance()!.provideUserTokens({
+    return TokenProvider.getInstance().provideUserTokens({
       user,
       clientId: call.request.params['clientId'],
       config,

--- a/modules/authentication/src/handlers/phone.ts
+++ b/modules/authentication/src/handlers/phone.ts
@@ -94,7 +94,7 @@ export class PhoneHandlers implements IAuthenticationStrategy {
       if (isNil(user)) throw new GrpcError(status.UNAUTHENTICATED, 'User not found');
     }
 
-    return TokenProvider.getInstance(this.grpcSdk)!.provideUserTokens({
+    return TokenProvider.getInstance().provideUserTokens({
       user,
       clientId: existingToken.data.clientId,
       config,

--- a/modules/authentication/src/handlers/service.ts
+++ b/modules/authentication/src/handlers/service.ts
@@ -53,7 +53,7 @@ export class ServiceHandler implements IAuthenticationStrategy {
     const config = ConfigController.getInstance().config;
 
     ConduitGrpcSdk.Metrics?.increment('logged_in_users_total');
-    return TokenProvider.getInstance()!.provideUserTokens({
+    return TokenProvider.getInstance().provideUserTokens({
       user: serviceUser as unknown as User,
       clientId,
       config,

--- a/modules/authentication/src/handlers/tokenProvider.ts
+++ b/modules/authentication/src/handlers/tokenProvider.ts
@@ -25,7 +25,7 @@ export class TokenProvider {
   public static getInstance(grpcSdk?: ConduitGrpcSdk) {
     if (TokenProvider._instance) return TokenProvider._instance;
     if (!grpcSdk) throw new Error('GrpcSdk not provided');
-    TokenProvider._instance = new TokenProvider(grpcSdk);
+    return (TokenProvider._instance = new TokenProvider(grpcSdk));
   }
 
   async provideUserTokens(tokenOptions: TokenOptions, redirectUrl?: string) {

--- a/modules/authentication/src/handlers/twoFa.ts
+++ b/modules/authentication/src/handlers/twoFa.ts
@@ -288,7 +288,7 @@ export class TwoFa implements IAuthenticationStrategy {
         throw new GrpcError(status.UNAUTHENTICATED, 'Code verification unsuccessful');
       }
       const config = ConfigController.getInstance().config;
-      return TokenProvider.getInstance(this.grpcSdk)!.provideUserTokens({
+      return TokenProvider.getInstance().provideUserTokens({
         user,
         clientId,
         config,
@@ -441,7 +441,7 @@ export class TwoFa implements IAuthenticationStrategy {
       throw new GrpcError(status.INVALID_ARGUMENT, 'Code is not correct');
     }
     const config = ConfigController.getInstance().config;
-    return TokenProvider.getInstance()!.provideUserTokens({
+    return TokenProvider.getInstance().provideUserTokens({
       user,
       clientId,
       config,

--- a/modules/authentication/src/routes/index.ts
+++ b/modules/authentication/src/routes/index.ts
@@ -14,7 +14,6 @@ import { PhoneHandlers } from '../handlers/phone';
 import { OAuth2 } from '../handlers/oauth2/OAuth2';
 import { OAuth2Settings } from '../handlers/oauth2/interfaces/OAuth2Settings';
 import { TwoFa } from '../handlers/twoFa';
-import { TokenProvider } from '../handlers/tokenProvider';
 import authMiddleware from './middleware';
 import { MagicLinkHandlers } from '../handlers/magicLink';
 import { Config } from '../config';
@@ -38,8 +37,6 @@ export class AuthenticationRoutes {
     this.localHandlers = new LocalHandlers(this.grpcSdk);
     this.twoFaHandlers = new TwoFa(this.grpcSdk);
     this.magicLinkHandlers = new MagicLinkHandlers(this.grpcSdk);
-    // initialize SDK
-    TokenProvider.getInstance(grpcSdk);
   }
 
   async registerRoutes() {


### PR DESCRIPTION
Fixed a bug where attempting to use `TokenProvider` without `Router` (through gRPC) would fail as the singleton was only initialized inside route handlers.
Also improved `TokenProvider.getInstance()` ergonomics.

TokenProvider is now initialized early enough to be used by gRPC requests when there's no Router available.

**What kind of change does this PR introduce?** <!--(check at least one)-->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other (please describe)

**Does this PR introduce a breaking change?** <!-- (check one) -->

- [ ] Yes
- [X] No

<!-- If yes, please describe the impact and migration path for existing applications. -->

**The PR fulfills these requirements:**

- [X] It's submitted to the `main` branch
- [ ] When resolving a specific issue, it's referenced in the PR's description  (e.g. `fix #xxx`, where "xxx" is the issue number)
