### PR TITLE
feat(authentication): 2fa backup codes

### DIFF
--- a/modules/authentication/src/config/config.ts
+++ b/modules/authentication/src/config/config.ts
@@ -24,6 +24,12 @@ export default {
         default: true,
       },
     },
+    backUpCodes: {
+      enabled: {
+        format: 'Boolean',
+        default: true,
+      },
+    },
   },
   phoneAuthentication: {
     enabled: {

--- a/modules/authentication/src/handlers/twoFa.ts
+++ b/modules/authentication/src/handlers/twoFa.ts
@@ -426,7 +426,7 @@ export class TwoFa implements IAuthenticationStrategy {
     }
     const instance = await TwoFactorBackUpCodes.getInstance().findOne({ user: user._id });
     if (isNil(instance)) {
-      throw new GrpcError(status.NOT_FOUND, 'User has not activated back up codes');
+      throw new GrpcError(status.NOT_FOUND, 'User has no back up codes');
     }
     let codeMatch;
     for (const hashedCode of instance.codes) {

--- a/modules/authentication/src/handlers/twoFa.ts
+++ b/modules/authentication/src/handlers/twoFa.ts
@@ -414,12 +414,8 @@ export class TwoFa implements IAuthenticationStrategy {
   }
 
   async recoverTwoFa(call: ParsedRouterRequest): Promise<UnparsedRouterResponse> {
-    const context = call.request.context;
-    const { user, clientId } = context;
+    const { user, clientId } = call.request.context;
     const { code } = call.request.params;
-    if (isNil(context) || isNil(user)) {
-      throw new GrpcError(status.UNAUTHENTICATED, 'Unauthorized');
-    }
     const reg = /^\d{8}$/;
     if (!reg.test(code)) {
       throw new GrpcError(status.INVALID_ARGUMENT, 'Incorrect code format');

--- a/modules/authentication/src/handlers/twoFa.ts
+++ b/modules/authentication/src/handlers/twoFa.ts
@@ -544,8 +544,8 @@ export class TwoFa implements IAuthenticationStrategy {
   }
 
   private async codeGenerator(user: User): Promise<string[]> {
-    let codes = [];
-    let hashedCodes = [];
+    const codes = [];
+    const hashedCodes = [];
     for (let i = 0; i < 10; i++) {
       codes[i] = (randomInt(1000, 10000) + ' ' + randomInt(1000, 10000)).toString();
       hashedCodes[i] = await AuthUtils.hashPassword(codes[i]);

--- a/modules/authentication/src/models/TwoFactorBackUpCodes.schema.ts
+++ b/modules/authentication/src/models/TwoFactorBackUpCodes.schema.ts
@@ -1,0 +1,48 @@
+import { ConduitActiveSchema, DatabaseProvider, TYPE } from '@conduitplatform/grpc-sdk';
+import { User } from './User.schema';
+
+const schema = {
+  _id: TYPE.ObjectId,
+  user: {
+    type: TYPE.Relation,
+    model: 'User',
+    required: true,
+  },
+  codes: [TYPE.String],
+  createdAt: TYPE.Date,
+  updatedAt: TYPE.Date,
+};
+
+const modelOptions = {
+  timestamps: true,
+  conduit: {
+    permissions: {
+      extendable: true,
+      canCreate: false,
+      canModify: 'ExtensionOnly',
+      canDelete: false,
+    },
+  },
+} as const;
+const collectionName = undefined;
+
+export class TwoFactorBackUpCodes extends ConduitActiveSchema<TwoFactorBackUpCodes> {
+  private static _instance: TwoFactorBackUpCodes;
+  _id: string;
+  user: string | User;
+  codes: string[];
+  createdAt: Date;
+  updatedAt: Date;
+
+  constructor(database: DatabaseProvider) {
+    super(database, TwoFactorBackUpCodes.name, schema, modelOptions, collectionName);
+  }
+
+  static getInstance(database?: DatabaseProvider) {
+    if (TwoFactorBackUpCodes._instance) return TwoFactorBackUpCodes._instance;
+    if (!database) throw new Error('No database instance provided!');
+
+    TwoFactorBackUpCodes._instance = new TwoFactorBackUpCodes(database);
+    return TwoFactorBackUpCodes._instance;
+  }
+}

--- a/modules/authentication/src/models/index.ts
+++ b/modules/authentication/src/models/index.ts
@@ -4,3 +4,4 @@ export * from './Token.schema';
 export * from './User.schema';
 export * from './Service.schema';
 export * from './TwoFactorSecret.schema';
+export * from './TwoFactorBackUpCodes.schema';


### PR DESCRIPTION
This PR introduces the generation of back up codes for 2FA.
When authenticated, the user can create 10 one-time-use codes for access recovering, when 2FA isn't possible at that moment.
After being used, each code gets deleted, so the user has to generate more when only a few of them are left. 

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** <!--(check at least one)-->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other (please describe)

**Does this PR introduce a breaking change?** <!-- (check one) -->

- [ ] Yes
- [x] No

<!-- If yes, please describe the impact and migration path for existing applications. -->

**The PR fulfills these requirements:**

- [x] It's submitted to the `main` branch
- [ ] When resolving a specific issue, it's referenced in the PR's description  (e.g. `fix #xxx`, where "xxx" is the issue number)

