### PR TITLE
build(grpc-sdk): fix build missing gRPC health check proto file

### DIFF
--- a/libraries/grpc-sdk/package.json
+++ b/libraries/grpc-sdk/package.json
@@ -10,6 +10,7 @@
     "prepublish": "npm run build",
     "prebuild": "npm run protoc",
     "build": "rimraf dist && tsc",
+    "postbuild": "copyfiles -u 1 src/*.proto src/**/*.json ./dist/",
     "protoc": "sh build.sh"
   },
   "license": "MIT",

--- a/libraries/grpc-sdk/src/classes/ConduitServiceModule.ts
+++ b/libraries/grpc-sdk/src/classes/ConduitServiceModule.ts
@@ -45,7 +45,7 @@ export abstract class ConduitServiceModule {
 
   protected async addHealthCheckService() {
     await this.grpcServer.addService(
-      path.resolve(__dirname, '../../src/grpc_health_check.proto'),
+      path.resolve(__dirname, '../grpc_health_check.proto'),
       'grpc.health.v1.Health',
       {
         Check: this.healthCheck.bind(this),


### PR DESCRIPTION
Fixes `grpc-sdk` build missing gRPC health checking proto file, resulting in out-of-tree modules being unable to initialize.

**What kind of change does this PR introduce?** <!--(check at least one)-->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [X] Build-related changes
- [ ] Other (please describe)

**Does this PR introduce a breaking change?** <!-- (check one) -->

- [ ] Yes
- [X] No

<!-- If yes, please describe the impact and migration path for existing applications. -->

**The PR fulfills these requirements:**

- [X] It's submitted to the `main` branch
- [ ] When resolving a specific issue, it's referenced in the PR's description  (e.g. `fix #xxx`, where "xxx" is the issue number)