### PR TITLE
fix: get-conduit.sh linux arm64 detection

### DIFF
--- a/docker/get-conduit.sh
+++ b/docker/get-conduit.sh
@@ -19,10 +19,8 @@ else
 fi
 
 # Detect Architecture
-if [[ $uname =~ "arm64" ]]; then
-  arch="arm64"
-elif [[ $uname =~ "aarch64" ]]; then
-  arch="arm64"
+if [[ $uname =~ "arm64" ]] || [[ $uname =~ "aarch64" ]]; then
+  arch="arm"
 elif [[ $uname =~ "x86_64" ]]; then
   arch="x64"
 else

--- a/docker/get-conduit.sh
+++ b/docker/get-conduit.sh
@@ -48,11 +48,14 @@ chmod a+x ~/.conduit/bin/conduit
 
 # Add To Executable Path
 shell_detected='false'
+already_installed='false'
 if which zsh >> /dev/null 2>&1; then
   shell_detected='true'
   if ! grep 'export PATH=$PATH:~/.conduit/bin' ~/.zshrc >> /dev/null 2>&1; then
     echo "Adding Conduit CLI to Zsh"
     printf '\n# Add Conduit CLI to executable PATH\nexport PATH=$PATH:~/.conduit/bin\n' >> ~/.zshrc
+  else
+    already_installed='true'
   fi
 fi
 if which bash >> /dev/null 2>&1; then
@@ -60,15 +63,19 @@ if which bash >> /dev/null 2>&1; then
   if ! grep 'export PATH=$PATH:~/.conduit/bin' ~/.bashrc >> /dev/null 2>&1; then
     echo "Adding Conduit CLI to Bash"
     printf '\n# Add Conduit CLI to executable PATH\nexport PATH=$PATH:~/.conduit/bin\n' >> ~/.bashrc
+  else
+      already_installed='true'
   fi
 fi
 if [[ $shell_detected == "false" ]]; then
   printf '\nShell auto-detection failed. Could not update executable $PATH.\n';
   echo "Conduit CLI located in ~/.conduit/bin/conduit"
+elif [[ $already_installed == 'false' ]]; then
+  printf "\nTo ensure that 'conduit' is available, please open a new terminal window.\n"
 fi
 
 # Bootstrap Local Deployment
 if [[ $deploy == "true" ]]; then
-  printf "\n\n"
+  printf "\n"
   ~/.conduit/bin/conduit deploy setup --config
 fi

--- a/docker/get-conduit.sh
+++ b/docker/get-conduit.sh
@@ -21,6 +21,8 @@ fi
 # Detect Architecture
 if [[ $uname =~ "arm64" ]]; then
   arch="arm64"
+elif [[ $uname =~ "aarch64" ]]; then
+  arch="arm64"
 elif [[ $uname =~ "x86_64" ]]; then
   arch="x64"
 else


### PR DESCRIPTION
Fixes installation oneliner failing to detect arm64 architecture on Linux.
Fixes Linux arm tarball url.
Adds a $PATH reload hint on new installations so that users are not confused over `conduit` not being available in their parent terminal session (auto-sourcing the rc file is not portable or reliable)

**What kind of change does this PR introduce?** <!--(check at least one)-->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other (please describe)

**Does this PR introduce a breaking change?** <!-- (check one) -->

- [ ] Yes
- [X] No

<!-- If yes, please describe the impact and migration path for existing applications. -->

**The PR fulfills these requirements:**

- [X] It's submitted to the `main` branch
- [ ] When resolving a specific issue, it's referenced in the PR's description  (e.g. `fix #xxx`, where "xxx" is the issue number)
