### PR TITLE
fix(database): body params getting in GET requests

### DIFF
--- a/modules/database/src/admin/customEndpoints/customEndpoints.admin.ts
+++ b/modules/database/src/admin/customEndpoints/customEndpoints.admin.ts
@@ -97,7 +97,7 @@ export class CustomEndpointsAdmin {
     if (error !== true) {
       throw new GrpcError(status.INVALID_ARGUMENT, error as string);
     }
-    error = inputValidation(inputs);
+    error = inputValidation(operation, inputs);
     if (error !== true) {
       throw new GrpcError(status.INVALID_ARGUMENT, error as string);
     }

--- a/modules/database/src/admin/customEndpoints/utils.ts
+++ b/modules/database/src/admin/customEndpoints/utils.ts
@@ -156,11 +156,14 @@ function _inputValidation(
   }
 
   if (location === 2 && isArray) {
-    return 'Url params cant have an array input';
+    return "Url params can't have an array input";
   }
 
-  if (operation === OperationsEnum.GET && location === 0) {
-    return 'GET requests can not have body parameters';
+  if (
+    (operation === OperationsEnum.GET || operation === OperationsEnum.DELETE) &&
+    location === 0
+  ) {
+    return 'GET or DELETE requests can not have body parameters';
   }
 
   return true;

--- a/modules/database/src/admin/customEndpoints/utils.ts
+++ b/modules/database/src/admin/customEndpoints/utils.ts
@@ -131,6 +131,7 @@ function _queryValidation(
  * }
  */
 function _inputValidation(
+  operation: number,
   name: string,
   type: any,
   location: number,
@@ -158,17 +159,31 @@ function _inputValidation(
     return 'Url params cant have an array input';
   }
 
+  if (operation === OperationsEnum.GET && location === 0) {
+    return 'GET requests can not have body parameters';
+  }
+
   return true;
 }
 
-export function inputValidation(inputs?: Indexable | null): boolean | string {
+export function inputValidation(
+  operation: number,
+  inputs?: Indexable | null,
+): boolean | string {
   if (!isNil(inputs) && inputs.length) {
-    inputs.forEach((r: Indexable) => {
-      const error = _inputValidation(r.name, r.type, r.location, r.array);
+    for (const r of Object.keys(inputs)) {
+      const input = inputs[r];
+      const error = _inputValidation(
+        operation,
+        input.name,
+        input.type,
+        input.location,
+        input.array,
+      );
       if (error !== true) {
         return error as string;
       }
-    });
+    }
   }
   return true;
 }


### PR DESCRIPTION
Custom GET endpoints can not have body parameters.
Before this fix , body parameters could be given to a custom GET endpoint.
So, this fix checks if body parameters have been given to a custom GET request.

**What kind of change does this PR introduce?** <!--(check at least one)-->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other (please describe)

**Does this PR introduce a breaking change?** <!-- (check one) -->

- [ ] Yes
- [x] No

<!-- If yes, please describe the impact and migration path for existing applications. -->

**The PR fulfills these requirements:**

- [x] It's submitted to the `main` branch
- [ ] When resolving a specific issue, it's referenced in the PR's description  (e.g. `fix #xxx`, where "xxx" is the issue number)
