### PR TITLE
fix(hermes): numeric param parsing, REST middleware running before param validation

### DIFF
--- a/libraries/hermes/src/GraphQl/GraphQL.ts
+++ b/libraries/hermes/src/GraphQl/GraphQL.ts
@@ -288,8 +288,8 @@ export class GraphQLController extends ConduitRouter {
         },
         parseLiteral(ast) {
           if (ast.kind === Kind.INT || ast.kind === Kind.FLOAT) {
-            return ast.value;
-          } else if (ast.kind == Kind.STRING) {
+            return Number(ast.value);
+          } else if (ast.kind === Kind.STRING) {
             if (Number.isInteger(ast.value)) {
               return Number.parseInt(ast.value);
             } else if (!Number.isNaN(ast.value)) {

--- a/libraries/hermes/src/Rest/Rest.ts
+++ b/libraries/hermes/src/Rest/Rest.ts
@@ -150,22 +150,18 @@ export class RestController extends ConduitRouter {
         route,
         req.headers['cache-control'],
       );
+      if (route.input.bodyParams)
+        validateParams(context.bodyParams, route.input.bodyParams);
+      if (route.input.queryParams)
+        validateParams(context.queryParams, route.input.queryParams);
+      if (route.input.urlParams) validateParams(context.urlParams, route.input.urlParams);
+      context.params = {
+        ...context.bodyParams,
+        ...context.queryParams,
+        ...context.urlParams,
+      };
       self
         .checkMiddlewares(context, route.input.middlewares)
-        .then(r => {
-          if (route.input.bodyParams)
-            validateParams(context.bodyParams, route.input.bodyParams);
-          if (route.input.queryParams)
-            validateParams(context.queryParams, route.input.queryParams);
-          if (route.input.urlParams)
-            validateParams(context.urlParams, route.input.urlParams);
-          context.params = {
-            ...context.bodyParams,
-            ...context.queryParams,
-            ...context.urlParams,
-          };
-          return r;
-        })
         .then(r => {
           Object.assign(context.context, r);
           if (route.input.action !== ConduitRouteActions.GET) {

--- a/libraries/hermes/src/Rest/Rest.ts
+++ b/libraries/hermes/src/Rest/Rest.ts
@@ -144,7 +144,7 @@ export class RestController extends ConduitRouter {
   constructHandler(route: ConduitRoute): (req: Request, res: Response) => void {
     const self = this;
     return (req, res) => {
-      const context = extractRequestData(req);
+      const context = { ...extractRequestData(req), params: {} };
       let hashKey: string;
       const { caching, cacheAge, scope } = extractCaching(
         route,
@@ -153,11 +153,17 @@ export class RestController extends ConduitRouter {
       self
         .checkMiddlewares(context, route.input.middlewares)
         .then(r => {
-          validateParams(context.params, {
-            ...route.input.bodyParams,
-            ...route.input.queryParams,
-            ...route.input.urlParams,
-          });
+          if (route.input.bodyParams)
+            validateParams(context.bodyParams, route.input.bodyParams);
+          if (route.input.queryParams)
+            validateParams(context.queryParams, route.input.queryParams);
+          if (route.input.urlParams)
+            validateParams(context.urlParams, route.input.urlParams);
+          context.params = {
+            ...context.bodyParams,
+            ...context.queryParams,
+            ...context.urlParams,
+          };
           return r;
         })
         .then(r => {

--- a/libraries/hermes/src/Rest/util.ts
+++ b/libraries/hermes/src/Rest/util.ts
@@ -6,7 +6,6 @@ type ConduitRequest = Request & { conduit?: Indexable };
 
 export function extractRequestData(req: ConduitRequest) {
   const context = req.conduit || {};
-  const params: any = {};
   const urlParams: any = {};
   const queryParams: any = {};
   const bodyParams: any = {};
@@ -25,29 +24,26 @@ export function extractRequestData(req: ConduitRequest) {
         newObj[k] = req.query[k];
       }
     });
-    Object.assign(params, newObj);
     Object.assign(queryParams, newObj);
   }
 
   if (req.body) {
-    Object.assign(params, req.body);
     Object.assign(bodyParams, req.body);
   }
 
   if (req.params) {
-    Object.assign(params, req.params);
     Object.assign(urlParams, req.params);
   }
 
-  if (params.populate) {
-    if (params.populate.includes(',')) {
-      params.populate = params.populate.split(',');
-    } else if (!Array.isArray(params.populate)) {
-      params.populate = [params.populate];
+  if (queryParams.populate) {
+    if (queryParams.populate.includes(',')) {
+      queryParams.populate = queryParams.populate.split(',');
+    } else if (!Array.isArray(queryParams.populate)) {
+      queryParams.populate = [queryParams.populate];
     }
   }
   const path = req.baseUrl + req.path;
-  return { context, params, headers, cookies, path, urlParams, queryParams, bodyParams };
+  return { context, headers, cookies, path, urlParams, queryParams, bodyParams };
 }
 
 export function validateParams(params: Params, routeDefinedParams: Params) {


### PR DESCRIPTION
This PR fixes numeric param parsing in REST and GraphQL so that numeric args are actually passed as true numbers (instead of stringified ones).

This fix currently further **breaks Sequelize** numeric comparisons (eg $gte) as these normally expect a true number, yet somehow only seem to work for stringified numbers despite models representing fields as floats.
Needs further investigation.

**What kind of change does this PR introduce?** <!--(check at least one)-->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other (please describe)

**Does this PR introduce a breaking change?** <!-- (check one) -->

- [ ] Yes
- [X] No

<!-- If yes, please describe the impact and migration path for existing applications. -->

**The PR fulfills these requirements:**

- [X] It's submitted to the `main` branch
- [ ] When resolving a specific issue, it's referenced in the PR's description  (e.g. `fix #xxx`, where "xxx" is the issue number)
