### PR TITLE
feat(grpc-sdk): support for early request termination in router

### DIFF
--- a/libraries/grpc-sdk/src/routing/wrapRouterFunctions.ts
+++ b/libraries/grpc-sdk/src/routing/wrapRouterFunctions.ts
@@ -70,8 +70,14 @@ function parseResponseData(
   callback: any,
   responded: { did: boolean },
 ) {
-  if (!r || responded.did) return;
+  if (responded.did) return;
   responded.did = true;
+  if (!r) {
+    callback({
+      code: status.INTERNAL,
+      message: 'Handler did not return a response',
+    });
+  }
   if (routerRequest) {
     if (typeof r === 'string') {
       callback(null, { result: r });

--- a/libraries/grpc-sdk/src/routing/wrapRouterFunctions.ts
+++ b/libraries/grpc-sdk/src/routing/wrapRouterFunctions.ts
@@ -133,8 +133,7 @@ export function wrapRouterGrpcFunction(
       });
     }
 
-    let responded = { did: false };
-
+    const responded = { did: false };
     fun(call, (r: any) => {
       parseResponseData(r, routerRequest, requestReceive, call, callback, responded);
     })


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/ConduitPlatform/Conduit/blob/main/.github/CONTRIBUTING.md#pull-request-guidelines
-->

This allows for router requests to be terminated before the promise resolves. This is useful if a function wants to continue processing some data, AFTER it successfully responded to the user. Previously this was not possible, but now it is.

It's able to use a hybrid of these solutions as well. You may respond using the callback depending on one condition, but if the condition is not satisfied you can respond with the promise resolution.

Also, if a handler does not return data either by callback or by the promise resolve, the wrapper will now throw an error towards the client, informing that no data was received from the handler.
<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** <!--(check at least one)-->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other (please describe)

**Does this PR introduce a breaking change?** <!-- (check one) -->

- [ ] Yes
- [x] No

<!-- If yes, please describe the impact and migration path for existing applications. -->

**The PR fulfills these requirements:**

- [x] It's submitted to the `main` branch
- [x] When resolving a specific issue, it's referenced in the PR's description  (e.g. `fix #xxx`, where "xxx" is the issue number)

If adding a **new feature**, the PR's description includes:

- [x] A convincing reason for adding this feature <!-- to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it -->

**Other information:**
