### PR TITLE
feat(hermes,grpc-sdk): route field descriptions support

### DIFF
--- a/libraries/grpc-sdk/src/interfaces/Model.ts
+++ b/libraries/grpc-sdk/src/interfaces/Model.ts
@@ -78,7 +78,6 @@ export interface ConduitSchemaOptions {
 export interface SchemaFieldIndex {
   type?: MongoIndexType | PostgresIndexType;
   options?: MongoIndexOptions | PostgresIndexOptions;
-
   [field: string]: any;
 }
 
@@ -86,7 +85,6 @@ export interface ModelOptionsIndexes {
   fields: string[];
   types?: MongoIndexType[] | PostgresIndexType;
   options?: MongoIndexOptions | PostgresIndexOptions;
-
   [field: string]: any;
 }
 

--- a/libraries/grpc-sdk/src/interfaces/Model.ts
+++ b/libraries/grpc-sdk/src/interfaces/Model.ts
@@ -39,6 +39,7 @@ export interface ConduitModelField {
   unique?: boolean;
   select?: boolean;
   required?: boolean;
+  description?: string;
   systemRequired?: boolean;
   index?: SchemaFieldIndex;
 }
@@ -77,6 +78,7 @@ export interface ConduitSchemaOptions {
 export interface SchemaFieldIndex {
   type?: MongoIndexType | PostgresIndexType;
   options?: MongoIndexOptions | PostgresIndexOptions;
+
   [field: string]: any;
 }
 
@@ -84,6 +86,7 @@ export interface ModelOptionsIndexes {
   fields: string[];
   types?: MongoIndexType[] | PostgresIndexType;
   options?: MongoIndexOptions | PostgresIndexOptions;
+
   [field: string]: any;
 }
 

--- a/libraries/hermes/src/GraphQl/GraphQlParser.ts
+++ b/libraries/hermes/src/GraphQl/GraphQlParser.ts
@@ -109,11 +109,13 @@ export class GraphQlParser extends ConduitParser<ParseResult, ProcessingObject> 
     value: string | ConduitModel | ConduitRouteOption,
     isRequired: boolean = false,
     isArray: boolean,
+    description?: string,
   ): void {
     // object of some kind
     const nestedName = this.constructName(name, fieldName);
     this.constructResolver(name, fieldName);
     processingObject.typeString +=
+      (description ? `""" ${description} """ ` : '') +
       fieldName +
       ': ' +
       `${isArray ? '[' : ''}` +
@@ -130,10 +132,12 @@ export class GraphQlParser extends ConduitParser<ParseResult, ProcessingObject> 
     value: any[],
     isRequired: boolean = false,
     nestedType?: boolean,
+    description?: string,
   ): void {
     const arrayProcessing = super.arrayHandler(resolverName, name, value);
     if (nestedType) {
       processingObject.typeString +=
+        `""" ${description} """ ` +
         arrayProcessing.typeString.slice(0, arrayProcessing.typeString.length - 1) +
         (isRequired ? '!' : '') +
         ' ';

--- a/libraries/hermes/src/GraphQl/GraphQlParser.ts
+++ b/libraries/hermes/src/GraphQl/GraphQlParser.ts
@@ -82,6 +82,7 @@ export class GraphQlParser extends ConduitParser<ParseResult, ProcessingObject> 
     isRequired: boolean,
     isArray: boolean,
     parentField: string,
+    description?: string,
   ): void {
     if (!isArray && name === parentField) {
       const typeFields = TypeRegistry.getInstance().getType(value);
@@ -96,6 +97,7 @@ export class GraphQlParser extends ConduitParser<ParseResult, ProcessingObject> 
       }
     } else {
       processingObject.typeString +=
+        (description ? `""" ${description} """ ` : '') +
         `${name}: ${isArray ? '[' : ''}` +
         this.getType(value) +
         `${isArray ? `${isRequired ? '!' : ''}]` : ''} `;

--- a/libraries/hermes/src/Rest/Swagger.ts
+++ b/libraries/hermes/src/Rest/Swagger.ts
@@ -85,6 +85,8 @@ export class SwaggerGenerator {
           in: 'path',
           required: true,
           schema: this._parser.extractTypes('url', route.input.urlParams, true),
+          //@ts-ignore
+          description: route.input.urlParams[name].description,
         });
       }
     }
@@ -98,6 +100,8 @@ export class SwaggerGenerator {
           name,
           in: 'query',
           schema: this._parser.extractTypes('query', route.input.queryParams, true),
+          //@ts-ignore
+          description: route.input.queryParams[name].description,
         });
       }
     }

--- a/libraries/hermes/src/Rest/SwaggerParser.ts
+++ b/libraries/hermes/src/Rest/SwaggerParser.ts
@@ -158,10 +158,12 @@ export class SwaggerParser extends ConduitParser<ParseResult, ProcessingObject> 
     value: any[],
     isRequired: boolean = false,
     nestedType?: boolean,
+    description?: string,
   ): void {
     // @ts-ignore
     processingObject.properties[name] = {
       type: 'array',
+      description: description,
       // @ts-ignore
       items: super.arrayHandler(resolverName, name, value).properties[name],
     };

--- a/libraries/hermes/src/Rest/SwaggerParser.ts
+++ b/libraries/hermes/src/Rest/SwaggerParser.ts
@@ -141,13 +141,14 @@ export class SwaggerParser extends ConduitParser<ParseResult, ProcessingObject> 
         type: 'string',
         description: description,
       };
+    } else {
       // @ts-ignore
       processingObject.properties[fieldName] = {
         type: 'object',
         properties: this.extractTypes(name, value, this.isInput).properties,
       };
-      this.addFieldToRequired(processingObject, fieldName, isRequired);
     }
+    this.addFieldToRequired(processingObject, fieldName, isRequired);
   }
 
   protected getResultFromArray(

--- a/libraries/hermes/src/Rest/SwaggerParser.ts
+++ b/libraries/hermes/src/Rest/SwaggerParser.ts
@@ -109,6 +109,7 @@ export class SwaggerParser extends ConduitParser<ParseResult, ProcessingObject> 
     isRequired: boolean = false,
     isArray: boolean,
     parentField: string,
+    description?: string,
   ): void {
     if (!isArray && (name === value || name === parentField)) {
       Object.keys(processingObject).forEach(field => {
@@ -122,6 +123,9 @@ export class SwaggerParser extends ConduitParser<ParseResult, ProcessingObject> 
       }
       // @ts-ignore
       processingObject.properties[name] = this.getType(value);
+      if (description)
+        // @ts-ignore
+        processingObject.properties[name].description = description;
     }
     this.addFieldToRequired(processingObject, name, isRequired);
   }

--- a/libraries/hermes/src/Rest/SwaggerParser.ts
+++ b/libraries/hermes/src/Rest/SwaggerParser.ts
@@ -133,13 +133,21 @@ export class SwaggerParser extends ConduitParser<ParseResult, ProcessingObject> 
     value: any,
     isRequired: boolean = false,
     isArray: boolean,
+    description?: string,
   ): void {
-    // @ts-ignore
-    processingObject.properties[fieldName] = {
-      type: 'object',
-      properties: this.extractTypes(name, value, this.isInput).properties,
-    };
-    this.addFieldToRequired(processingObject, fieldName, isRequired);
+    if (description && name === 'body') {
+      // @ts-ignore
+      processingObject.properties[fieldName] = {
+        type: 'string',
+        description: description,
+      };
+      // @ts-ignore
+      processingObject.properties[fieldName] = {
+        type: 'object',
+        properties: this.extractTypes(name, value, this.isInput).properties,
+      };
+      this.addFieldToRequired(processingObject, fieldName, isRequired);
+    }
   }
 
   protected getResultFromArray(

--- a/libraries/hermes/src/Rest/SwaggerParser.ts
+++ b/libraries/hermes/src/Rest/SwaggerParser.ts
@@ -139,7 +139,7 @@ export class SwaggerParser extends ConduitParser<ParseResult, ProcessingObject> 
       // @ts-ignore
       processingObject.properties[fieldName] = {
         type: 'string',
-        description: description,
+        description,
       };
     } else {
       // @ts-ignore
@@ -163,7 +163,7 @@ export class SwaggerParser extends ConduitParser<ParseResult, ProcessingObject> 
     // @ts-ignore
     processingObject.properties[name] = {
       type: 'array',
-      description: description,
+      description,
       // @ts-ignore
       items: super.arrayHandler(resolverName, name, value).properties[name],
     };

--- a/libraries/hermes/src/classes/ConduitParser.ts
+++ b/libraries/hermes/src/classes/ConduitParser.ts
@@ -54,6 +54,7 @@ export abstract class ConduitParser<ParseResult, ProcessingObject> {
     value: any,
     isRequired: boolean,
     isArray: boolean,
+    description?: string,
   ): void;
 
   protected abstract getResultFromArray(

--- a/libraries/hermes/src/classes/ConduitParser.ts
+++ b/libraries/hermes/src/classes/ConduitParser.ts
@@ -45,6 +45,7 @@ export abstract class ConduitParser<ParseResult, ProcessingObject> {
     isRequired: boolean,
     isArray: boolean,
     parentField: string,
+    description?: string,
   ): void;
 
   protected abstract getResultFromObject(
@@ -102,6 +103,7 @@ export abstract class ConduitParser<ParseResult, ProcessingObject> {
             false,
             false,
             name,
+            (fields[field] as ConduitModelField).description!,
           );
         }
         // if field is an array
@@ -135,6 +137,7 @@ export abstract class ConduitParser<ParseResult, ProcessingObject> {
                   (fields[field] as ConduitModelField).required!,
                   false,
                   name,
+                  (fields[field] as ConduitModelField).description!,
                 );
               }
             }
@@ -168,6 +171,7 @@ export abstract class ConduitParser<ParseResult, ProcessingObject> {
               fields[field] as ConduitModelField,
               false,
               false,
+              (fields[field] as ConduitModelField).description!,
             );
           }
         }

--- a/libraries/hermes/src/classes/ConduitParser.ts
+++ b/libraries/hermes/src/classes/ConduitParser.ts
@@ -155,6 +155,7 @@ export abstract class ConduitParser<ParseResult, ProcessingObject> {
                 (fields[field] as ConduitModelField).type,
                 (fields[field] as ConduitModelField).required!,
                 false,
+                (fields[field] as ConduitModelField).description!,
               );
             }
           } else {

--- a/libraries/hermes/src/classes/ConduitParser.ts
+++ b/libraries/hermes/src/classes/ConduitParser.ts
@@ -64,6 +64,7 @@ export abstract class ConduitParser<ParseResult, ProcessingObject> {
     value: any[],
     isRequired: boolean,
     nestedType?: boolean,
+    description?: string,
   ): void;
 
   protected abstract getResultFromRelation(
@@ -146,6 +147,7 @@ export abstract class ConduitParser<ParseResult, ProcessingObject> {
                 (fields[field] as ConduitModelField).type as Array,
                 (fields[field] as ConduitModelField).required!,
                 true,
+                (fields[field] as ConduitModelField).description,
               );
             } else {
               this.getResultFromObject(

--- a/modules/authentication/src/admin/index.ts
+++ b/modules/authentication/src/admin/index.ts
@@ -36,7 +36,10 @@ export class AdminHandlers {
         action: ConduitRouteActions.GET,
         description: `Returns queried users and their total count.`,
         queryParams: {
-          skip: ConduitNumber.Optional,
+          skip: {
+            type: ConduitNumber.Optional,
+            description: 'Used for pagination',
+          },
           limit: ConduitNumber.Optional,
           sort: ConduitString.Optional,
           search: ConduitString.Optional,
@@ -56,7 +59,10 @@ export class AdminHandlers {
         action: ConduitRouteActions.POST,
         description: `Creates a new user using email/password.`,
         bodyParams: {
-          email: ConduitString.Required,
+          email: {
+            type: ConduitString.Required,
+            description: 'User email',
+          },
           password: ConduitString.Required,
         },
       },

--- a/modules/authentication/src/admin/index.ts
+++ b/modules/authentication/src/admin/index.ts
@@ -36,10 +36,7 @@ export class AdminHandlers {
         action: ConduitRouteActions.GET,
         description: `Returns queried users and their total count.`,
         queryParams: {
-          skip: {
-            type: ConduitNumber.Optional,
-            description: 'Used for pagination',
-          },
+          skip: ConduitNumber.Optional,
           limit: ConduitNumber.Optional,
           sort: ConduitString.Optional,
           search: ConduitString.Optional,
@@ -61,7 +58,6 @@ export class AdminHandlers {
         bodyParams: {
           email: {
             type: ConduitString.Required,
-            description: 'User email',
           },
           password: ConduitString.Required,
         },

--- a/modules/authentication/src/admin/index.ts
+++ b/modules/authentication/src/admin/index.ts
@@ -56,9 +56,7 @@ export class AdminHandlers {
         action: ConduitRouteActions.POST,
         description: `Creates a new user using email/password.`,
         bodyParams: {
-          email: {
-            type: ConduitString.Required,
-          },
+          email: ConduitString.Required,
           password: ConduitString.Required,
         },
       },


### PR DESCRIPTION
Conduit did not support description in route parameters.
Now , both GraphQL and Swagger parsers in hermes library support it.
Also field descriptions inside route responses supported.

**What kind of change does this PR introduce?** <!--(check at least one)-->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other (please describe)

**Does this PR introduce a breaking change?** <!-- (check one) -->

- [ ] Yes
- [x] No

<!-- If yes, please describe the impact and migration path for existing applications. -->

**The PR fulfills these requirements:**

- [x] It's submitted to the `main` branch
- [ ] When resolving a specific issue, it's referenced in the PR's description  (e.g. `fix #xxx`, where "xxx" is the issue number)
