### PR TITLE
fix(authentication): crash on PostgreSQL migrations

### DIFF
--- a/modules/authentication/src/migrations/index.ts
+++ b/modules/authentication/src/migrations/index.ts
@@ -5,8 +5,13 @@ import { UserIdToUserRefreshTokenSchemaMigration } from './UserIdToUserRefreshTo
 import { UserIdToUserTwoFactorSchemaMigration } from './UserIdToUserTwoFactorSchemaMigration';
 
 export async function runMigrations(grpcSdk: ConduitGrpcSdk) {
-  await UserIdToUserTokenSchemaMigration(grpcSdk);
-  await UserIdToUserAccessTokenSchemaMigration(grpcSdk);
-  await UserIdToUserRefreshTokenSchemaMigration(grpcSdk);
-  await UserIdToUserTwoFactorSchemaMigration(grpcSdk);
+  await UserIdToUserTokenSchemaMigration(grpcSdk).catch(ignorePostgres);
+  await UserIdToUserAccessTokenSchemaMigration(grpcSdk).catch(ignorePostgres);
+  await UserIdToUserRefreshTokenSchemaMigration(grpcSdk).catch(ignorePostgres);
+  await UserIdToUserTwoFactorSchemaMigration(grpcSdk).catch(ignorePostgres);
+}
+
+function ignorePostgres(error: { details: string }) {
+  if (error.details.endsWith('.userId does not exist')) return;
+  throw error;
 }


### PR DESCRIPTION
This is a dirty workaround for `Authentication`'s crashing PostgreSQL migrations.
This should be replaced by raw sql migrations in v0.16.

**What kind of change does this PR introduce?** <!--(check at least one)-->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other (please describe)

**Does this PR introduce a breaking change?** <!-- (check one) -->

- [ ] Yes
- [X] No

<!-- If yes, please describe the impact and migration path for existing applications. -->

**The PR fulfills these requirements:**

- [X] It's submitted to the `main` branch
- [ ] When resolving a specific issue, it's referenced in the PR's description  (e.g. `fix #xxx`, where "xxx" is the issue number)