### PR TITLE
fix(grpc-sdk): loki availability checks

### DIFF
--- a/libraries/grpc-sdk/src/index.ts
+++ b/libraries/grpc-sdk/src/index.ts
@@ -33,10 +33,9 @@ import {
 import { GrpcError, HealthCheckStatus } from './types';
 import { createSigner } from 'fast-jwt';
 import { checkModuleHealth } from './classes/HealthCheck';
-import { ConduitLogger } from './utilities/Logger';
+import { ConduitLogger, setupLoki } from './utilities/Logger';
 import winston from 'winston';
 import path from 'path';
-import LokiTransport from 'winston-loki';
 import { ConduitMetrics } from './metrics';
 
 export default class ConduitGrpcSdk {
@@ -102,21 +101,7 @@ export default class ConduitGrpcSdk {
         module_instance: this.instance,
       });
     }
-    if (process.env.LOKI_URL && process.env.LOKI_URL !== '') {
-      ConduitGrpcSdk.Logger.addTransport(
-        new LokiTransport({
-          level: 'debug',
-          host: process.env.LOKI_URL,
-          batching: false,
-          replaceTimestamp: true,
-          labels: {
-            module: this.name,
-            instance: this.instance,
-          },
-        }),
-      );
-    }
-
+    setupLoki(this.name, this.instance).then();
     this.serverUrl = serverUrl;
     this._watchModules = watchModules;
     this._serviceHealthStatusGetter = serviceHealthStatusGetter;
@@ -494,3 +479,4 @@ export * from './helpers';
 export * from './constants';
 export * from './routing';
 export * from './types';
+export * from './utilities';

--- a/libraries/grpc-sdk/src/utilities/Logger.ts
+++ b/libraries/grpc-sdk/src/utilities/Logger.ts
@@ -116,7 +116,7 @@ export class ConduitLogger {
 
 async function lokiReadyCheck(lokiUrl: string): Promise<void> {
   return new Promise((resolve, reject) => {
-    let data: any[] = [];
+    const data: any[] = [];
     get(`${lokiUrl}/ready`, r => {
       r.on('data', chunk => data.push(chunk));
       r.on('end', () => {

--- a/libraries/grpc-sdk/src/utilities/index.ts
+++ b/libraries/grpc-sdk/src/utilities/index.ts
@@ -1,3 +1,5 @@
+export * from './linearBackoffTimeout';
+
 export function sleep(ms: number) {
   return new Promise(resolve => {
     setTimeout(resolve, ms);

--- a/libraries/grpc-sdk/src/utilities/linearBackoffTimeout.ts
+++ b/libraries/grpc-sdk/src/utilities/linearBackoffTimeout.ts
@@ -1,8 +1,10 @@
-/*
+/**
  * Registers a timeout with linear backoff.
  * onFailure() only runs on rep exhaustion.
  * Timeout can be cleared through returned clear() or inside onTry().
  */
+import { clearTimeout } from 'timers';
+
 export function linearBackoffTimeout(
   onTry: (timeout: NodeJS.Timeout) => void,
   delay: number,
@@ -30,4 +32,28 @@ export function linearBackoffTimeout(
       }
     },
   };
+}
+
+/**
+ * Registers a timeout with linear backoff.
+ * onFailure() only runs on rep exhaustion.
+ * @param {() => Promise<boolean>} onTry - Async handler, returns 'continue' boolean flag
+ */
+export async function linearBackoffTimeoutAsync(
+  onTry: () => Promise<boolean>,
+  delay: number,
+  reps?: number,
+  onFailure?: () => void | Promise<void>,
+  startNow = false,
+) {
+  const nextRep = () => reps === undefined || --reps > 0;
+  const invoker = async () => {
+    delay = Math.floor(delay * 2);
+    if (delay > 0 && nextRep()) {
+      if (await onTry()) setTimeout(invoker, delay);
+    } else {
+      onFailure && (await onFailure());
+    }
+  };
+  setTimeout(invoker, startNow ? 0 : delay);
 }

--- a/modules/database/src/adapters/sequelize-adapter/index.ts
+++ b/modules/database/src/adapters/sequelize-adapter/index.ts
@@ -6,8 +6,8 @@ import ConduitGrpcSdk, {
   ConduitSchema,
   GrpcError,
   Indexable,
+  sleep,
 } from '@conduitplatform/grpc-sdk';
-import { sleep } from '@conduitplatform/grpc-sdk/dist/utilities';
 import { DatabaseAdapter } from '../DatabaseAdapter';
 import { validateSchema } from '../utils/validateSchema';
 import { sqlSchemaConverter } from '../../introspection/sequelize/utils';

--- a/packages/core/src/config-manager/service-discovery/index.ts
+++ b/packages/core/src/config-manager/service-discovery/index.ts
@@ -4,9 +4,9 @@ import ConduitGrpcSdk, {
   GrpcRequest,
   GrpcResponse,
   HealthCheckStatus,
+  linearBackoffTimeout,
 } from '@conduitplatform/grpc-sdk';
 import { IModuleConfig } from '../../interfaces/IModuleConfig';
-import { linearBackoffTimeout } from './utils';
 import { ServerWritableStream, status } from '@grpc/grpc-js';
 import { EventEmitter } from 'events';
 import { clearTimeout } from 'timers';


### PR DESCRIPTION
Loki is now only initialized as a logger transport after it becomes available and ready to serve.
Connection is attempted 15 times using linear backooff, with a starting delay of 250ms.
Failing that, no more checks are currently performed until module restart.

**What kind of change does this PR introduce?** <!--(check at least one)-->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other (please describe)

**Does this PR introduce a breaking change?** <!-- (check one) -->

- [ ] Yes
- [X] No

<!-- If yes, please describe the impact and migration path for existing applications. -->

**The PR fulfills these requirements:**

- [X] It's submitted to the `main` branch
- [ ] When resolving a specific issue, it's referenced in the PR's description  (e.g. `fix #xxx`, where "xxx" is the issue number)