### PR TITLE
feat(storage): getFolders() admin search query param

### DIFF
--- a/modules/storage/src/admin/index.ts
+++ b/modules/storage/src/admin/index.ts
@@ -151,8 +151,8 @@ export class AdminRoutes {
         action: ConduitRouteActions.GET,
         description: `Returns queried folders.`,
         queryParams: {
-          skip: ConduitNumber.Required,
-          limit: ConduitNumber.Required,
+          skip: ConduitNumber.Optional,
+          limit: ConduitNumber.Optional,
           sort: ConduitString.Optional,
           container: ConduitString.Optional,
           parent: ConduitString.Optional,
@@ -236,7 +236,9 @@ export class AdminRoutes {
   }
 
   async getFiles(call: ParsedRouterRequest): Promise<UnparsedRouterResponse> {
-    const { skip, limit, sort, folder, search } = call.request.params;
+    const { sort, folder, search } = call.request.params;
+    const { skip } = call.request.params ?? 0;
+    const { limit } = call.request.params ?? 25;
     const query: Query = {
       container: call.request.params.container,
     };

--- a/modules/storage/src/admin/index.ts
+++ b/modules/storage/src/admin/index.ts
@@ -156,6 +156,7 @@ export class AdminRoutes {
           sort: ConduitString.Optional,
           container: ConduitString.Optional,
           parent: ConduitString.Optional,
+          search: ConduitString.Optional,
         },
       },
       new ConduitRouteReturnDefinition('getFolders', {
@@ -258,15 +259,19 @@ export class AdminRoutes {
   }
 
   async getFolders(call: ParsedRouterRequest): Promise<UnparsedRouterResponse> {
-    const { sort } = call.request.params;
+    const { sort, parent, search } = call.request.params;
     const { skip } = call.request.params ?? 0;
     const { limit } = call.request.params ?? 25;
     const query: Query = {
       container: call.request.params.container,
     };
-    if (!isNil(call.request.params.parent)) {
+    if (!isNil(search)) {
+      query.name = { $regex: search, $options: 'i' };
+    }
+    if (!isNil(parent)) {
+      const regexSuffix = query.name.$regex !== '' ? query.name.$regex : '([^/]+)/?$';
       query.name = {
-        $regex: `${call.request.params.parent}\/([^\/]+)\/?$`,
+        $regex: `${parent}\/${regexSuffix}`,
         $options: 'i',
       };
     }


### PR DESCRIPTION
This PR introduces a search query param for `Storage`'s admin API getFolders() route.
Can be combined with existing `parent` query param.

I also introduced default pagination values for the getFiles() admin route (previously required).

**What kind of change does this PR introduce?** <!--(check at least one)-->

- [ ] Bugfix
- [X] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other (please describe)

**Does this PR introduce a breaking change?** <!-- (check one) -->

- [ ] Yes
- [X] No

<!-- If yes, please describe the impact and migration path for existing applications. -->

**The PR fulfills these requirements:**

- [X] It's submitted to the `main` branch
- [ ] When resolving a specific issue, it's referenced in the PR's description  (e.g. `fix #xxx`, where "xxx" is the issue number)

If adding a **new feature**, the PR's description includes:

- [X] A convincing reason for adding this feature <!-- to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it -->

Feature was requested by Conduit-UI.
