### PR TITLE
feat(grpc-sdk): dynamic module clients

### DIFF
--- a/libraries/grpc-sdk/src/classes/ConduitModule.ts
+++ b/libraries/grpc-sdk/src/classes/ConduitModule.ts
@@ -23,11 +23,10 @@ export class ConduitModule<T extends CompatServiceDefinition> {
     private readonly _grpcToken?: string,
   ) {}
 
-  initializeClient(type: T): Client<T> {
-    if (this._serviceClient) return this._serviceClient;
+  initializeClients(type: T) {
+    if (this._serviceClient) return;
     this.type = type;
     this.openConnection();
-    return this._serviceClient!;
   }
 
   openConnection() {
@@ -54,9 +53,11 @@ export class ConduitModule<T extends CompatServiceDefinition> {
     this._conduitClient = clientFactory.create(ConduitModuleDefinition, this.channel, {
       '*': retryOptions,
     });
-    this._serviceClient = clientFactory.create(this.type!, this.channel, {
-      '*': retryOptions,
-    });
+    if (this.type) {
+      this._serviceClient = clientFactory.create(this.type!, this.channel, {
+        '*': retryOptions,
+      });
+    }
     this.active = true;
   }
 

--- a/libraries/grpc-sdk/src/index.ts
+++ b/libraries/grpc-sdk/src/index.ts
@@ -454,11 +454,7 @@ export default class ConduitGrpcSdk {
   }
 
   createModuleClient(moduleName: string, moduleUrl: string) {
-    if (
-      this._modules[moduleName] ||
-      (!this._availableModules[moduleName] && !this._dynamicModules[moduleName])
-    )
-      return;
+    if (this._modules[moduleName] || moduleName === 'core') return;
     if (this._availableModules[moduleName]) {
       // ConduitGrpcSdk.Logger.log(`Creating gRPC client for ${moduleName}`);
       this._modules[moduleName] = new this._availableModules[moduleName](
@@ -466,7 +462,7 @@ export default class ConduitGrpcSdk {
         this.urlRemap ? `${this.urlRemap}:${moduleUrl.split(':')[1]}` : moduleUrl,
         this._grpcToken,
       );
-    } else if (this._dynamicModules[moduleName]) {
+    } else {
       // ConduitGrpcSdk.Logger.log(`Creating gRPC client for ${moduleName}`);
       this._modules[moduleName] = new ConduitModule(
         this.name,
@@ -474,7 +470,7 @@ export default class ConduitGrpcSdk {
         this.urlRemap ? `${this.urlRemap}:${moduleUrl.split(':')[1]}` : moduleUrl,
         this._grpcToken,
       );
-      this._modules[moduleName].initializeClient(this._dynamicModules[moduleName]);
+      this._modules[moduleName].initializeClients(this._dynamicModules[moduleName]);
     }
   }
 
@@ -482,8 +478,8 @@ export default class ConduitGrpcSdk {
     return checkServiceHealth(this.name, moduleUrl, service, this._grpcToken);
   }
 
-  moduleClient(name: string, type: CompatServiceDefinition): void {
-    this._dynamicModules[name] = type;
+  importDynamicModuleDefinition(name: string, definition: CompatServiceDefinition): void {
+    this._dynamicModules[name] = definition;
   }
 
   getModule<T extends CompatServiceDefinition>(

--- a/libraries/grpc-sdk/src/modules/admin/index.ts
+++ b/libraries/grpc-sdk/src/modules/admin/index.ts
@@ -10,7 +10,7 @@ import { ConduitRouteObject, SocketProtoDescription } from '../../routing';
 export class Admin extends ConduitModule<typeof AdminDefinition> {
   constructor(readonly moduleName: string, url: string, grpcToken?: string) {
     super(moduleName, 'admin', url, grpcToken);
-    this.initializeClient(AdminDefinition);
+    this.initializeClients(AdminDefinition);
   }
 
   generateProtoFile(

--- a/libraries/grpc-sdk/src/modules/authentication/index.ts
+++ b/libraries/grpc-sdk/src/modules/authentication/index.ts
@@ -9,7 +9,7 @@ import {
 export class Authentication extends ConduitModule<typeof AuthenticationDefinition> {
   constructor(private readonly moduleName: string, url: string, grpcToken?: string) {
     super(moduleName, 'authentication', url, grpcToken);
-    this.initializeClient(AuthenticationDefinition);
+    this.initializeClients(AuthenticationDefinition);
   }
 
   userLogin(userId: string, clientId: string): Promise<UserLoginResponse> {

--- a/libraries/grpc-sdk/src/modules/authorization/index.ts
+++ b/libraries/grpc-sdk/src/modules/authorization/index.ts
@@ -15,7 +15,7 @@ import {
 export class Authorization extends ConduitModule<typeof AuthorizationDefinition> {
   constructor(private readonly moduleName: string, url: string, grpcToken?: string) {
     super(moduleName, 'authorization', url, grpcToken);
-    this.initializeClient(AuthorizationDefinition);
+    this.initializeClients(AuthorizationDefinition);
   }
 
   defineResource(data: Resource): Promise<Empty> {

--- a/libraries/grpc-sdk/src/modules/chat/index.ts
+++ b/libraries/grpc-sdk/src/modules/chat/index.ts
@@ -4,7 +4,7 @@ import { ChatDefinition, Room, SendMessageRequest } from '../../protoUtils/chat'
 export class Chat extends ConduitModule<typeof ChatDefinition> {
   constructor(private readonly moduleName: string, url: string, grpcToken?: string) {
     super(moduleName, 'chat', url, grpcToken);
-    this.initializeClient(ChatDefinition);
+    this.initializeClients(ChatDefinition);
   }
 
   sendMessage(messageData: SendMessageRequest): Promise<any> {

--- a/libraries/grpc-sdk/src/modules/config/index.ts
+++ b/libraries/grpc-sdk/src/modules/config/index.ts
@@ -21,7 +21,7 @@ export class Config extends ConduitModule<typeof ConfigDefinition> {
     grpcToken?: string,
   ) {
     super(moduleName, 'config', url, grpcToken);
-    this.initializeClient(ConfigDefinition);
+    this.initializeClients(ConfigDefinition);
     this._serviceHealthStatusGetter = serviceHealthStatusGetter;
   }
 

--- a/libraries/grpc-sdk/src/modules/core/index.ts
+++ b/libraries/grpc-sdk/src/modules/core/index.ts
@@ -4,6 +4,6 @@ import { CoreDefinition } from '../../protoUtils/core';
 export class Core extends ConduitModule<typeof CoreDefinition> {
   constructor(private readonly moduleName: string, url: string, grpcToken?: string) {
     super(moduleName, 'core', url, grpcToken);
-    this.initializeClient(CoreDefinition);
+    this.initializeClients(CoreDefinition);
   }
 }

--- a/libraries/grpc-sdk/src/modules/database/index.ts
+++ b/libraries/grpc-sdk/src/modules/database/index.ts
@@ -11,7 +11,7 @@ import { Query } from '../../types/db';
 export class DatabaseProvider extends ConduitModule<typeof DatabaseProviderDefinition> {
   constructor(private readonly moduleName: string, url: string, grpcToken?: string) {
     super(moduleName, 'database', url, grpcToken);
-    this.initializeClient(DatabaseProviderDefinition);
+    this.initializeClients(DatabaseProviderDefinition);
   }
 
   getSchema(schemaName: string): Promise<{

--- a/libraries/grpc-sdk/src/modules/email/index.ts
+++ b/libraries/grpc-sdk/src/modules/email/index.ts
@@ -4,7 +4,7 @@ import { EmailDefinition } from '../../protoUtils/email';
 export class Email extends ConduitModule<typeof EmailDefinition> {
   constructor(private readonly moduleName: string, url: string, grpcToken?: string) {
     super(moduleName, 'email', url, grpcToken);
-    this.initializeClient(EmailDefinition);
+    this.initializeClients(EmailDefinition);
   }
 
   registerTemplate(template: {

--- a/libraries/grpc-sdk/src/modules/forms/index.ts
+++ b/libraries/grpc-sdk/src/modules/forms/index.ts
@@ -4,6 +4,6 @@ import { FormsDefinition } from '../../protoUtils/forms';
 export class Forms extends ConduitModule<typeof FormsDefinition> {
   constructor(private readonly moduleName: string, url: string, grpcToken?: string) {
     super(moduleName, 'forms', url, grpcToken);
-    this.initializeClient(FormsDefinition);
+    this.initializeClients(FormsDefinition);
   }
 }

--- a/libraries/grpc-sdk/src/modules/pushNotifications/index.ts
+++ b/libraries/grpc-sdk/src/modules/pushNotifications/index.ts
@@ -4,7 +4,7 @@ import { PushNotificationsDefinition } from '../../protoUtils/push-notifications
 export class PushNotifications extends ConduitModule<typeof PushNotificationsDefinition> {
   constructor(private readonly moduleName: string, url: string, grpcToken?: string) {
     super(moduleName, 'push-notifications', url, grpcToken);
-    this.initializeClient(PushNotificationsDefinition);
+    this.initializeClients(PushNotificationsDefinition);
   }
 
   sendNotificationToken(token: string, platform: string, userId: string) {

--- a/libraries/grpc-sdk/src/modules/router/index.ts
+++ b/libraries/grpc-sdk/src/modules/router/index.ts
@@ -11,7 +11,7 @@ import { ConduitRouteObject, SocketProtoDescription } from '../../routing';
 export class Router extends ConduitModule<typeof RouterDefinition> {
   constructor(readonly moduleName: string, url: string, grpcToken?: string) {
     super(moduleName, 'router', url, grpcToken);
-    this.initializeClient(RouterDefinition);
+    this.initializeClients(RouterDefinition);
   }
 
   generateProtoFile(

--- a/libraries/grpc-sdk/src/modules/sms/index.ts
+++ b/libraries/grpc-sdk/src/modules/sms/index.ts
@@ -9,7 +9,7 @@ import {
 export class SMS extends ConduitModule<typeof SmsDefinition> {
   constructor(private readonly moduleName: string, url: string, grpcToken?: string) {
     super(moduleName, 'sms', url, grpcToken);
-    this.initializeClient(SmsDefinition);
+    this.initializeClients(SmsDefinition);
   }
 
   sendSms(to: string, message: string): Promise<SendSmsResponse> {

--- a/libraries/grpc-sdk/src/modules/storage/index.ts
+++ b/libraries/grpc-sdk/src/modules/storage/index.ts
@@ -8,7 +8,7 @@ import {
 export class Storage extends ConduitModule<typeof StorageDefinition> {
   constructor(private readonly moduleName: string, url: string, grpcToken?: string) {
     super(moduleName, 'storage', url, grpcToken);
-    this.initializeClient(StorageDefinition);
+    this.initializeClients(StorageDefinition);
   }
 
   getFile(id: string): Promise<FileResponse> {

--- a/packages/core/src/config-manager/service-discovery/index.ts
+++ b/packages/core/src/config-manager/service-discovery/index.ts
@@ -300,7 +300,7 @@ export class ServiceDiscovery {
   ) {
     const { moduleName, moduleVersion } = moduleManifest;
     this.grpcSdk.createModuleClient(moduleName, moduleUrl);
-    if (!healthStatus) {
+    if (healthStatus === undefined) {
       const healthResponse = await this.grpcSdk.checkServiceHealth(moduleUrl);
       if (healthResponse === HealthCheckStatus.SERVICE_UNKNOWN) {
         throw new Error('Failed to register unresponsive module');

--- a/packages/core/src/config-manager/service-discovery/index.ts
+++ b/packages/core/src/config-manager/service-discovery/index.ts
@@ -362,7 +362,12 @@ export class ServiceDiscovery {
       moduleManifest,
       call.request.url,
       call.request.healthStatus as HealthCheckStatus,
-    );
+    ).catch(err => {
+      return callback({
+        code: status.INTERNAL,
+        message: err.message,
+      });
+    });
     this.updateRedisState(moduleManifest, call.request.url, instance);
     this.publishModuleData(
       'serving-modules-update',


### PR DESCRIPTION
This PR improves `grpc-sdk`'s support for dynamic module clients.
`grpc-sdk` may now automatically initialize `ConduitModule` clients for out-of-tree modules.

This change allows Conduit to handle the configurations for third-party modules.

Custom microservices may explicitly utilize `importDynamicModuleDefinition()` to provide service definition details for initializing a service client.

[Here](https://github.com/kon14/ConduitModuleExample)'s an example module implementation for testing this.
Make sure you update the default `.env` file (defaults to dockerized enviroment support)

**What kind of change does this PR introduce?** <!--(check at least one)-->

- [X] Bugfix
- [X] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other (please describe)

**Does this PR introduce a breaking change?** <!-- (check one) -->

- [X] Yes
- [ ] No

<!-- If yes, please describe the impact and migration path for existing applications. -->

**The PR fulfills these requirements:**

- [ ] It's submitted to the `main` branch
- [ ] When resolving a specific issue, it's referenced in the PR's description  (e.g. `fix #xxx`, where "xxx" is the issue number)