### PR TITLE
fix(grpc-sdk,admin): config object patch array field merging

### DIFF
--- a/libraries/grpc-sdk/src/classes/ManagedModule.ts
+++ b/libraries/grpc-sdk/src/classes/ManagedModule.ts
@@ -3,10 +3,11 @@ import ConduitGrpcSdk, {
   GrpcServer,
   SetConfigRequest,
   SetConfigResponse,
+  merge,
 } from '..';
 import { ConduitServiceModule } from './ConduitServiceModule';
 import { ConfigController } from './ConfigController';
-import { kebabCase, merge } from 'lodash';
+import { kebabCase } from 'lodash';
 import { status } from '@grpc/grpc-js';
 import convict from 'convict';
 

--- a/libraries/grpc-sdk/src/utilities/index.ts
+++ b/libraries/grpc-sdk/src/utilities/index.ts
@@ -1,7 +1,3 @@
 export * from './linearBackoffTimeout';
-
-export function sleep(ms: number) {
-  return new Promise(resolve => {
-    setTimeout(resolve, ms);
-  });
-}
+export * from './merge';
+export * from './sleep';

--- a/libraries/grpc-sdk/src/utilities/merge.ts
+++ b/libraries/grpc-sdk/src/utilities/merge.ts
@@ -1,0 +1,11 @@
+import { mergeWith as _mergeWith } from 'lodash';
+
+export function merge<T extends object>(objA: T, objB: T) {
+  const customizer = (objValue: unknown, srcValue: unknown) => {
+    if (Array.isArray(objValue)) {
+      // don't merge arrays
+      return srcValue;
+    }
+  };
+  return _mergeWith({}, objA, objB, customizer);
+}

--- a/libraries/grpc-sdk/src/utilities/sleep.ts
+++ b/libraries/grpc-sdk/src/utilities/sleep.ts
@@ -1,0 +1,5 @@
+export function sleep(ms: number) {
+  return new Promise(resolve => {
+    setTimeout(resolve, ms);
+  });
+}

--- a/packages/admin/src/index.ts
+++ b/packages/admin/src/index.ts
@@ -1,4 +1,4 @@
-import { isNaN, isNil, merge } from 'lodash';
+import { isNaN, isNil } from 'lodash';
 import { status } from '@grpc/grpc-js';
 import ConduitGrpcSdk, {
   ConduitError,
@@ -10,6 +10,7 @@ import ConduitGrpcSdk, {
   Indexable,
   ConduitRouteObject,
   SocketProtoDescription,
+  merge,
 } from '@conduitplatform/grpc-sdk';
 import {
   ConduitCommons,

--- a/packages/core/src/config-manager/config-storage/index.ts
+++ b/packages/core/src/config-manager/config-storage/index.ts
@@ -8,7 +8,6 @@ import { merge } from 'lodash';
 export class ConfigStorage {
   toBeReconciled: string[] = [];
   reconciling: boolean = false;
-  private configDocId: string | null = null;
 
   constructor(
     private readonly commons: ConduitCommons,


### PR DESCRIPTION
This PR fixes config object patches, where array fields would previously get merged.

Previously patching `{ a: true, b: [1, 2, 3] }` with `{ b: [3] }` resulted in `{ a: false, b: [3, 2, 3] }`.
With fix, the above patch results in `{ a: true, b: [3] }`.

**What kind of change does this PR introduce?** <!--(check at least one)-->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other (please describe)

**Does this PR introduce a breaking change?** <!-- (check one) -->

- [ ] Yes
- [X] No

<!-- If yes, please describe the impact and migration path for existing applications. -->

**The PR fulfills these requirements:**

- [X] It's submitted to the `main` branch
- [ ] When resolving a specific issue, it's referenced in the PR's description  (e.g. `fix #xxx`, where "xxx" is the issue number)