### PR TITLE
fix(database): sql findMany() populates cache identifier uniqueness

### DIFF
--- a/modules/database/src/adapters/sequelize-adapter/SequelizeSchema.ts
+++ b/modules/database/src/adapters/sequelize-adapter/SequelizeSchema.ts
@@ -210,14 +210,15 @@ export class SequelizeSchema implements SchemaAdapter<ModelCtor<any>> {
         for (const document of documents) {
           if (this.relations.hasOwnProperty(relationField)) {
             const relationSchema = this.relations[relationField];
-            if (!cache.hasOwnProperty(document[relation])) {
+            const cacheIdentifier = `${relation}:${document[relationField]}`;
+            if (!cache.hasOwnProperty(cacheIdentifier)) {
               incrementDbQueries();
               const schemaModel = this.adapter.getSchemaModel(relationSchema).model;
-              cache[document[relation]] = await schemaModel.findOne({
-                _id: document[relation],
+              cache[cacheIdentifier] = await schemaModel.findOne({
+                _id: document[relationField],
               });
             }
-            document[relationField] = cache[document[relation]];
+            document[relationField] = cache[cacheIdentifier];
           }
         }
       }


### PR DESCRIPTION
Fixes an adapter bug where SDL findMany() populate caching resulted in all populated fields being assigned the same value.

**What kind of change does this PR introduce?** <!--(check at least one)-->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other (please describe)

**Does this PR introduce a breaking change?** <!-- (check one) -->

- [ ] Yes
- [X] No

<!-- If yes, please describe the impact and migration path for existing applications. -->

**The PR fulfills these requirements:**

- [X] It's submitted to the `main` branch
- [ ] When resolving a specific issue, it's referenced in the PR's description  (e.g. `fix #xxx`, where "xxx" is the issue number)
