### PR TITLE
build: docker compose rename default mongodb db

### DIFF
--- a/docker/.env
+++ b/docker/.env
@@ -37,3 +37,6 @@ GRPC_KEY=""
 # Metrics & Logs
 PROMETHEUS_PORT="9090"
 LOKI_PORT="3100"
+
+# Miscallenous
+COMPOSE_PROJECT_NAME="conduit-cli"

--- a/docker/.env
+++ b/docker/.env
@@ -27,8 +27,8 @@ DB_TYPE="mongodb"
 DB_USER="conduit"
 DB_PASS="pass"
 DB_PORT="27017"
-DB_CONN_URI="mongodb://conduit:pass@conduit-mongo:27017"              # profile: mongodb
-#DB_CONN_URI="postgres://conduit:pass@conduit-postgres:5432/conduit"  # profile: postgres
+DB_CONN_URI="mongodb://conduit:pass@conduit-mongo:27017/conduit?authSource=admin"  # profile: mongodb
+#DB_CONN_URI="postgres://conduit:pass@conduit-postgres:5432/conduit"               # profile: postgres
 
 # Security
 CORE_MASTER_KEY="M4ST3RK3Y"

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -91,7 +91,7 @@ services:
       LOKI_URL: 'http://conduit-loki:3100'
       GRPC_KEY: '${GRPC_KEY}'
       DB_TYPE: '${DB_TYPE:-mongodb}'
-      DB_CONN_URI: '${DB_CONN_URI:-mongodb://conduit:pass@conduit-mongo:27017}'
+      DB_CONN_URI: '${DB_CONN_URI:-mongodb://conduit:pass@conduit-mongo:27017/conduit?authSource=admin}'
     networks:
       default:
         aliases:
@@ -332,6 +332,7 @@ services:
     ports:
       - '${DB_PORT:-27017}:27017'
     environment:
+      MONGO_INITDB_DATABASE: 'conduit'
       MONGO_INITDB_ROOT_USERNAME: '${DB_USER:-conduit}'
       MONGO_INITDB_ROOT_PASSWORD: '${DB_PASS:-pass}'
     profiles: ['mongodb']


### PR DESCRIPTION
This PR changes Docker compose's default MongoDB database name to `conduit` (previously `test`).

This is going to break persistent updates (once) across existing demo deployments (once), but seeing as we also have a persistent volume bug in `CLI` (new volume names across versions, [fix here](https://github.com/ConduitPlatform/CLI/pull/34)) and as the existing volumes or`test` dbs are unused, but not technically deleted, I figured it'd be worth doing this now.

We could also have upcoming CLI versions overwrite the previous behavior for older release tags, but it's probably not worth the effort as CLI deployments are demo-oriented.

**What kind of change does this PR introduce?** <!--(check at least one)-->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [X] Other (please describe)

**Does this PR introduce a breaking change?** <!-- (check one) -->

- [ ] Yes
- [X] No

<!-- If yes, please describe the impact and migration path for existing applications. -->

**The PR fulfills these requirements:**

- [X] It's submitted to the `main` branch
- [ ] When resolving a specific issue, it's referenced in the PR's description  (e.g. `fix #xxx`, where "xxx" is the issue number)
