### PR TITLE
refactor(grpc-sdk): way of declaring fields and descriptions changed

### DIFF
--- a/libraries/grpc-sdk/src/helpers/TypeHelpers.ts
+++ b/libraries/grpc-sdk/src/helpers/TypeHelpers.ts
@@ -1,90 +1,142 @@
 import { ConduitModelField, TYPE } from '../interfaces';
 
-class ConduitStringConstructor {
-  // private to disallow creating other instances of this type
-  private constructor() {}
+export class FieldConstructor {
+  protected readonly type: string;
+  protected readonly required: boolean;
+  protected readonly description?: string;
 
-  static get Optional() {
-    return TYPE.String;
+  protected constructor(type: string, required: boolean, description?: string) {
+    this.type = type;
+    this.required = required;
+    this.description = description;
   }
 
-  static get Required(): ConduitModelField {
-    return { type: TYPE.String, required: true };
+  construct() {
+    return { type: this.type, required: this.required, description: this.description };
+  }
+}
+
+class ConduitStringConstructor extends FieldConstructor {
+  // private to disallow creating other instances of this type
+  private constructor(required: boolean, description?: string) {
+    super(TYPE.String, required, description);
+  }
+
+  static get Optional() {
+    return new ConduitStringConstructor(false);
+  }
+
+  static get Required() {
+    return new ConduitStringConstructor(true);
+  }
+
+  Description(description: string) {
+    return new ConduitStringConstructor(this.required, description);
   }
 }
 
 export const ConduitString = ConduitStringConstructor;
 
-class ConduitNumberConstructor {
+class ConduitNumberConstructor extends FieldConstructor {
   // private to disallow creating other instances of this type
-  private constructor() {}
-
-  static get Optional() {
-    return TYPE.Number;
+  private constructor(required: boolean, description?: string) {
+    super(TYPE.Number, required, description);
   }
 
-  static get Required(): ConduitModelField {
-    return { type: TYPE.Number, required: true };
+  static get Optional() {
+    return new ConduitNumberConstructor(false);
+  }
+
+  static get Required() {
+    return new ConduitNumberConstructor(true);
+  }
+
+  Description(description: string) {
+    return new ConduitNumberConstructor(this.required, description);
   }
 }
 
 export const ConduitNumber = ConduitNumberConstructor;
 
-class ConduitBooleanConstructor {
+class ConduitBooleanConstructor extends FieldConstructor {
   // private to disallow creating other instances of this type
-  private constructor() {}
-
-  static get Optional() {
-    return TYPE.Boolean;
+  private constructor(required: boolean, description?: string) {
+    super(TYPE.Boolean, required, description);
   }
 
-  static get Required(): ConduitModelField {
-    return { type: TYPE.Boolean, required: true };
+  static get Optional() {
+    return new ConduitBooleanConstructor(false);
+  }
+
+  static get Required() {
+    return new ConduitBooleanConstructor(true);
+  }
+
+  Description(description: string) {
+    return new ConduitBooleanConstructor(this.required, description);
   }
 }
 
 export const ConduitBoolean = ConduitBooleanConstructor;
 
-class ConduitDateConstructor {
+class ConduitDateConstructor extends FieldConstructor {
   // private to disallow creating other instances of this type
-  private constructor() {}
-
-  static get Optional() {
-    return TYPE.Date;
+  private constructor(required: boolean, description?: string) {
+    super(TYPE.Date, required, description);
   }
 
-  static get Required(): ConduitModelField {
-    return { type: TYPE.Date, required: true };
+  static get Optional() {
+    return new ConduitDateConstructor(false);
+  }
+
+  static get Required() {
+    return new ConduitDateConstructor(true);
+  }
+
+  Description(description: string) {
+    return new ConduitDateConstructor(this.required, description);
   }
 }
 
 export const ConduitDate = ConduitDateConstructor;
 
-class ConduitObjectIdConstructor {
+class ConduitObjectIdConstructor extends FieldConstructor {
   // private to disallow creating other instances of this type
-  private constructor() {}
-
-  static get Optional() {
-    return TYPE.ObjectId;
+  private constructor(required: boolean, description?: string) {
+    super(TYPE.ObjectId, required, description);
   }
 
-  static get Required(): ConduitModelField {
-    return { type: TYPE.ObjectId, required: true };
+  static get Optional() {
+    return new ConduitObjectIdConstructor(false);
+  }
+
+  static get Required() {
+    return new ConduitObjectIdConstructor(true);
+  }
+
+  Description(description: string) {
+    return new ConduitObjectIdConstructor(this.required, description);
   }
 }
 
 export const ConduitObjectId = ConduitObjectIdConstructor;
 
-class ConduitJSONConstructor {
+class ConduitJSONConstructor extends FieldConstructor {
   // private to disallow creating other instances of this type
-  private constructor() {}
-
-  static get Optional() {
-    return TYPE.JSON;
+  private constructor(required: boolean, description?: string) {
+    super(TYPE.JSON, required, description);
   }
 
-  static get Required(): ConduitModelField {
-    return { type: TYPE.JSON, required: true };
+  static get Optional() {
+    return new ConduitJSONConstructor(false);
+  }
+
+  static get Required() {
+    return new ConduitJSONConstructor(true);
+  }
+
+  Description(description: string) {
+    return new ConduitJSONConstructor(this.required, description);
   }
 }
 

--- a/libraries/grpc-sdk/src/interfaces/Model.ts
+++ b/libraries/grpc-sdk/src/interfaces/Model.ts
@@ -1,4 +1,5 @@
 import type { WhereOptions } from 'sequelize';
+import { FieldConstructor } from '../helpers';
 
 export enum TYPE {
   String = 'String',
@@ -49,6 +50,7 @@ export interface ConduitModel {
     | ConduitModelField
     | ConduitModelField[]
     | ConduitModel
+    | FieldConstructor
     | TYPE
     | TYPE[]
     | any[]; // removing this caused multiple issues

--- a/libraries/grpc-sdk/src/routing/RoutingManager.ts
+++ b/libraries/grpc-sdk/src/routing/RoutingManager.ts
@@ -1,4 +1,4 @@
-import { GrpcServer } from '../index';
+import { buildParameters, GrpcServer } from '../index';
 import { Admin, Router } from '../modules';
 import { RouteBuilder } from './RouteBuilder';
 import { RequestHandlers } from './wrapRouterFunctions';
@@ -82,7 +82,7 @@ export class RoutingManager {
     handler: RequestHandlers,
   ) {
     const routeObject: ConduitRouteObject = this.parseRouteObject({
-      options: input,
+      options: buildParameters(input),
       returns: {
         name: type.name,
         fields: JSON.stringify(type.fields),

--- a/libraries/grpc-sdk/src/routing/RoutingUtilities.ts
+++ b/libraries/grpc-sdk/src/routing/RoutingUtilities.ts
@@ -1,5 +1,7 @@
 import { RequestHandlers, wrapRouterGrpcFunction } from './wrapRouterFunctions';
-import { Indexable } from '../interfaces';
+import { ConduitModel, Indexable } from '../interfaces';
+import { ConduitRouteOption, ConduitRouteOptions } from './interfaces';
+import { FieldConstructor } from '../helpers';
 
 export function wrapFunctionsAsync(
   functions: { [name: string]: RequestHandlers },
@@ -14,4 +16,30 @@ export function wrapFunctionsAsync(
     modifiedFunctions[key] = wrapRouterGrpcFunction(functions[key], routerType);
   });
   return modifiedFunctions;
+}
+
+function constructParameters(paramArray: any) {
+  for (const param in paramArray) {
+    const field = paramArray[param];
+    if (field instanceof FieldConstructor) {
+      paramArray[param] = (field as FieldConstructor).construct();
+    }
+  }
+  return paramArray;
+}
+
+export function buildParameters(input: ConduitRouteOptions) {
+  if (input.queryParams) {
+    input.queryParams = constructParameters(input.queryParams);
+  }
+
+  if (input.bodyParams) {
+    input.bodyParams = constructParameters(input.bodyParams);
+  }
+
+  if (input.urlParams) {
+    input.urlParams = constructParameters(input.urlParams);
+  }
+
+  return input;
 }

--- a/libraries/grpc-sdk/src/routing/interfaces/Route.ts
+++ b/libraries/grpc-sdk/src/routing/interfaces/Route.ts
@@ -1,4 +1,5 @@
 import { ConduitModel } from '../../interfaces';
+import { FieldConstructor } from '../../helpers';
 
 export interface ConduitRouteParameters {
   params?: { [field: string]: any };
@@ -27,6 +28,7 @@ export interface ConduitRouteOption {
     | string
     | string[]
     | ConduitRouteOptionExtended
+    | FieldConstructor
     | RouteOptionType
     | RouteOptionType[];
 }


### PR DESCRIPTION
Way of declaring descriptions in route fields changed.

Current implementation: 

```
field: {
  type: ConduitType.Required,
  description: 'some description'
}
```

PR's Implementation

```
field: ConduitType.Required.Description("Some description")
```
Also you the way that fields are declared without description remains the same

```
field: ConduitType.Required
```

**What kind of change does this PR introduce?** <!--(check at least one)-->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [x] Refactor
- [ ] Build-related changes
- [ ] Other (please describe)

**Does this PR introduce a breaking change?** <!-- (check one) -->

- [ ] Yes
- [x] No

<!-- If yes, please describe the impact and migration path for existing applications. -->

**The PR fulfills these requirements:**

- [x] It's submitted to the `main` branch
- [ ] When resolving a specific issue, it's referenced in the PR's description  (e.g. `fix #xxx`, where "xxx" is the issue number)
