### PR TITLE
fix(database,grpc-sdk): sql parseQuery numeric parsing, grpc-sdk depending on sequelize

### DIFF
--- a/libraries/grpc-sdk/package.json
+++ b/libraries/grpc-sdk/package.json
@@ -54,7 +54,6 @@
     "@types/ioredis": "^4.28.10",
     "@types/lodash": "^4.14.182",
     "@types/node": "14.14.31",
-    "@types/sequelize": "^4.28.14",
     "copyfiles": "^2.4.1",
     "rimraf": "^3.0.2",
     "ts-proto": "^1.117.0",

--- a/libraries/grpc-sdk/src/interfaces/Model.ts
+++ b/libraries/grpc-sdk/src/interfaces/Model.ts
@@ -1,5 +1,3 @@
-import type { WhereOptions } from 'sequelize';
-
 export enum TYPE {
   String = 'String',
   Number = 'Number',
@@ -119,5 +117,7 @@ export interface PostgresIndexOptions {
   prefix?: string;
   unique?: boolean;
   using?: PostgresIndexType;
-  where?: WhereOptions<any>;
+  where?: {
+    [opt: string]: any;
+  };
 }

--- a/modules/database/src/adapters/sequelize-adapter/utils.ts
+++ b/modules/database/src/adapters/sequelize-adapter/utils.ts
@@ -1,5 +1,5 @@
 import { Op } from 'sequelize';
-import _, { isArray, isBoolean, isObject, isString } from 'lodash';
+import _, { isArray, isBoolean, isNumber, isObject, isString } from 'lodash';
 import {
   ConduitModel,
   Indexable,
@@ -64,7 +64,7 @@ function matchOperation(operator: string, value: any) {
 
 export function parseQuery(query: ParsedQuery) {
   const parsed: Indexable = isArray(query) ? [] : {};
-  if (isString(query) || isBoolean(query)) return query;
+  if (isString(query) || isBoolean(query) || isNumber(query)) return query;
   for (const key in query) {
     if (key === '$or') {
       Object.assign(parsed, {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3587,11 +3587,6 @@
   dependencies:
     "@types/node" "*"
 
-"@types/bluebird@*":
-  version "3.5.37"
-  resolved "https://registry.yarnpkg.com/@types/bluebird/-/bluebird-3.5.37.tgz#b99e5c7fe382c2c6d5252dc99d9fba6810fedbeb"
-  integrity sha512-g2qEd+zkfkTEudA2SrMAeAvY7CrFqtbsLILm2dT2VIeKTqMqVzcdfURlvu6FU3srRgbmXN1Srm94pg34EIehww==
-
 "@types/body-parser@*":
   version "1.19.2"
   resolved "https://registry.yarnpkg.com/@types/body-parser/-/body-parser-1.19.2.tgz#aea2059e28b7658639081347ac4fab3de166e6f0"
@@ -3629,13 +3624,6 @@
   version "0.5.5"
   resolved "https://registry.yarnpkg.com/@types/content-disposition/-/content-disposition-0.5.5.tgz#650820e95de346e1f84e30667d168c8fd25aa6e3"
   integrity sha512-v6LCdKfK6BwcqMo+wYW05rLS12S0ZO0Fl4w1h4aaZMD7bqT3gVUns6FvLJKGZHQmYn3SX55JWGpziwJRwVgutA==
-
-"@types/continuation-local-storage@*":
-  version "3.2.4"
-  resolved "https://registry.yarnpkg.com/@types/continuation-local-storage/-/continuation-local-storage-3.2.4.tgz#655c8ffd9327aa60fb8ae773a5f2efbc973a7cbb"
-  integrity sha512-OT32vCVMymU1JMPKDeY0lX3cduAr0Pm/VwIbxygMeDS4lRcv57qYXn9bMwBRcRnEpXKBb/r4xYaZCARTZllP0A==
-  dependencies:
-    "@types/node" "*"
 
 "@types/convict@^6.1.1":
   version "6.1.1"
@@ -3840,11 +3828,6 @@
   resolved "https://registry.yarnpkg.com/@types/linkify-it/-/linkify-it-3.0.2.tgz#fd2cd2edbaa7eaac7e7f3c1748b52a19143846c9"
   integrity sha512-HZQYqbiFVWufzCwexrvh694SOim8z2d+xJl5UNamcvQFejLY/2YUtzXHYi3cHdI7PMlS8ejH2slRAOJQ32aNbA==
 
-"@types/lodash@*":
-  version "4.14.189"
-  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.189.tgz#975ff8c38da5ae58b751127b19ad5e44b5b7f6d2"
-  integrity sha512-kb9/98N6X8gyME9Cf7YaqIMvYGnBSWqEci6tiettE6iJWH1XdJz/PO8LB0GtLCG7x8dU3KWhZT+lA1a35127tA==
-
 "@types/lodash@^4.14.182":
   version "4.14.182"
   resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.182.tgz#05301a4d5e62963227eaafe0ce04dd77c54ea5c2"
@@ -3987,16 +3970,6 @@
     "@types/tough-cookie" "*"
     form-data "^2.5.0"
 
-"@types/sequelize@^4.28.14":
-  version "4.28.14"
-  resolved "https://registry.yarnpkg.com/@types/sequelize/-/sequelize-4.28.14.tgz#70302689ddef09f5d472b548a14e5a150e690aff"
-  integrity sha512-O8lTJ8YPVVaoY9xjduchDlo0MOS3w262pro2H1QMuFIo/kc/p1elP/UxLOTP2wcVO2cFd6Gvghg9ZSAiJi0GLA==
-  dependencies:
-    "@types/bluebird" "*"
-    "@types/continuation-local-storage" "*"
-    "@types/lodash" "*"
-    "@types/validator" "*"
-
 "@types/serve-static@*":
   version "1.13.10"
   resolved "https://registry.yarnpkg.com/@types/serve-static/-/serve-static-1.13.10.tgz#f5e0ce8797d2d7cc5ebeda48a52c96c4fa47a8d9"
@@ -4034,11 +4007,6 @@
   version "8.3.4"
   resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-8.3.4.tgz#bd86a43617df0594787d38b735f55c805becf1bc"
   integrity sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw==
-
-"@types/validator@*":
-  version "13.7.10"
-  resolved "https://registry.yarnpkg.com/@types/validator/-/validator-13.7.10.tgz#f9763dc0933f8324920afa9c0790308eedf55ca7"
-  integrity sha512-t1yxFAR2n0+VO6hd/FJ9F2uezAZVWHLmpmlJzm1eX03+H7+HsuTAp7L8QJs+2pQCfWkP1+EXsGK9Z9v7o/qPVQ==
 
 "@types/validator@^13.7.1", "@types/validator@^13.7.4":
   version "13.7.4"


### PR DESCRIPTION
This PR includes the following fixes:
- Database's sql parseQuery() failing to parse numeric values
- grpc-sdk depending on sequelize (not @types/sequelize) being available

**What kind of change does this PR introduce?** <!--(check at least one)-->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other (please describe)

**Does this PR introduce a breaking change?** <!-- (check one) -->

- [ ] Yes
- [X] No

<!-- If yes, please describe the impact and migration path for existing applications. -->

**The PR fulfills these requirements:**

- [X] It's submitted to the `main` branch
- [ ] When resolving a specific issue, it's referenced in the PR's description  (e.g. `fix #xxx`, where "xxx" is the issue number)
