### PR TITLE
fix(database): schema index deletion admin route invalid param type

### DIFF
--- a/modules/database/src/admin/index.ts
+++ b/modules/database/src/admin/index.ts
@@ -635,7 +635,7 @@ export class AdminHandlers {
         urlParams: {
           id: { type: RouteOptionType.String, required: true },
         },
-        bodyParams: {
+        queryParams: {
           indexNames: [ConduitString.Required],
         },
       },


### PR DESCRIPTION
Fixes schema index deletion admin route expecting `indexNames` as body params in a `DELETE` request.
This is technically a breaking change in the admin API, but it reality shouldn't affect end users + UI already expected query params.

**What kind of change does this PR introduce?** <!--(check at least one)-->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other (please describe)

**Does this PR introduce a breaking change?** <!-- (check one) -->

- [ ] Yes
- [ ] No

<!-- If yes, please describe the impact and migration path for existing applications. -->

**The PR fulfills these requirements:**

- [X] It's submitted to the `main` branch
- [ ] When resolving a specific issue, it's referenced in the PR's description  (e.g. `fix #xxx`, where "xxx" is the issue number)
