### PR TITLE
feat(grpc-sdk): service address url remapping for host/docker interoperability

### DIFF
--- a/docker/.env
+++ b/docker/.env
@@ -1,19 +1,39 @@
+# Target Container Tags
 IMAGE_TAG="latest"
 UI_IMAGE_TAG="latest"
+
+# gRPC Services
 CORE_GRPC_PORT="55152"
-CORE_MASTER_KEY="M4ST3RK3Y"
+DB_GRPC_PORT_DB="55160"
+ROUTER_GRPC_PORT="55161"
+AUTH_GRPC_PORT="55162"
+CHAT_GRPC_PORT="55163"
+EMAIL_GRPC_PORT="55164"
+FORMS_GRPC_PORT="55165"
+PUSH_GRPC_PORT="55166"
+SMS_GRPC_PORT="55167"
+STORAGE_GRPC_PORT="55168"
+
+# API Settings
 ADMIN_HTTP_PORT="3030"
 ADMIN_SOCKET_PORT="3031"
 ADMIN_DEFAULT_HOST_URL="http://localhost:3030"
 CLIENT_HTTP_PORT="3000"
 CLIENT_SOCKET_PORT="3001"
 CLIENT_DEFAULT_HOST_URL="http://localhost:3000"
+
+# Database Engine
 DB_TYPE="mongodb"
 DB_USER="conduit"
 DB_PASS="pass"
 DB_PORT="27017"
 DB_CONN_URI="mongodb://conduit:pass@conduit-mongo:27017"              # profile: mongodb
 #DB_CONN_URI="postgres://conduit:pass@conduit-postgres:5432/conduit"  # profile: postgres
+
+# Security
+CORE_MASTER_KEY="M4ST3RK3Y"
 GRPC_KEY=""
+
+# Metrics & Logs
 PROMETHEUS_PORT="9090"
 LOKI_PORT="3100"

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -37,7 +37,7 @@ services:
       - prometheus
       - loki
     ports:
-      - '${CORE_GRPC_PORT:-55152}:55152'
+#      - '${CORE_GRPC_PORT:-55152}:${CORE_GRPC_PORT:-55152}'
       - '${CORE_ADMIN_HTTP_PORT:-3030}:3030'
       - '${CORE_ADMIN_SOCKET_PORT:-3031}:3031'
     environment:
@@ -54,6 +54,8 @@ services:
       default:
         aliases:
           - conduit
+    extra_hosts:
+      - host.docker.internal:host-gateway
 
   ui:
     container_name: 'conduit-ui'
@@ -79,9 +81,11 @@ services:
       - ${DB_TYPE:-mongodb}
       - prometheus
       - loki
+#    ports:
+#      - '${DB_GRPC_PORT:-55160}:${DB_GRPC_PORT:-55160}'
     environment:
-      CONDUIT_SERVER: 'conduit:55152'
-      SERVICE_URL: 'conduit-database:55160'
+      CONDUIT_SERVER: 'conduit:${CORE_GRPC_PORT:-55152}'
+      SERVICE_URL: 'conduit-database:${DB_GRPC_PORT:-55160}'
       GRPC_PORT: '55160'
       METRICS_PORT: '9092'
       LOKI_URL: 'http://conduit-loki:3100'
@@ -92,6 +96,8 @@ services:
       default:
         aliases:
           - conduit-database
+    extra_hosts:
+      - host.docker.internal:host-gateway
 
   router:
     container_name: 'conduit-router'
@@ -103,11 +109,12 @@ services:
       - prometheus
       - loki
     ports:
+#      - '${ROUTER_GRPC_PORT:-55161}:${ROUTER_GRPC_PORT:-55161}'
       - '${CLIENT_HTTP_PORT:-3000}:3000'
       - '${CLIENT_SOCKET_PORT:-3001}:3001'
     environment:
-      CONDUIT_SERVER: 'conduit:55152'
-      SERVICE_URL: 'conduit-router:55161'
+      CONDUIT_SERVER: 'conduit:${CORE_GRPC_PORT:-55152}'
+      SERVICE_URL: 'conduit-router:${ROUTER_GRPC_PORT:-55161}'
       GRPC_PORT: '55161'
       __DEFAULT_HOST_URL: '${CLIENT_DEFAULT_HOST_URL:-http://localhost:3000}'
       METRICS_PORT: '9093'
@@ -119,6 +126,8 @@ services:
       default:
         aliases:
           - conduit-router
+    extra_hosts:
+      - host.docker.internal:host-gateway
 
   authentication:
     container_name: 'conduit-authentication'
@@ -129,9 +138,11 @@ services:
       - database
       - prometheus
       - loki
+#    ports:
+#      - '${AUTH_GRPC_PORT:-55162}:${AUTH_GRPC_PORT:-55162}'
     environment:
-      CONDUIT_SERVER: 'conduit:55152'
-      SERVICE_URL: 'conduit-authentication:55162'
+      CONDUIT_SERVER: 'conduit:${CORE_GRPC_PORT:-55152}'
+      SERVICE_URL: 'conduit-authentication:${AUTH_GRPC_PORT:-55162}'
       GRPC_PORT: '55162'
       METRICS_PORT: '9094'
       LOKI_URL: 'http://conduit-loki:3100'
@@ -140,6 +151,8 @@ services:
       default:
         aliases:
           - conduit-authentication
+    extra_hosts:
+      - host.docker.internal:host-gateway
 
 #  # Optional Services
   chat:
@@ -149,12 +162,15 @@ services:
     depends_on:
       - core
       - database
+      - authentication
       - router
       - prometheus
       - loki
+#    ports:
+#      - '${CHAT_GRPC_PORT:-55163}:${CHAT_GRPC_PORT:-55163}'
     environment:
-      CONDUIT_SERVER: 'conduit:55152'
-      SERVICE_URL: 'conduit-chat:55163'
+      CONDUIT_SERVER: 'conduit:${CORE_GRPC_PORT:-55152}'
+      SERVICE_URL: 'conduit-chat:${CHAT_GRPC_PORT:-55163}'
       GRPC_PORT: '55163'
       METRICS_PORT: '9095'
       LOKI_URL: 'http://conduit-loki:3100'
@@ -164,6 +180,8 @@ services:
       default:
         aliases:
           - conduit-chat
+    extra_hosts:
+      - host.docker.internal:host-gateway
 
   email:
     container_name: 'conduit-email'
@@ -174,9 +192,11 @@ services:
       - database
       - prometheus
       - loki
+#    ports:
+#      - '${EMAIL_GRPC_PORT:-55164}:${EMAIL_GRPC_PORT:-55164}'
     environment:
-      CONDUIT_SERVER: 'conduit:55152'
-      SERVICE_URL: 'conduit-email:55164'
+      CONDUIT_SERVER: 'conduit:${CORE_GRPC_PORT:-55152}'
+      SERVICE_URL: 'conduit-email:${EMAIL_GRPC_PORT:-55164}'
       GRPC_PORT: '55164'
       METRICS_PORT: '9096'
       LOKI_URL: 'http://conduit-loki:3100'
@@ -186,6 +206,8 @@ services:
       default:
         aliases:
           - conduit-email
+    extra_hosts:
+      - host.docker.internal:host-gateway
 
   forms:
     container_name: 'conduit-forms'
@@ -198,10 +220,11 @@ services:
       - email
       - prometheus
       - loki
+#    ports:
+#      - '${FORMS_GRPC_PORT:-55165}:${FORMS_GRPC_PORT:-55165}'
     environment:
-      CONDUIT_SERVER: 'conduit:55152'
-      SERVICE_URL: 'conduit-forms:55165'
-      REGISTER_NAME: 'true'
+      CONDUIT_SERVER: 'conduit:${CORE_GRPC_PORT:-55152}'
+      SERVICE_URL: 'conduit-forms:${FORMS_GRPC_PORT:-55165}'
       GRPC_PORT: '55165'
       METRICS_PORT: '9097'
       LOKI_URL: 'http://conduit-loki:3100'
@@ -211,6 +234,8 @@ services:
       default:
         aliases:
           - conduit-forms
+    extra_hosts:
+      - host.docker.internal:host-gateway
 
   push-notifications:
     container_name: 'conduit-push-notifications'
@@ -222,9 +247,11 @@ services:
       - router
       - prometheus
       - loki
+#    ports:
+#      - '${PUSH_GRPC_PORT:-55166}:${PUSH_GRPC_PORT:-55166}'
     environment:
-      CONDUIT_SERVER: 'conduit:55152'
-      SERVICE_URL: 'conduit-push-notifications:55166'
+      CONDUIT_SERVER: 'conduit:${CORE_GRPC_PORT:-55152}'
+      SERVICE_URL: 'conduit-push-notifications:${PUSH_GRPC_PORT:-55166}'
       GRPC_PORT: '55166'
       METRICS_PORT: '9098'
       LOKI_URL: 'http://conduit-loki:3100'
@@ -234,6 +261,8 @@ services:
       default:
         aliases:
           - conduit-push-notifications
+    extra_hosts:
+      - host.docker.internal:host-gateway
 
   sms:
     container_name: 'conduit-sms'
@@ -244,9 +273,11 @@ services:
       - database
       - prometheus
       - loki
+#    ports:
+#      - '${SMS_GRPC_PORT:-55167}:${SMS_GRPC_PORT:-55167}'
     environment:
-      CONDUIT_SERVER: 'conduit:55152'
-      SERVICE_URL: 'conduit-sms:55167'
+      CONDUIT_SERVER: 'conduit:${CORE_GRPC_PORT:-55152}'
+      SERVICE_URL: 'conduit-sms:${SMS_GRPC_PORT:-55167}'
       GRPC_PORT: '55167'
       METRICS_PORT: '9099'
       LOKI_URL: 'http://conduit-loki:3100'
@@ -256,6 +287,8 @@ services:
       default:
         aliases:
           - conduit-sms
+    extra_hosts:
+      - host.docker.internal:host-gateway
 
   storage:
     container_name: 'conduit-storage'
@@ -267,9 +300,11 @@ services:
       - router
       - prometheus
       - loki
+#    ports:
+#      - '${STORAGE_GRPC_PORT:-55168}:${STORAGE_GRPC_PORT:-55168}'
     environment:
-      CONDUIT_SERVER: 'conduit:55152'
-      SERVICE_URL: 'conduit-storage:55168'
+      CONDUIT_SERVER: 'conduit:${CORE_GRPC_PORT:-55152}'
+      SERVICE_URL: 'conduit-storage:${STORAGE_GRPC_PORT:-55168}'
       GRPC_PORT: '55168'
       METRICS_PORT: '9190'
       LOKI_URL: 'http://conduit-loki:3100'
@@ -279,6 +314,8 @@ services:
       default:
         aliases:
           - conduit-storage
+    extra_hosts:
+      - host.docker.internal:host-gateway
 
   # Dependencies
   redis:

--- a/libraries/grpc-sdk/src/classes/ModuleManager.ts
+++ b/libraries/grpc-sdk/src/classes/ModuleManager.ts
@@ -26,6 +26,7 @@ export class ModuleManager<T> {
     this.serviceAddress =
       // @compat (v0.15): SERVICE_IP -> SERVICE_URL
       process.env.SERVICE_URL || process.env.SERVICE_IP || '0.0.0.0:' + this.servicePort;
+    const urlRemap = process.env.URL_REMAP;
     try {
       this.grpcSdk = new ConduitGrpcSdk(
         process.env.CONDUIT_SERVER,
@@ -33,6 +34,8 @@ export class ModuleManager<T> {
           return this.module.healthState;
         },
         module.name,
+        true,
+        urlRemap,
       );
     } catch {
       throw new Error('Failed to initialize grpcSdk');

--- a/libraries/grpc-sdk/src/index.ts
+++ b/libraries/grpc-sdk/src/index.ts
@@ -85,6 +85,7 @@ export default class ConduitGrpcSdk {
     serviceHealthStatusGetter: Function,
     name?: string,
     watchModules = true,
+    private readonly urlRemap?: string,
   ) {
     if (!name) {
       this.name = 'module_' + Crypto.randomBytes(16).toString('hex');
@@ -375,7 +376,7 @@ export default class ConduitGrpcSdk {
     return promise
       .then(() => {
         const redisManager = new RedisManager(
-          this._redisDetails!.host,
+          this.urlRemap ?? this._redisDetails!.host,
           this._redisDetails!.port,
         );
         this._eventBus = new EventBus(redisManager);
@@ -418,7 +419,7 @@ export default class ConduitGrpcSdk {
       // ConduitGrpcSdk.Logger.log(`Creating gRPC client for ${moduleName}`);
       this._modules[moduleName] = new this._availableModules[moduleName](
         this.name,
-        moduleUrl,
+        this.urlRemap ? `${this.urlRemap}:${moduleUrl.split(':')[1]}` : moduleUrl,
         this._grpcToken,
       );
     } else if (this._dynamicModules[moduleName]) {
@@ -426,7 +427,7 @@ export default class ConduitGrpcSdk {
       this._modules[moduleName] = new ConduitModule(
         this.name,
         moduleName,
-        moduleUrl,
+        this.urlRemap ? `${this.urlRemap}:${moduleUrl.split(':')[1]}` : moduleUrl,
         this._grpcToken,
       );
       this._modules[moduleName].initializeClient(this._dynamicModules[moduleName]);


### PR DESCRIPTION
This should facilitiate development of Conduit modules on the host, while making use of a locally deployed container-based Conduit instance.

Spin up a dockerized Conduit deployment, then start your microservice with the following env vars:
`SERVICE_URL`: host.docker.internal:XXXXX (specifying an available port)
`URL_REMAP`:   0.0.0.0

Notes:
- container gRPC service ports should be exposed
- Linux systems need: --add-host=host.docker.internal:host-gateway
- Remote deployments are not supported

I've updated the compose file so that it includes the solution for Linux users.
I kept the service port exports commented out so as not keep failure points to a minimum for the vast majority of users.
I also updated all the port related envs to match internal/external ports (as we only update the address part).

Ideally, I'll handle optionally exposing the ports through the CLI using a single compose file.

**What kind of change does this PR introduce?** <!--(check at least one)-->

- [ ] Bugfix
- [X] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other (please describe)

**Does this PR introduce a breaking change?** <!-- (check one) -->

- [ ] Yes
- [X] No

<!-- If yes, please describe the impact and migration path for existing applications. -->

**The PR fulfills these requirements:**

- [X] It's submitted to the `main` branch
- [ ] When resolving a specific issue, it's referenced in the PR's description  (e.g. `fix #xxx`, where "xxx" is the issue number)

If adding a **new feature**, the PR's description includes:

- [X] A convincing reason for adding this feature <!-- to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it -->

**Other information:**
