### PR TITLE
feat(database): like,ilike operators

### DIFF
--- a/libraries/grpc-sdk/src/types/db.ts
+++ b/libraries/grpc-sdk/src/types/db.ts
@@ -1,6 +1,16 @@
 type documentKeys<T> = keyof T;
 type documentValues<T> = T[keyof T];
-type operators = '$eq' | '$ne' | '$gt' | '$gte' | '$lt' | '$lte' | '$regex' | '$options';
+type operators =
+  | '$eq'
+  | '$ne'
+  | '$gt'
+  | '$gte'
+  | '$lt'
+  | '$lte'
+  | '$regex'
+  | '$options'
+  | '$like'
+  | '$ilike';
 type arrayOperators = '$in' | '$nin';
 type conditionOperators = '$or' | '$and';
 

--- a/modules/database/src/adapters/mongoose-adapter/MongooseSchema.ts
+++ b/modules/database/src/adapters/mongoose-adapter/MongooseSchema.ts
@@ -38,7 +38,7 @@ export class MongooseSchema implements SchemaAdapter<Model<any>> {
 
   async create(query: SingleDocQuery) {
     const parsedQuery = {
-      ...parseQuery(typeof query === 'string' ? EJSON.parse(query) : query),
+      ...(typeof query === 'string' ? EJSON.parse(query) : query),
       createdAt: new Date(),
       updatedAt: new Date(),
     };
@@ -46,7 +46,7 @@ export class MongooseSchema implements SchemaAdapter<Model<any>> {
   }
 
   async createMany(query: MultiDocQuery) {
-    const docs = parseQuery(typeof query === 'string' ? EJSON.parse(query) : query);
+    const docs = typeof query === 'string' ? EJSON.parse(query) : query;
     return this.model.insertMany(docs).then(r => r);
   }
 

--- a/modules/database/src/adapters/mongoose-adapter/parser/index.ts
+++ b/modules/database/src/adapters/mongoose-adapter/parser/index.ts
@@ -1,58 +1,23 @@
-import { ParsedQuery } from '../../../interfaces';
-import { isArray, isBoolean, isNumber, isString } from 'lodash';
 import { Indexable } from '@conduitplatform/grpc-sdk';
+import { ParsedQuery } from '../../../interfaces';
 
 export function parseQuery(query: ParsedQuery): ParsedQuery {
-  return _parseQuery(query) as ParsedQuery;
-}
-
-export function _parseQuery(query?: ParsedQuery | null): ParsedQuery | null | undefined {
-  if (query === undefined) return undefined;
-  if (query === null) return null;
-  const parsed: Indexable = isArray(query) ? [] : {};
-  if (isString(query) || isBoolean(query) || isNumber(query)) return query;
-  for (const key in query) {
-    if (key === '$or') {
-      Object.assign(parsed, {
-        $or: query[key].map((operation: ParsedQuery) => {
-          return parseQuery(operation);
-        }),
-      });
-    } else if (key === '$and') {
-      Object.assign(parsed, {
-        $and: query[key].map((operation: ParsedQuery) => {
-          return parseQuery(operation);
-        }),
-      });
-    } else {
-      if (!!query[key] && typeof query[key] === 'object' && !Array.isArray(query[key])) {
-        const likeCandidates = Object.keys(query[key]);
-        if (likeCandidates.includes('$like')) {
-          Object.assign(parsed, {
-            [key]: { $regex: query[key].$like.replace(/%/g, '.*') },
-          });
-          continue;
-        }
-        if (likeCandidates.includes('$ilike')) {
-          Object.assign(parsed, {
-            [key]: {
-              $regex: query[key].$ilike.replace(/%/g, '.*'),
-              $options: 'i',
-            },
-          });
-          continue;
-        }
-      }
-      if (query[key] === undefined) {
-        Object.assign(parsed, {
-          [key]: undefined,
-        });
+  if (Array.isArray(query)) {
+    return query.map(item => parseQuery(item));
+  } else if (typeof query === 'object' && query !== null) {
+    const parsedQuery: Indexable = {};
+    Object.keys(query).forEach(key => {
+      if (key === '$like') {
+        parsedQuery.$regex = query.$like.replace(/%/g, '.*');
+      } else if (key === '$ilike') {
+        parsedQuery.$regex = query.$ilike.replace(/%/g, '.*');
+        parsedQuery.$options = 'i';
       } else {
-        Object.assign(parsed, {
-          [key]: parseQuery(query[key]),
-        });
+        parsedQuery[key] = parseQuery(query[key]);
       }
-    }
+    });
+    return parsedQuery;
+  } else {
+    return query;
   }
-  return parsed;
 }

--- a/modules/database/src/adapters/mongoose-adapter/parser/index.ts
+++ b/modules/database/src/adapters/mongoose-adapter/parser/index.ts
@@ -29,14 +29,14 @@ export function _parseQuery(query?: ParsedQuery | null): ParsedQuery | null | un
         const likeCandidates = Object.keys(query[key]);
         if (likeCandidates.includes('$like')) {
           Object.assign(parsed, {
-            [key]: { $regex: `.*${query[key].$like.slice(1).slice(0, -1)}.*` },
+            [key]: { $regex: query[key].$like.replace(/%/g, '.*') },
           });
           continue;
         }
         if (likeCandidates.includes('$ilike')) {
           Object.assign(parsed, {
             [key]: {
-              $regex: `.*${query[key].$ilike.slice(1).slice(0, -1)}.*`,
+              $regex: query[key].$ilike.replace(/%/g, '.*'),
               $options: 'i',
             },
           });

--- a/modules/database/src/adapters/mongoose-adapter/parser/index.ts
+++ b/modules/database/src/adapters/mongoose-adapter/parser/index.ts
@@ -1,0 +1,58 @@
+import { ParsedQuery } from '../../../interfaces';
+import { isArray, isBoolean, isNumber, isString } from 'lodash';
+import { Indexable } from '@conduitplatform/grpc-sdk';
+
+export function parseQuery(query: ParsedQuery): ParsedQuery {
+  return _parseQuery(query) as ParsedQuery;
+}
+
+export function _parseQuery(query?: ParsedQuery | null): ParsedQuery | null | undefined {
+  if (query === undefined) return undefined;
+  if (query === null) return null;
+  const parsed: Indexable = isArray(query) ? [] : {};
+  if (isString(query) || isBoolean(query) || isNumber(query)) return query;
+  for (const key in query) {
+    if (key === '$or') {
+      Object.assign(parsed, {
+        $or: query[key].map((operation: ParsedQuery) => {
+          return parseQuery(operation);
+        }),
+      });
+    } else if (key === '$and') {
+      Object.assign(parsed, {
+        $and: query[key].map((operation: ParsedQuery) => {
+          return parseQuery(operation);
+        }),
+      });
+    } else {
+      if (!!query[key] && typeof query[key] === 'object' && !Array.isArray(query[key])) {
+        const likeCandidates = Object.keys(query[key]);
+        if (likeCandidates.includes('$like')) {
+          Object.assign(parsed, {
+            [key]: { $regex: `.*${query[key].$like.slice(1).slice(0, -1)}.*` },
+          });
+          continue;
+        }
+        if (likeCandidates.includes('$ilike')) {
+          Object.assign(parsed, {
+            [key]: {
+              $regex: `.*${query[key].$ilike.slice(1).slice(0, -1)}.*`,
+              $options: 'i',
+            },
+          });
+          continue;
+        }
+      }
+      if (query[key] === undefined) {
+        Object.assign(parsed, {
+          [key]: undefined,
+        });
+      } else {
+        Object.assign(parsed, {
+          [key]: parseQuery(query[key]),
+        });
+      }
+    }
+  }
+  return parsed;
+}

--- a/modules/database/src/adapters/sequelize-adapter/SequelizeSchema.ts
+++ b/modules/database/src/adapters/sequelize-adapter/SequelizeSchema.ts
@@ -205,6 +205,7 @@ export abstract class SequelizeSchema implements SchemaAdapter<ModelStatic<any>>
     }
     const parsingResult = parseQuery(
       parsedQuery,
+      this.adapter.sequelize.getDialect(),
       this.extractedRelations,
       { populate, select, exclude: [...this.excludedFields] },
       this.associations,
@@ -382,6 +383,7 @@ export abstract class SequelizeSchema implements SchemaAdapter<ModelStatic<any>>
     }
     const parsingResult = parseQuery(
       parsedQuery,
+      this.adapter.sequelize.getDialect(),
       this.extractedRelations,
       { populate, select, exclude: [...this.excludedFields] },
       this.associations,
@@ -425,6 +427,7 @@ export abstract class SequelizeSchema implements SchemaAdapter<ModelStatic<any>>
     incrementDbQueries();
     const parsingResult = parseQuery(
       parsedQuery,
+      this.adapter.sequelize.getDialect(),
       this.extractedRelations,
       {},
       this.associations,
@@ -457,6 +460,7 @@ export abstract class SequelizeSchema implements SchemaAdapter<ModelStatic<any>>
     incrementDbQueries();
     const parsingResult = parseQuery(
       parsedQuery,
+      this.adapter.sequelize.getDialect(),
       this.extractedRelations,
       {},
       this.associations,
@@ -487,6 +491,7 @@ export abstract class SequelizeSchema implements SchemaAdapter<ModelStatic<any>>
     incrementDbQueries();
     const parsingResult = parseQuery(
       parsedQuery,
+      this.adapter.sequelize.getDialect(),
       this.extractedRelations,
       {},
       this.associations,
@@ -515,6 +520,7 @@ export abstract class SequelizeSchema implements SchemaAdapter<ModelStatic<any>>
 
     const parsingResult = parseQuery(
       parsedFilter!,
+      this.adapter.sequelize.getDialect(),
       this.extractedRelations,
       {},
       this.associations,

--- a/modules/database/src/admin/customEndpoints/customEndpoints.admin.ts
+++ b/modules/database/src/admin/customEndpoints/customEndpoints.admin.ts
@@ -46,7 +46,7 @@ export class CustomEndpointsAdmin {
       query: Query = {};
     if (!isNil(call.request.params.search)) {
       identifier = escapeStringRegexp(call.request.params.search);
-      query['name'] = { $regex: `.*${identifier}.*`, $options: 'i' };
+      query['name'] = { $ilike: `%${identifier}%` };
     }
     if (!isNil(call.request.params.operation)) {
       query['operation'] = call.request.params.operation;

--- a/modules/database/src/admin/schema.admin.ts
+++ b/modules/database/src/admin/schema.admin.ts
@@ -51,7 +51,7 @@ export class SchemaAdmin {
     let identifier;
     if (!isNil(search)) {
       identifier = escapeStringRegexp(search);
-      query['name'] = { $regex: `.*${identifier}.*`, $options: 'i' };
+      query['name'] = { $ilike: `%${identifier}%` };
     }
     if (!isNil(enabled)) {
       const enabledQuery = {
@@ -487,7 +487,7 @@ export class SchemaAdmin {
     let query = {};
     if (!isNil(search)) {
       const identifier = escapeStringRegexp(search);
-      query = { name: { $regex: `.*${identifier}.*`, $options: 'i' } };
+      query = { name: { $ilike: `%${identifier}%` } };
     }
     const schemasPromise = this.database
       .getSchemaModel('_PendingSchemas')

--- a/modules/database/src/handlers/CustomEndpoints/utils.ts
+++ b/modules/database/src/handlers/CustomEndpoints/utils.ts
@@ -136,7 +136,7 @@ function _translateQuery(
   } else if (like) {
     comparisonField = escapeStringRegexp(comparisonField);
     if (like === 'sensitive') {
-      comparisonField = { $like: `%${comparisonField}%` }; // TODO: %abc% instead...
+      comparisonField = { $like: `%${comparisonField}%` };
     } else {
       comparisonField = { $ilike: `%${comparisonField}%` };
     }

--- a/modules/database/src/handlers/CustomEndpoints/utils.ts
+++ b/modules/database/src/handlers/CustomEndpoints/utils.ts
@@ -1,7 +1,7 @@
 import moment from 'moment';
 import { isNil } from 'lodash';
 import { Indexable } from '@conduitplatform/grpc-sdk';
-import { CustomEndpointsQuery, LikeComparison } from '../../interfaces';
+import { CustomEndpointsQuery } from '../../interfaces';
 
 const escapeStringRegexp = require('escape-string-regexp');
 
@@ -58,7 +58,12 @@ function _constructQuery(
   query: {
     schemaField: string;
     operation: number;
-    comparisonField: { type: string; value: any; like: LikeComparison };
+    comparisonField: {
+      type: string;
+      value: any;
+      like?: boolean;
+      caseSensitiveLike?: boolean;
+    };
   },
   inputs: {
     name: string;
@@ -87,6 +92,7 @@ function _constructQuery(
       query.operation,
       params[query.comparisonField.value],
       query.comparisonField.like,
+      query.comparisonField.caseSensitiveLike,
     );
   } else if (query.comparisonField.type === 'Context') {
     if (isNil(context)) {
@@ -104,6 +110,7 @@ function _constructQuery(
       query.operation,
       context,
       query.comparisonField.like,
+      query.comparisonField.caseSensitiveLike,
     );
   } else {
     return _translateQuery(
@@ -111,6 +118,7 @@ function _constructQuery(
       query.operation,
       query.comparisonField.value,
       query.comparisonField.like,
+      query.comparisonField.caseSensitiveLike,
     );
   }
 }
@@ -119,7 +127,8 @@ function _translateQuery(
   schemaField: string,
   operation: number,
   comparisonField: any,
-  like?: LikeComparison,
+  like?: boolean,
+  caseSensitiveLike?: boolean,
 ) {
   //   EQUAL: 0, //'equal to'
   //   NEQUAL: 1, //'not equal to'
@@ -135,7 +144,7 @@ function _translateQuery(
     comparisonField = { $date: comparisonField };
   } else if (like) {
     comparisonField = escapeStringRegexp(comparisonField);
-    if (like === 'sensitive') {
+    if (caseSensitiveLike) {
       comparisonField = { $like: `%${comparisonField}%` };
     } else {
       comparisonField = { $ilike: `%${comparisonField}%` };

--- a/modules/database/src/handlers/CustomEndpoints/utils.ts
+++ b/modules/database/src/handlers/CustomEndpoints/utils.ts
@@ -1,7 +1,7 @@
 import moment from 'moment';
 import { isNil } from 'lodash';
 import { Indexable } from '@conduitplatform/grpc-sdk';
-import { CustomEndpointsQuery } from '../../interfaces';
+import { CustomEndpointsQuery, LikeComparison } from '../../interfaces';
 
 const escapeStringRegexp = require('escape-string-regexp');
 
@@ -58,7 +58,7 @@ function _constructQuery(
   query: {
     schemaField: string;
     operation: number;
-    comparisonField: { type: string; value: any; like: boolean };
+    comparisonField: { type: string; value: any; like: LikeComparison };
   },
   inputs: {
     name: string;
@@ -119,7 +119,7 @@ function _translateQuery(
   schemaField: string,
   operation: number,
   comparisonField: any,
-  like?: boolean,
+  like?: LikeComparison,
 ) {
   //   EQUAL: 0, //'equal to'
   //   NEQUAL: 1, //'not equal to'
@@ -135,7 +135,11 @@ function _translateQuery(
     comparisonField = { $date: comparisonField };
   } else if (like) {
     comparisonField = escapeStringRegexp(comparisonField);
-    comparisonField = { $regex: `.*${comparisonField}.*`, $options: 'i' };
+    if (like === 'sensitive') {
+      comparisonField = { $like: `%${comparisonField}%` }; // TODO: %abc% instead...
+    } else {
+      comparisonField = { $ilike: `%${comparisonField}%` };
+    }
   }
 
   switch (operation) {

--- a/modules/database/src/interfaces/CustomEndpointsQuery.ts
+++ b/modules/database/src/interfaces/CustomEndpointsQuery.ts
@@ -1,7 +1,10 @@
-export type LikeComparison = 'sensitive' | 'insensitive' | undefined;
-
 export interface CustomEndpointsQuery {
   schemaField: string;
   operation: number;
-  comparisonField: { type: string; value: any; like: LikeComparison };
+  comparisonField: {
+    type: string;
+    value: any;
+    like?: boolean;
+    caseSensitiveLike?: boolean;
+  };
 }

--- a/modules/database/src/interfaces/CustomEndpointsQuery.ts
+++ b/modules/database/src/interfaces/CustomEndpointsQuery.ts
@@ -1,5 +1,7 @@
+export type LikeComparison = 'sensitive' | 'insensitive' | undefined;
+
 export interface CustomEndpointsQuery {
   schemaField: string;
   operation: number;
-  comparisonField: { type: string; value: any; like: boolean };
+  comparisonField: { type: string; value: any; like: LikeComparison };
 }


### PR DESCRIPTION
This PR adds `$like` and `$ilike` operators, introducing support for case-insensitive SQL like comparisons.
Like-strings are now wrapped in `%` instead of `.*`. Eg: `.*abc.*` -> `%abc%`.

~~Custom endpoint queries are to be migrated over to the new format.~~
Custom endpoint syntax has been updated to remain compatible with legacy `{ like: boolean }`.
Specify `{ like: true, caseSensitiveLike: true }` for case-sensitive search.
This change does not affect the underlying `$like` / `$ilike` implementation. 

TODOs:
- [X] MongoDB implementation
- [X] Generic SQL implementation (based on `Sequelize.fn('lower')`)
- [X] Use `ILIKE` operator for PostgreSQL

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** <!--(check at least one)-->

- [X] Bugfix
- [X] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other (please describe)

**Does this PR introduce a breaking change?** <!-- (check one) -->

- [ ] Yes
- [X] No

Not a breaking change as custom endpoints are to be auto-migrated over.

**The PR fulfills these requirements:**

- [ ] It's submitted to the `main` branch
- [ ] When resolving a specific issue, it's referenced in the PR's description  (e.g. `fix #xxx`, where "xxx" is the issue number)

If adding a **new feature**, the PR's description includes:

- [X] A convincing reason for adding this feature <!-- to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it -->