### PR TITLE
fix(database): sequelize populations

### DIFF
--- a/modules/database/src/Database.ts
+++ b/modules/database/src/Database.ts
@@ -317,7 +317,6 @@ export default class DatabaseModule extends ManagedModule<void> {
         call.request.query,
         call.request.select,
         call.request.populate,
-        schemaAdapter.relations,
       );
       callback(null, { result: JSON.stringify(doc) });
     } catch (err) {
@@ -347,7 +346,6 @@ export default class DatabaseModule extends ManagedModule<void> {
         select,
         sort,
         populate,
-        schemaAdapter.relations,
       );
       callback(null, { result: JSON.stringify(docs) });
     } catch (err) {
@@ -433,7 +431,6 @@ export default class DatabaseModule extends ManagedModule<void> {
         call.request.query,
         call.request.updateProvidedOnly,
         call.request.populate,
-        schemaAdapter.relations,
       );
       const resultString = JSON.stringify(result);
 

--- a/modules/database/src/adapters/DatabaseAdapter.ts
+++ b/modules/database/src/adapters/DatabaseAdapter.ts
@@ -5,6 +5,7 @@ import ConduitGrpcSdk, {
   ModelOptionsIndexes,
   RawMongoQuery,
   RawSQLQuery,
+  Indexable,
 } from '@conduitplatform/grpc-sdk';
 import { Schema, _ConduitSchema, ConduitDatabaseSchema } from '../interfaces';
 import { stitchSchema, validateExtensionFields } from './utils/extensions';
@@ -168,7 +169,10 @@ export abstract class DatabaseAdapter<T extends Schema> {
     instanceSync?: boolean,
   ): Promise<string>;
 
-  abstract getSchemaModel(schemaName: string): { model: Schema; relations: any };
+  abstract getSchemaModel(schemaName: string): {
+    model: Schema;
+    relations: null | Indexable;
+  };
 
   abstract getDatabaseType(): string;
 

--- a/modules/database/src/adapters/mongoose-adapter/MongooseSchema.ts
+++ b/modules/database/src/adapters/mongoose-adapter/MongooseSchema.ts
@@ -137,7 +137,7 @@ export class MongooseSchema implements SchemaAdapter<Model<any>> {
     return this.model.deleteMany(this.parseQuery(parsedQuery)).exec();
   }
 
-  calculatePopulates(queryObj: any, population: string[]) {
+  private calculatePopulates(queryObj: any, population: string[]) {
     population.forEach((r: string | string[], index: number) => {
       const final = r.toString().trim();
       if (r.indexOf('.') !== -1) {

--- a/modules/database/src/adapters/sequelize-adapter/SequelizeSchema.ts
+++ b/modules/database/src/adapters/sequelize-adapter/SequelizeSchema.ts
@@ -17,7 +17,11 @@ import {
 } from '../../interfaces';
 import { createWithPopulations, parseQuery } from './utils';
 import { SequelizeAdapter } from './index';
-import ConduitGrpcSdk, { ConduitSchema, Indexable } from '@conduitplatform/grpc-sdk';
+import ConduitGrpcSdk, {
+  ConduitModelField,
+  ConduitSchema,
+  Indexable,
+} from '@conduitplatform/grpc-sdk';
 
 const deepdash = require('deepdash/standalone');
 
@@ -137,12 +141,7 @@ export class SequelizeSchema implements SchemaAdapter<ModelCtor<any>> {
     return this.model.bulkCreate(parsedQuery);
   }
 
-  async findOne(
-    query: Query,
-    select?: string,
-    populate?: string[],
-    relations?: Indexable,
-  ) {
+  async findOne(query: Query, select?: string, populate?: string[]) {
     let parsedQuery: ParsedQuery | ParsedQuery[];
     if (typeof query === 'string') {
       parsedQuery = JSON.parse(query);
@@ -159,15 +158,18 @@ export class SequelizeSchema implements SchemaAdapter<ModelCtor<any>> {
     incrementDbQueries();
     const document = await this.model.findOne(options);
 
-    if (!isNil(populate) && !isNil(relations)) {
-      for (const relation of populate) {
-        if (this.relations.hasOwnProperty(relation)) {
-          if (relations.hasOwnProperty(this.relations[relation])) {
-            incrementDbQueries();
-            document[relation] = await relations[this.relations[relation]].findOne({
-              _id: document[relation],
-            });
-          }
+    if (!isNil(populate) && !isNil(this.relations)) {
+      for (const relationField of populate) {
+        const relationSchema = (
+          this.originalSchema.fields[relationField] as ConduitModelField
+        )?.model;
+        if (!relationSchema) continue;
+        if (this.relations.hasOwnProperty(relationField)) {
+          incrementDbQueries();
+          const schemaModel = this.adapter.getSchemaModel(relationSchema).model;
+          document[relationField] = await schemaModel.findOne({
+            _id: document[relationField],
+          });
         }
       }
     }
@@ -182,7 +184,6 @@ export class SequelizeSchema implements SchemaAdapter<ModelCtor<any>> {
     select?: string,
     sort?: { [key: string]: number },
     populate?: string[],
-    relations?: Indexable,
   ): Promise<any> {
     let parsedQuery: ParsedQuery | ParsedQuery[];
     if (typeof query === 'string') {
@@ -209,20 +210,24 @@ export class SequelizeSchema implements SchemaAdapter<ModelCtor<any>> {
 
     const documents = await this.model.findAll(options);
 
-    if (!isNil(populate) && !isNil(relations)) {
+    if (!isNil(populate) && !isNil(this.relations)) {
       for (const relation of populate) {
+        const relationField = relation.split('.')[1];
+        const relationSchema = (
+          this.originalSchema.fields[relationField] as ConduitModelField
+        )?.model;
+        if (!relationSchema) continue;
         const cache: Indexable = {};
         for (const document of documents) {
-          if (this.relations.hasOwnProperty(relation)) {
-            if (relations.hasOwnProperty(this.relations[relation])) {
-              if (!cache.hasOwnProperty(document[relation])) {
-                incrementDbQueries();
-                cache[document[relation]] = await relations[
-                  this.relations[relation]
-                ].findOne({ _id: document[relation] });
-              }
-              document[relation] = cache[document[relation]];
+          if (this.relations.hasOwnProperty(relationField)) {
+            if (!cache.hasOwnProperty(document[relation])) {
+              incrementDbQueries();
+              const schemaModel = this.adapter.getSchemaModel(relationSchema).model;
+              cache[document[relation]] = await schemaModel.findOne({
+                _id: document[relation],
+              });
             }
+            document[relationField] = cache[document[relation]];
           }
         }
       }
@@ -258,7 +263,6 @@ export class SequelizeSchema implements SchemaAdapter<ModelCtor<any>> {
     query: SingleDocQuery,
     updateProvidedOnly: boolean = false,
     populate?: string[],
-    relations?: Indexable,
   ) {
     let parsedQuery: ParsedQuery;
     if (typeof query === 'string') {
@@ -334,19 +338,18 @@ export class SequelizeSchema implements SchemaAdapter<ModelCtor<any>> {
     incrementDbQueries();
     await this.createWithPopulations(parsedQuery);
     const document = (await this.model.upsert({ _id: id, ...parsedQuery }))[0];
-    if (!isNil(populate) && !isNil(relations)) {
-      for (const relation of populate) {
-        const cache: Indexable = {};
-        if (this.relations.hasOwnProperty(relation)) {
-          if (relations.hasOwnProperty(this.relations[relation])) {
-            if (!cache.hasOwnProperty(document[relation])) {
-              incrementDbQueries();
-              cache[document[relation]] = await relations[
-                this.relations[relation]
-              ].findOne({ _id: document[relation] });
-            }
-            document[relation] = cache[document[relation]];
-          }
+    if (!isNil(populate) && !isNil(this.relations)) {
+      for (const relationField of populate) {
+        const relationSchema = (
+          this.originalSchema.fields[relationField] as ConduitModelField
+        )?.model;
+        if (!relationSchema) continue;
+        if (this.relations.hasOwnProperty(relationField)) {
+          incrementDbQueries();
+          const schemaModel = this.adapter.getSchemaModel(relationSchema).model;
+          document[relationField] = await schemaModel.findOne({
+            _id: document[relationField],
+          });
         }
       }
     }

--- a/modules/database/src/adapters/sequelize-adapter/SequelizeSchema.ts
+++ b/modules/database/src/adapters/sequelize-adapter/SequelizeSchema.ts
@@ -160,11 +160,8 @@ export class SequelizeSchema implements SchemaAdapter<ModelCtor<any>> {
 
     if (!isNil(populate) && !isNil(this.relations)) {
       for (const relationField of populate) {
-        const relationSchema = (
-          this.originalSchema.fields[relationField] as ConduitModelField
-        )?.model;
-        if (!relationSchema) continue;
         if (this.relations.hasOwnProperty(relationField)) {
+          const relationSchema = this.relations[relationField];
           incrementDbQueries();
           const schemaModel = this.adapter.getSchemaModel(relationSchema).model;
           document[relationField] = await schemaModel.findOne({
@@ -213,13 +210,10 @@ export class SequelizeSchema implements SchemaAdapter<ModelCtor<any>> {
     if (!isNil(populate) && !isNil(this.relations)) {
       for (const relation of populate) {
         const relationField = relation.split('.')[1];
-        const relationSchema = (
-          this.originalSchema.fields[relationField] as ConduitModelField
-        )?.model;
-        if (!relationSchema) continue;
         const cache: Indexable = {};
         for (const document of documents) {
           if (this.relations.hasOwnProperty(relationField)) {
+            const relationSchema = this.relations[relationField];
             if (!cache.hasOwnProperty(document[relation])) {
               incrementDbQueries();
               const schemaModel = this.adapter.getSchemaModel(relationSchema).model;
@@ -340,11 +334,8 @@ export class SequelizeSchema implements SchemaAdapter<ModelCtor<any>> {
     const document = (await this.model.upsert({ _id: id, ...parsedQuery }))[0];
     if (!isNil(populate) && !isNil(this.relations)) {
       for (const relationField of populate) {
-        const relationSchema = (
-          this.originalSchema.fields[relationField] as ConduitModelField
-        )?.model;
-        if (!relationSchema) continue;
         if (this.relations.hasOwnProperty(relationField)) {
+          const relationSchema = this.relations[relationField];
           incrementDbQueries();
           const schemaModel = this.adapter.getSchemaModel(relationSchema).model;
           document[relationField] = await schemaModel.findOne({

--- a/modules/database/src/interfaces/ConduitDatabaseSchema.ts
+++ b/modules/database/src/interfaces/ConduitDatabaseSchema.ts
@@ -54,15 +54,8 @@ export class ConduitDatabaseSchema extends ConduitSchema {
     document: ParsedQuery,
     updateProvidedOnly?: boolean,
     populate?: string[] | undefined,
-    relations?: any,
   ) {
-    return this.model.findByIdAndUpdate(
-      id,
-      document,
-      updateProvidedOnly,
-      populate,
-      relations,
-    );
+    return this.model.findByIdAndUpdate(id, document, updateProvidedOnly, populate);
   }
 
   updateMany(filterQuery: ParsedQuery, query: ParsedQuery, updateProvidedOnly?: boolean) {

--- a/modules/database/src/interfaces/SchemaAdapter.ts
+++ b/modules/database/src/interfaces/SchemaAdapter.ts
@@ -31,12 +31,7 @@ export interface SchemaAdapter<T> {
    * @param populate
    * @param relations
    */
-  findOne(
-    query: Query,
-    select?: string,
-    populate?: string[],
-    relations?: Indexable,
-  ): Promise<any>;
+  findOne(query: Query, select?: string, populate?: string[]): Promise<any>;
 
   /**
    * Should find Many
@@ -55,7 +50,6 @@ export interface SchemaAdapter<T> {
     select?: string,
     sort?: any,
     populate?: string[],
-    relations?: Indexable,
   ): Promise<any>;
 
   /**
@@ -75,7 +69,6 @@ export interface SchemaAdapter<T> {
     document: SingleDocQuery,
     updateProvidedOnly?: boolean,
     populate?: string[],
-    relations?: Indexable,
   ): Promise<any>;
 
   updateMany(


### PR DESCRIPTION
This PR fixes Sequelize populations through.
SequelizeSchema now implicitly handles population relations in `findOne()`, `findMany()` and `findByIdAndUpdate()`.

This bug resulted in populations not working through the client API etc.

**What kind of change does this PR introduce?** <!--(check at least one)-->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other (please describe)

**Does this PR introduce a breaking change?** <!-- (check one) -->

- [ ] Yes
- [X] No

<!-- If yes, please describe the impact and migration path for existing applications. -->

**The PR fulfills these requirements:**

- [X] It's submitted to the `main` branch
- [ ] When resolving a specific issue, it's referenced in the PR's description  (e.g. `fix #xxx`, where "xxx" is the issue number)