### PR TITLE
fix(grpc-sdk): serving-modules-update

### DIFF
--- a/libraries/grpc-sdk/src/index.ts
+++ b/libraries/grpc-sdk/src/index.ts
@@ -26,8 +26,7 @@ import {
 import { ConduitModuleDefinition } from './protoUtils/conduit_module';
 import {
   GetRedisDetailsResponse,
-  DeploymentState,
-  DeploymentState_ModuleStateInfo,
+  DeploymentState_ModuleStateInfo as ModuleStateInfo,
 } from './protoUtils/core';
 import { GrpcError, HealthCheckStatus } from './types';
 import { checkServiceHealth } from './classes/HealthCheck';
@@ -304,19 +303,17 @@ export default class ConduitGrpcSdk {
   watchModules() {
     const emitter = this.config.getModuleWatcher();
     this.config.watchDeploymentState().then();
-    emitter.on('serving-modules-update', (state: DeploymentState) => {
+    emitter.on('serving-modules-update', (modules: ModuleStateInfo[]) => {
       Object.keys(this._modules).forEach(r => {
         if (r !== this.name) {
-          const found = state.modules.find(
-            m => m.moduleName === r && !m.pending && m.serving,
-          );
+          const found = modules.find(m => m.moduleName === r && !m.pending && m.serving);
           if (!found && this._modules[r]) {
             this._modules[r]?.closeConnection();
             emitter.emit(`module-connection-update:${r}`, false);
           }
         }
       });
-      state.modules.forEach((m: DeploymentState_ModuleStateInfo) => {
+      modules.forEach((m: ModuleStateInfo) => {
         if (m.moduleName !== this.name && !m.pending) {
           const alreadyActive = this._modules[m.moduleName]?.connectionsActive;
           if (!alreadyActive && m.serving) {

--- a/libraries/grpc-sdk/src/modules/config/index.ts
+++ b/libraries/grpc-sdk/src/modules/config/index.ts
@@ -117,7 +117,12 @@ export class Config extends ConduitModule<typeof ConfigDefinition> {
   async watchDeploymentState() {
     const self = this;
     this.emitter.setMaxListeners(150);
-    self.emitter.emit('serving-modules-update', await self.getDeploymentState().catch());
+    const readyModules =
+      (await self
+        .getDeploymentState()
+        .then(data => data.modules.filter(m => !m.pending))
+        .catch()) ?? [];
+    self.emitter.emit('serving-modules-update', readyModules);
     try {
       const call = this.serviceClient!.watchDeploymentState({});
       for await (const data of call) {

--- a/libraries/grpc-sdk/src/modules/config/index.ts
+++ b/libraries/grpc-sdk/src/modules/config/index.ts
@@ -2,6 +2,7 @@ import { EventEmitter } from 'events';
 import { ConduitModule } from '../../classes/ConduitModule';
 import { HealthCheckStatus } from '../../types';
 import {
+  DeploymentState,
   ConfigDefinition,
   ModuleHealthRequest,
   RegisterModuleRequest,
@@ -102,7 +103,7 @@ export class Config extends ConduitModule<typeof ConfigDefinition> {
           self.watchDeploymentState();
         }
       })
-      .catch(e => {
+      .catch(() => {
         if (self.coreLive) {
           ConduitGrpcSdk.Logger.warn('Core unhealthy');
           self.coreLive = false;
@@ -117,19 +118,14 @@ export class Config extends ConduitModule<typeof ConfigDefinition> {
   async watchDeploymentState() {
     const self = this;
     this.emitter.setMaxListeners(150);
-    const readyModules =
-      (await self
-        .getDeploymentState()
-        .then(data => data.modules.filter(m => !m.pending))
-        .catch()) ?? [];
-    self.emitter.emit('serving-modules-update', readyModules);
+    const state: DeploymentState = await self.getDeploymentState().catch(() => {
+      return { modules: [] };
+    });
+    self.emitter.emit('serving-modules-update', state);
     try {
       const call = this.serviceClient!.watchDeploymentState({});
-      for await (const data of call) {
-        self.emitter.emit(
-          'serving-modules-update',
-          data.modules.filter(m => !m.pending),
-        );
+      for await (const state of call) {
+        self.emitter.emit('serving-modules-update', state);
       }
     } catch (error) {
       self.coreLive = false;

--- a/packages/core/src/config-manager/service-discovery/index.ts
+++ b/packages/core/src/config-manager/service-discovery/index.ts
@@ -148,7 +148,7 @@ export class ServiceDiscovery {
     if (readyCheckRes.issues.length > 0) {
       return Promise.resolve(ModuleRegistrationState.PENDING);
     }
-    if (!healthStatus) {
+    if (healthStatus === undefined) {
       const healthClient = this.grpcSdk.getHealthClient(module.moduleName)!;
       healthStatus = await healthClient
         .check({})


### PR DESCRIPTION
This PR cleans up `grpc-sdk` module client initialization and renames certain types and variables so as to improve readability and code clarity (or so I would hope).

It also fixes `serving-modules-update` (broken in `next` due to inconsistent message type publishing) and fixes a 0->false evaluation in `Core` resulting in unknown health states being considered unhealthy (also only affecting `next`).

**What kind of change does this PR introduce?** <!--(check at least one)-->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other (please describe)

**Does this PR introduce a breaking change?** <!-- (check one) -->

- [ ] Yes
- [X] No

<!-- If yes, please describe the impact and migration path for existing applications. -->

**The PR fulfills these requirements:**

- [ ] It's submitted to the `main` branch
- [ ] When resolving a specific issue, it's referenced in the PR's description  (e.g. `fix #xxx`, where "xxx" is the issue number)
