### PR TITLE
fix(database): sql deleteOne/Many not returning deletion count

### DIFF
--- a/modules/database/src/adapters/sequelize-adapter/SequelizeSchema.ts
+++ b/modules/database/src/adapters/sequelize-adapter/SequelizeSchema.ts
@@ -444,9 +444,10 @@ export abstract class SequelizeSchema implements SchemaAdapter<ModelStatic<any>>
         ).concat(...this.includeRelations(parsingResult.requiredRelations, [])),
       })
       .then(docs => {
-        if (docs) {
-          return Promise.all(docs.map(doc => doc.destroy()));
-        }
+        return Promise.all(docs.map(doc => doc.destroy({ returning: true })));
+      })
+      .then(r => {
+        return { deletedCount: r.length };
       });
   }
 
@@ -477,7 +478,10 @@ export abstract class SequelizeSchema implements SchemaAdapter<ModelStatic<any>>
         ).concat(...this.includeRelations(parsingResult.requiredRelations, [])),
       })
       .then(doc => {
-        doc?.destroy();
+        return doc?.destroy({ returning: true });
+      })
+      .then(r => {
+        return { deletedCount: r ? 1 : 0 };
       });
   }
 


### PR DESCRIPTION
Fixes SQL `deleteOne`/`deleteMany` not returning deletion count.
Syntax is somewhat sketchy as Sequelize's `{ returning: true }` wouldn't behave as expected (plus it wouldn't work on all db engines anyway).

**What kind of change does this PR introduce?** <!--(check at least one)-->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other (please describe)

**Does this PR introduce a breaking change?** <!-- (check one) -->

- [ ] Yes
- [X] No

<!-- If yes, please describe the impact and migration path for existing applications. -->

**The PR fulfills these requirements:**

- [ ] It's submitted to the `main` branch
- [ ] When resolving a specific issue, it's referenced in the PR's description  (e.g. `fix #xxx`, where "xxx" is the issue number)
