### PR TITLE
feat: get-conduit.sh --no-deploy flag

### DIFF
--- a/docker/get-conduit.sh
+++ b/docker/get-conduit.sh
@@ -2,6 +2,8 @@
 
 # Installation: sh <(curl -s https://getconduit.dev/bootstrap)
 
+[[ $1 = '--no-deploy' ]] && deploy="false" || deploy="true"
+
 uname=$(uname -a)
 website="https://getconduit.dev"
 
@@ -66,5 +68,7 @@ if [[ $shell_detected == "false" ]]; then
 fi
 
 # Bootstrap Local Deployment
-printf "\n\n"
-~/.conduit/bin/conduit deploy setup --config
+if [[ $deploy == "true" ]]; then
+  printf "\n\n"
+  ~/.conduit/bin/conduit deploy setup --config
+fi


### PR DESCRIPTION
<!--
This PR allows for `get-conduit.sh` to optionally not run `deploy:setup`.
This change complements Conduit CLI (`cli:deploy`).

I'm intentionally not using `getopt` for args as it's not portable between Linux (GNU getopt) and Mac (BSD getopt, does not support long args).

**What kind of change does this PR introduce?** <!--(check at least one)-->

- [ ] Bugfix
- [X] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other (please describe)

**Does this PR introduce a breaking change?** <!-- (check one) -->

- [ ] Yes
- [X] No

<!-- If yes, please describe the impact and migration path for existing applications. -->

**The PR fulfills these requirements:**

- [X] It's submitted to the `main` branch
- [ ] When resolving a specific issue, it's referenced in the PR's description  (e.g. `fix #xxx`, where "xxx" is the issue number)

If adding a **new feature**, the PR's description includes:

- [X] A convincing reason for adding this feature <!-- to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it -->
