### PR TITLE
fix(authentication): OAuth2 authentication url construction

### DIFF
--- a/modules/authentication/src/handlers/oauth2/OAuth2.ts
+++ b/modules/authentication/src/handlers/oauth2/OAuth2.ts
@@ -34,9 +34,9 @@ export abstract class OAuth2<T, S extends OAuth2Settings>
   mapScopes: { [key: string]: string };
   defaultScopes: string[];
   protected settings: S;
-  private providerName: string;
+  private readonly providerName: string;
 
-  constructor(grpcSdk: ConduitGrpcSdk, providerName: string, settings: S) {
+  protected constructor(grpcSdk: ConduitGrpcSdk, providerName: string, settings: S) {
     this.providerName = providerName;
     this.grpcSdk = grpcSdk;
     this.settings = settings;

--- a/modules/authentication/src/handlers/oauth2/OAuth2.ts
+++ b/modules/authentication/src/handlers/oauth2/OAuth2.ts
@@ -74,7 +74,7 @@ export abstract class OAuth2<T, S extends OAuth2Settings>
         .replace(/\//g, '_');
     }
 
-    const options: RedirectOptions = {
+    const queryOptions: RedirectOptions = {
       client_id: this.settings.clientId,
       redirect_uri: conduitUrl + this.settings.callbackUrl,
       response_type: this.settings.responseType,
@@ -94,7 +94,7 @@ export abstract class OAuth2<T, S extends OAuth2Settings>
         data: {
           invitationToken: call.request.params?.invitationToken,
           clientId: call.request.context.clientId,
-          scope: options.scope,
+          scope: queryOptions.scope,
           codeChallenge: codeChallenge,
           expiresAt: new Date(Date.now() + 10 * 60 * 1000),
         },
@@ -102,15 +102,15 @@ export abstract class OAuth2<T, S extends OAuth2Settings>
       .catch(err => {
         throw new GrpcError(status.INTERNAL, err);
       });
-    options['state'] = stateToken.token;
+    queryOptions['state'] = stateToken.token;
 
-    const keys = Object.keys(options) as [keyof RedirectOptions];
-    const url = keys
+    const keys = Object.keys(queryOptions) as [keyof RedirectOptions];
+    const queryString = keys
       .map(k => {
-        return k + '=' + options[k];
+        return k + '=' + queryOptions[k];
       })
       .join('&');
-    return baseUrl + '?' + url;
+    return baseUrl + '?' + queryString;
   }
 
   async authorize(call: ParsedRouterRequest) {

--- a/modules/authentication/src/handlers/oauth2/OAuth2.ts
+++ b/modules/authentication/src/handlers/oauth2/OAuth2.ts
@@ -80,8 +80,10 @@ export abstract class OAuth2<T, S extends OAuth2Settings>
       response_type: this.settings.responseType,
       response_mode: this.settings.responseMode,
       scope: this.constructScopes(scopes),
-      code_challenge: codeChallenge,
-      code_challenge_method: this.settings.codeChallengeMethod,
+      ...(codeChallenge !== undefined && { code_challenge: codeChallenge }),
+      ...(this.settings.codeChallengeMethod !== undefined && {
+        code_challenge_method: this.settings.codeChallengeMethod,
+      }),
     };
     const baseUrl = this.settings.authorizeUrl;
 

--- a/modules/authentication/src/handlers/oauth2/OAuth2.ts
+++ b/modules/authentication/src/handlers/oauth2/OAuth2.ts
@@ -108,7 +108,7 @@ export abstract class OAuth2<T, S extends OAuth2Settings>
         return k + '=' + options[k];
       })
       .join('&');
-    return baseUrl + url;
+    return baseUrl + '?' + url;
   }
 
   async authorize(call: ParsedRouterRequest) {


### PR DESCRIPTION
This PR fixes the following issues in regards to OAuth2 authentication url construction:
- `code_challenge` and `code_challenge_method` passed as `undefined` when not explicitly used by provider
- activation url query params not being prefixed by `?`

**What kind of change does this PR introduce?** <!--(check at least one)-->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other (please describe)

**Does this PR introduce a breaking change?** <!-- (check one) -->

- [ ] Yes
- [X] No

<!-- If yes, please describe the impact and migration path for existing applications. -->

**The PR fulfills these requirements:**

- [X] It's submitted to the `main` branch
- [ ] When resolving a specific issue, it's referenced in the PR's description  (e.g. `fix #xxx`, where "xxx" is the issue number)
