### PR TITLE
feat(database,grpc-sdk): raw query support

### DIFF
--- a/libraries/grpc-sdk/src/interfaces/RawQuery.ts
+++ b/libraries/grpc-sdk/src/interfaces/RawQuery.ts
@@ -1,0 +1,24 @@
+export interface RawQuery {
+  mongoQuery?: RawMongoQuery;
+  sqlQuery?: RawSQLQuery;
+}
+
+export type RawMongoQuery = {
+  aggregate?: object[];
+  count?: object;
+  deleteOne?: object;
+  deleteMany?: object | object[];
+  drop?: object;
+  explain?: object;
+  find?: object;
+  insertOne?: object;
+  insertMany?: object | object[];
+  updateOne?: object;
+  updateMany?: object | object[];
+  options?: object;
+};
+
+export type RawSQLQuery = {
+  query: string;
+  options?: object;
+};

--- a/libraries/grpc-sdk/src/interfaces/index.ts
+++ b/libraries/grpc-sdk/src/interfaces/index.ts
@@ -3,3 +3,4 @@ export * from './ConduitService';
 export * from './Model';
 export * from './GrpcCallback';
 export * from './Indexable';
+export * from './RawQuery';

--- a/libraries/grpc-sdk/src/modules/database/index.ts
+++ b/libraries/grpc-sdk/src/modules/database/index.ts
@@ -6,7 +6,7 @@ import {
   Schema,
 } from '../../protoUtils/database';
 import { ConduitSchemaExtension } from '../../interfaces';
-import { Query } from '../../types/db';
+import { Query, RawQuery } from '../../types/db';
 
 export class DatabaseProvider extends ConduitModule<typeof DatabaseProviderDefinition> {
   constructor(private readonly moduleName: string, url: string, grpcToken?: string) {
@@ -238,6 +238,22 @@ export class DatabaseProvider extends ConduitModule<typeof DatabaseProviderDefin
       schemaName,
       query: this.processQuery(query),
     }).then(res => {
+      return JSON.parse(res.result);
+    });
+  }
+
+  rawQuery(schemaName: string, query: RawQuery) {
+    const processed = {
+      mongoQuery: {
+        query: query.rawMongoQuery?.query,
+        queryBody: JSON.stringify(query.rawMongoQuery?.queryBody),
+      },
+      sqlQuery: {
+        query: query.rawSqlQuery?.query,
+        options: JSON.stringify(query.rawSqlQuery?.options),
+      },
+    };
+    return this.client!.rawQuery({ schemaName, query: processed }).then(res => {
       return JSON.parse(res.result);
     });
   }

--- a/libraries/grpc-sdk/src/modules/database/index.ts
+++ b/libraries/grpc-sdk/src/modules/database/index.ts
@@ -243,16 +243,15 @@ export class DatabaseProvider extends ConduitModule<typeof DatabaseProviderDefin
   }
 
   rawQuery(schemaName: string, query: RawQuery) {
-    const processed = {
-      mongoQuery: {
-        query: query.rawMongoQuery?.query,
-        queryBody: JSON.stringify(query.rawMongoQuery?.queryBody),
-      },
-      sqlQuery: {
-        query: query.rawSqlQuery?.query,
-        options: JSON.stringify(query.rawSqlQuery?.options),
-      },
-    };
+    const processed: any = query;
+    if (query.mongoQuery) {
+      for (const key of Object.keys(query.mongoQuery)) {
+        processed.mongoQuery[key] = JSON.stringify(processed.mongoQuery[key]);
+      }
+    }
+    if (query.sqlQuery?.options) {
+      processed.sqlQuery.options = JSON.stringify(processed.sqlQuery.options);
+    }
     return this.client!.rawQuery({ schemaName, query: processed }).then(res => {
       return JSON.parse(res.result);
     });

--- a/libraries/grpc-sdk/src/modules/database/index.ts
+++ b/libraries/grpc-sdk/src/modules/database/index.ts
@@ -5,8 +5,8 @@ import {
   DropCollectionResponse,
   Schema,
 } from '../../protoUtils/database';
-import { ConduitSchemaExtension } from '../../interfaces';
-import { Query, RawQuery } from '../../types/db';
+import { ConduitSchemaExtension, RawQuery } from '../../interfaces';
+import { Query } from '../../types/db';
 
 export class DatabaseProvider extends ConduitModule<typeof DatabaseProviderDefinition> {
   constructor(private readonly moduleName: string, url: string, grpcToken?: string) {

--- a/libraries/grpc-sdk/src/types/db.ts
+++ b/libraries/grpc-sdk/src/types/db.ts
@@ -31,28 +31,3 @@ export type Query<T> =
   | setQuery<T>
   // | arrayQuery<T>
   | conditionalQuery<T>;
-
-export interface RawQuery {
-  mongoQuery?: RawMongoQuery;
-  sqlQuery?: RawSQLQuery;
-}
-
-export type RawMongoQuery = {
-  aggregate?: object[];
-  count?: object;
-  deleteOne?: object;
-  deleteMany?: object | object[];
-  drop?: object;
-  explain?: object;
-  find?: object;
-  insertOne?: object;
-  insertMany?: object | object[];
-  updateOne?: object;
-  updateMany?: object | object[];
-  options?: object;
-};
-
-export type RawSQLQuery = {
-  query: string;
-  options?: object;
-};

--- a/libraries/grpc-sdk/src/types/db.ts
+++ b/libraries/grpc-sdk/src/types/db.ts
@@ -33,30 +33,26 @@ export type Query<T> =
   | conditionalQuery<T>;
 
 export interface RawQuery {
-  rawMongoQuery?: RawMongoQuery;
-  rawSqlQuery?: RawSQLQuery;
+  mongoQuery?: RawMongoQuery;
+  sqlQuery?: RawSQLQuery;
 }
 
 export type RawMongoQuery = {
-  query: MongoQueryOperations;
-  queryBody: object | object[];
+  aggregate?: object[];
+  count?: object;
+  deleteOne?: object;
+  deleteMany?: object | object[];
+  drop?: object;
+  explain?: object;
+  find?: object;
+  insertOne?: object;
+  insertMany?: object | object[];
+  updateOne?: object;
+  updateMany?: object | object[];
+  options?: object;
 };
 
 export type RawSQLQuery = {
   query: string;
   options?: object;
 };
-
-export type MongoQueryOperations =
-  | 'aggregate'
-  | 'count'
-  | 'deleteOne'
-  | 'deleteMany'
-  | 'distinct'
-  | 'drop'
-  | 'explain'
-  | 'find'
-  | 'insertOne'
-  | 'insertMany'
-  | 'updateOne'
-  | 'updateMany';

--- a/libraries/grpc-sdk/src/types/db.ts
+++ b/libraries/grpc-sdk/src/types/db.ts
@@ -31,3 +31,32 @@ export type Query<T> =
   | setQuery<T>
   // | arrayQuery<T>
   | conditionalQuery<T>;
+
+export interface RawQuery {
+  rawMongoQuery?: RawMongoQuery;
+  rawSqlQuery?: RawSQLQuery;
+}
+
+export type RawMongoQuery = {
+  query: MongoQueryOperations;
+  queryBody: object | object[];
+};
+
+export type RawSQLQuery = {
+  query: string;
+  options?: object;
+};
+
+export type MongoQueryOperations =
+  | 'aggregate'
+  | 'count'
+  | 'deleteOne'
+  | 'deleteMany'
+  | 'distinct'
+  | 'drop'
+  | 'explain'
+  | 'find'
+  | 'insertOne'
+  | 'insertMany'
+  | 'updateOne'
+  | 'updateMany';

--- a/modules/database/src/Database.ts
+++ b/modules/database/src/Database.ts
@@ -584,7 +584,7 @@ export default class DatabaseModule extends ManagedModule<void> {
       if (dbType === 'MongoDB') {
         const processed: any = query!.mongoQuery!;
         for (const key of Object.keys(query!.mongoQuery!)) {
-          if (key[0] === '_') {
+          if (key === 'operation' || key[0] === '_') {
             delete processed[key];
             continue;
           }

--- a/modules/database/src/Database.ts
+++ b/modules/database/src/Database.ts
@@ -561,23 +561,14 @@ export default class DatabaseModule extends ManagedModule<void> {
   ) {
     const { schemaName, query } = call.request;
     const dbType = this._activeAdapter.getDatabaseType();
-    const schemaAdapter = this._activeAdapter.getSchemaModel(schemaName);
-    const moduleName = call.metadata!.get('module-name')![0] as string;
-    if (
-      !(await canCreate(moduleName, schemaAdapter.model)) ||
-      !(await canModify(moduleName, schemaAdapter.model)) ||
-      !(await canDelete(moduleName, schemaAdapter.model))
-    ) {
-      return callback({
-        code: status.PERMISSION_DENIED,
-        message: `Module ${moduleName} is not authorized to raw query ${schemaName}!`,
-      });
-    }
     if (
       (dbType === 'MongoDB' && isNil(query?.mongoQuery)) ||
       (dbType === 'PostgreSQL' && isNil(query?.sqlQuery))
     ) {
-      callback({ code: status.INVALID_ARGUMENT, message: 'Invalid query format' });
+      callback({
+        code: status.INVALID_ARGUMENT,
+        message: `Invalid raw query format for ${dbType}`,
+      });
     }
     try {
       let result;

--- a/modules/database/src/adapters/DatabaseAdapter.ts
+++ b/modules/database/src/adapters/DatabaseAdapter.ts
@@ -9,6 +9,7 @@ import { stitchSchema, validateExtensionFields } from './utils/extensions';
 import { status } from '@grpc/grpc-js';
 import { isNil } from 'lodash';
 import ObjectHash from 'object-hash';
+import { RawMongoQuery, RawSQLQuery } from '@conduitplatform/grpc-sdk/src/types/db';
 
 export abstract class DatabaseAdapter<T extends Schema> {
   protected readonly maxConnTimeoutMs: number;
@@ -179,6 +180,11 @@ export abstract class DatabaseAdapter<T extends Schema> {
   abstract getIndexes(schemaName: string): Promise<ModelOptionsIndexes[]>;
 
   abstract deleteIndexes(schemaName: string, indexNames: string[]): Promise<string>;
+
+  abstract execRawQuery(
+    schemaName: string,
+    rawQuery: RawMongoQuery | RawSQLQuery,
+  ): Promise<any>;
 
   fixDatabaseSchemaOwnership(schema: ConduitSchema) {
     const dbSchemas = ['CustomEndpoints', '_PendingSchemas'];

--- a/modules/database/src/adapters/DatabaseAdapter.ts
+++ b/modules/database/src/adapters/DatabaseAdapter.ts
@@ -3,13 +3,14 @@ import ConduitGrpcSdk, {
   ConduitSchema,
   GrpcError,
   ModelOptionsIndexes,
+  RawMongoQuery,
+  RawSQLQuery,
 } from '@conduitplatform/grpc-sdk';
 import { Schema, _ConduitSchema, ConduitDatabaseSchema } from '../interfaces';
 import { stitchSchema, validateExtensionFields } from './utils/extensions';
 import { status } from '@grpc/grpc-js';
 import { isNil } from 'lodash';
 import ObjectHash from 'object-hash';
-import { RawMongoQuery, RawSQLQuery } from '@conduitplatform/grpc-sdk/src/types/db';
 
 export abstract class DatabaseAdapter<T extends Schema> {
   protected readonly maxConnTimeoutMs: number;

--- a/modules/database/src/adapters/mongoose-adapter/index.ts
+++ b/modules/database/src/adapters/mongoose-adapter/index.ts
@@ -7,6 +7,7 @@ import ConduitGrpcSdk, {
   Indexable,
   ModelOptionsIndexes,
   MongoIndexType,
+  RawMongoQuery,
 } from '@conduitplatform/grpc-sdk';
 import { DatabaseAdapter } from '../DatabaseAdapter';
 import { validateSchema } from '../utils/validateSchema';
@@ -15,7 +16,6 @@ import { mongoSchemaConverter } from '../../introspection/mongoose/utils';
 import { status } from '@grpc/grpc-js';
 import { checkIfMongoOptions } from './utils';
 import { ConduitDatabaseSchema } from '../../interfaces';
-import { RawMongoQuery } from '@conduitplatform/grpc-sdk/src/types/db';
 
 const parseSchema = require('mongodb-schema');
 let deepPopulate = require('mongoose-deep-populate');
@@ -368,7 +368,9 @@ export class MongooseAdapter extends DatabaseAdapter<MongooseSchema> {
     const collection = this.models[schemaName].model.collection;
     let result;
     try {
-      const queryOperation = Object.keys(rawQuery)[0];
+      const queryOperation = Object.keys(rawQuery).filter(v => {
+        if (v !== 'options') return v;
+      })[0];
       // @ts-ignore
       result = await collection[queryOperation](
         rawQuery[queryOperation as keyof RawMongoQuery],

--- a/modules/database/src/adapters/mongoose-adapter/index.ts
+++ b/modules/database/src/adapters/mongoose-adapter/index.ts
@@ -1,4 +1,4 @@
-import { Collection, ConnectOptions, IndexOptions, Mongoose } from 'mongoose';
+import { ConnectOptions, IndexOptions, Mongoose } from 'mongoose';
 import { MongooseSchema } from './MongooseSchema';
 import { schemaConverter } from './SchemaConverter';
 import ConduitGrpcSdk, {
@@ -16,7 +16,6 @@ import { status } from '@grpc/grpc-js';
 import { checkIfMongoOptions } from './utils';
 import { ConduitDatabaseSchema } from '../../interfaces';
 import { RawMongoQuery } from '@conduitplatform/grpc-sdk/src/types/db';
-import { isNil } from 'lodash';
 
 const parseSchema = require('mongodb-schema');
 let deepPopulate = require('mongoose-deep-populate');

--- a/modules/database/src/adapters/mongoose-adapter/index.ts
+++ b/modules/database/src/adapters/mongoose-adapter/index.ts
@@ -368,8 +368,12 @@ export class MongooseAdapter extends DatabaseAdapter<MongooseSchema> {
     const collection = this.models[schemaName].model.collection;
     let result;
     try {
+      const queryOperation = Object.keys(rawQuery)[0];
       // @ts-ignore
-      result = await collection[rawQuery.query](JSON.parse(rawQuery.queryBody));
+      result = await collection[queryOperation](
+        rawQuery[queryOperation as keyof RawMongoQuery],
+        rawQuery.options,
+      );
     } catch (e: any) {
       throw new GrpcError(status.INTERNAL, e.message);
     }

--- a/modules/database/src/adapters/sequelize-adapter/index.ts
+++ b/modules/database/src/adapters/sequelize-adapter/index.ts
@@ -19,6 +19,7 @@ import { SequelizeAuto } from 'sequelize-auto';
 import { isNil } from 'lodash';
 import { checkIfPostgresOptions } from './utils';
 import { ConduitDatabaseSchema } from '../../interfaces';
+import { RawSQLQuery } from '@conduitplatform/grpc-sdk/src/types/db';
 
 const sqlSchemaName = process.env.SQL_SCHEMA ?? 'public';
 
@@ -364,6 +365,14 @@ export class SequelizeAdapter extends DatabaseAdapter<SequelizeSchema> {
       });
     }
     return 'Indexes deleted';
+  }
+
+  async execRawQuery(schemaName: string, rawQuery: RawSQLQuery): Promise<any> {
+    return await this.sequelize
+      .query(rawQuery.query, rawQuery.options)
+      .catch((e: Error) => {
+        throw new GrpcError(status.INTERNAL, e.message);
+      });
   }
 
   private checkAndConvertIndexes(

--- a/modules/database/src/adapters/sequelize-adapter/index.ts
+++ b/modules/database/src/adapters/sequelize-adapter/index.ts
@@ -9,6 +9,7 @@ import ConduitGrpcSdk, {
   ModelOptionsIndexes,
   PostgresIndexOptions,
   PostgresIndexType,
+  RawSQLQuery,
   sleep,
 } from '@conduitplatform/grpc-sdk';
 import { DatabaseAdapter } from '../DatabaseAdapter';
@@ -19,7 +20,6 @@ import { SequelizeAuto } from 'sequelize-auto';
 import { isNil } from 'lodash';
 import { checkIfPostgresOptions } from './utils';
 import { ConduitDatabaseSchema } from '../../interfaces';
-import { RawSQLQuery } from '@conduitplatform/grpc-sdk/src/types/db';
 
 const sqlSchemaName = process.env.SQL_SCHEMA ?? 'public';
 

--- a/modules/database/src/database.proto
+++ b/modules/database/src/database.proto
@@ -62,6 +62,26 @@ message QueryRequest {
     string query = 2;
 }
 
+message CombinedRawQueryRequest {
+    string schemaName = 1;
+    rawQuery query = 2;
+}
+
+message rawQuery {
+    optional rawMongoQuery mongoQuery = 1;
+    optional rawSQLQuery sqlQuery = 2;
+};
+
+message rawMongoQuery {
+    string query = 1;
+    string queryBody = 2;
+}
+
+message rawSQLQuery {
+    string query = 1;
+    optional string options = 2;
+}
+
 message UpdateRequest {
     string schemaName = 1;
     string id = 2;
@@ -98,4 +118,5 @@ service DatabaseProvider {
     rpc findByIdAndUpdate(UpdateRequest) returns (QueryResponse);
     rpc updateMany(UpdateManyRequest) returns (QueryResponse);
     rpc countDocuments(QueryRequest) returns (QueryResponse);
+    rpc rawQuery(CombinedRawQueryRequest) returns (QueryResponse);
 }

--- a/modules/database/src/database.proto
+++ b/modules/database/src/database.proto
@@ -65,17 +65,19 @@ message QueryRequest {
 message RawQueryRequest {
     message RawQuery {
         message MongoQuery {
-            optional string aggregate = 1;
-            optional string count = 2;
-            optional string deleteOne = 3;
-            optional string deleteMany = 4;
-            optional string drop = 5;
-            optional string explain = 6;
-            optional string find = 7;
-            optional string insertOne = 8;
-            optional string insertMany = 9;
-            optional string updateOne = 10;
-            optional string updateMany = 11;
+            oneof operation {
+                string aggregate = 1;
+                string count = 2;
+                string deleteOne = 3;
+                string deleteMany = 4;
+                string drop = 5;
+                string explain = 6;
+                string find = 7;
+                string insertOne = 8;
+                string insertMany = 9;
+                string updateOne = 10;
+                string updateMany = 11;
+            }
             optional string options = 12;
         }
         message SQLQuery {

--- a/modules/database/src/database.proto
+++ b/modules/database/src/database.proto
@@ -62,24 +62,31 @@ message QueryRequest {
     string query = 2;
 }
 
-message CombinedRawQueryRequest {
+message RawQueryRequest {
+    message RawQuery {
+        message MongoQuery {
+            optional string aggregate = 1;
+            optional string count = 2;
+            optional string deleteOne = 3;
+            optional string deleteMany = 4;
+            optional string drop = 5;
+            optional string explain = 6;
+            optional string find = 7;
+            optional string insertOne = 8;
+            optional string insertMany = 9;
+            optional string updateOne = 10;
+            optional string updateMany = 11;
+            optional string options = 12;
+        }
+        message SQLQuery {
+            string query = 1;
+            optional string options = 2;
+        };
+        optional MongoQuery mongoQuery = 1;
+        optional SQLQuery sqlQuery = 2;
+    };
     string schemaName = 1;
-    rawQuery query = 2;
-}
-
-message rawQuery {
-    optional rawMongoQuery mongoQuery = 1;
-    optional rawSQLQuery sqlQuery = 2;
-};
-
-message rawMongoQuery {
-    string query = 1;
-    string queryBody = 2;
-}
-
-message rawSQLQuery {
-    string query = 1;
-    optional string options = 2;
+    RawQuery query = 2;
 }
 
 message UpdateRequest {
@@ -118,5 +125,5 @@ service DatabaseProvider {
     rpc findByIdAndUpdate(UpdateRequest) returns (QueryResponse);
     rpc updateMany(UpdateManyRequest) returns (QueryResponse);
     rpc countDocuments(QueryRequest) returns (QueryResponse);
-    rpc rawQuery(CombinedRawQueryRequest) returns (QueryResponse);
+    rpc rawQuery(RawQueryRequest) returns (QueryResponse);
 }


### PR DESCRIPTION
This PR adds a new rpc for raw query execution.
A raw query in the rpc can be like this:
```javascript
rawQuery = {
      mongoQuery: {
        insertOne?: {
          _id: 'example',
          username: 'example'
        },
        options?: {
          example: true
        }
      },
      sqlQuery: {
        query: 'SELECT * FROM "cnd_User"',
        options?: {
          example: true
        }
      }
    }
```

**What kind of change does this PR introduce?** <!--(check at least one)-->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other (please describe)

**Does this PR introduce a breaking change?** <!-- (check one) -->

- [ ] Yes
- [x] No

<!-- If yes, please describe the impact and migration path for existing applications. -->

**The PR fulfills these requirements:**

- [x] It's submitted to the `main` branch
- [ ] When resolving a specific issue, it's referenced in the PR's description  (e.g. `fix #xxx`, where "xxx" is the issue number)

If adding a **new feature**, the PR's description includes:

- [x] A convincing reason for adding this feature <!-- to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it -->
