### PR TITLE
fix(database): remove throw on repetitive extension deletions

### DIFF
--- a/modules/database/src/adapters/DatabaseAdapter.ts
+++ b/modules/database/src/adapters/DatabaseAdapter.ts
@@ -286,14 +286,11 @@ export abstract class DatabaseAdapter<T extends Schema> {
     }
     validateExtensionFields(schema, extFields, extOwner);
     const extIndex = schema.extensions.findIndex(ext => ext.ownerModule === extOwner);
-    if (extIndex === -1) {
+    const extFieldsCount = Object.keys(extFields).length;
+    if (extIndex === -1 && extFieldsCount === 0) {
+      return Promise.resolve(schema as unknown as Schema); // @dirty-type-cast
+    } else if (extIndex === -1) {
       // Create Extension
-      if (Object.keys(extFields).length === 0) {
-        throw new GrpcError(
-          status.INVALID_ARGUMENT,
-          'Could not create schema extension with no custom fields',
-        );
-      }
       schema.extensions.push({
         fields: extFields,
         ownerModule: extOwner,
@@ -301,7 +298,7 @@ export abstract class DatabaseAdapter<T extends Schema> {
         updatedAt: new Date(), // TODO FORMAT
       });
     } else {
-      if (Object.keys(extFields).length === 0) {
+      if (extFieldsCount === 0) {
         // Remove Extension
         schema.extensions.splice(extIndex, 1);
       } else {


### PR DESCRIPTION
This PR makes it so that `setSchemaExtension()` with empty extension fields does not throw an error.
Previously repetitive extension updates (eg from `UI`) would throw an error unless frontend tracked when not to send an update request.

**What kind of change does this PR introduce?** <!--(check at least one)-->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other (please describe)

**Does this PR introduce a breaking change?** <!-- (check one) -->

- [ ] Yes
- [X] No

<!-- If yes, please describe the impact and migration path for existing applications. -->

**The PR fulfills these requirements:**

- [X] It's submitted to the `main` branch
- [ ] When resolving a specific issue, it's referenced in the PR's description  (e.g. `fix #xxx`, where "xxx" is the issue number)
