### PR TITLE
refactor(database): removal of mssql & additional parsing for json queries in sql

### DIFF
--- a/modules/database/package.json
+++ b/modules/database/package.json
@@ -36,8 +36,7 @@
     "pg-hstore": "^2.3.4",
     "sequelize": "^6.21.2",
     "sequelize-auto": "^0.8.8",
-    "sqlite3": "^5.1.4",
-    "tedious": "^15.1.2"
+    "sqlite3": "^5.1.4"
   },
   "directories": {
     "lib": "src"

--- a/modules/database/src/Database.ts
+++ b/modules/database/src/Database.ts
@@ -82,7 +82,7 @@ export default class DatabaseModule extends ManagedModule<void> {
       this._activeAdapter = new MongooseAdapter(dbUri);
     } else if (dbType === 'postgres') {
       this._activeAdapter = new PostgresAdapter(dbUri);
-    } else if (['sql', 'mariadb', 'mysql', 'sqlite', 'mssql'].includes(dbType)) {
+    } else if (['mariadb', 'mysql', 'sqlite'].includes(dbType)) {
       this._activeAdapter = new SQLAdapter(dbUri);
     } else {
       throw new Error('Database type not supported');

--- a/modules/database/src/adapters/sequelize-adapter/index.ts
+++ b/modules/database/src/adapters/sequelize-adapter/index.ts
@@ -26,7 +26,7 @@ export abstract class SequelizeAdapter<
 > extends DatabaseAdapter<T> {
   connectionUri: string;
   sequelize!: Sequelize;
-  readonly SUPPORTED_DIALECTS = ['postgres', 'mysql', 'sqlite', 'mariadb', 'mssql'];
+  readonly SUPPORTED_DIALECTS = ['postgres', 'mysql', 'sqlite', 'mariadb'];
 
   constructor(connectionUri: string) {
     super();

--- a/modules/database/src/adapters/sequelize-adapter/parser/index.ts
+++ b/modules/database/src/adapters/sequelize-adapter/parser/index.ts
@@ -139,13 +139,7 @@ function _parseQuery(
             associations?.associations,
             associations?.associationsDirectory,
           ) ||
-          handleEmbeddedJson(
-            key,
-            matched,
-            dialect,
-            relations.relations,
-            associations?.associations,
-          ) || { [key]: matched }),
+          handleEmbeddedJson(key, matched, dialect) || { [key]: matched }),
       });
     }
   }
@@ -202,20 +196,13 @@ function handleRelation(
   }
 }
 
-function handleEmbeddedJson(
-  key: string,
-  value: any,
-  dialect: string,
-  relations: { [key: string]: SequelizeSchema | SequelizeSchema[] },
-  associations?: { [key: string]: SequelizeSchema | SequelizeSchema[] },
-) {
+function handleEmbeddedJson(key: string, value: any, dialect: string) {
   if (dialect === 'postgres' || key.indexOf('.') === -1) return null;
   const keyArray = key.split('.');
-  if (
-    (relations && relations[keyArray[0]]) ||
-    (associations && associations[keyArray[0]])
-  )
-    return null;
+  // Should not be a relation or association
+  // if ((relations && relations[keyArray[0]]) ||
+  //   (associations && associations[keyArray[0]]))
+  //   return null;
   let embeddedJson = {};
   for (let i = keyArray.length - 1; i >= 0; i--) {
     const k = i !== 0 ? `"${keyArray[i]}"` : keyArray[i];

--- a/modules/database/src/adapters/sequelize-adapter/parser/index.ts
+++ b/modules/database/src/adapters/sequelize-adapter/parser/index.ts
@@ -139,7 +139,13 @@ function _parseQuery(
             associations?.associations,
             associations?.associationsDirectory,
           ) ||
-          handleEmbeddedJson(key, matched, dialect) || { [key]: matched }),
+          handleEmbeddedJson(
+            key,
+            matched,
+            dialect,
+            relations.relations,
+            associations?.associations,
+          ) || { [key]: matched }),
       });
     }
   }
@@ -196,9 +202,20 @@ function handleRelation(
   }
 }
 
-function handleEmbeddedJson(key: string, value: any, dialect: string) {
+function handleEmbeddedJson(
+  key: string,
+  value: any,
+  dialect: string,
+  relations: { [key: string]: SequelizeSchema | SequelizeSchema[] },
+  associations?: { [key: string]: SequelizeSchema | SequelizeSchema[] },
+) {
   if (dialect === 'postgres' || key.indexOf('.') === -1) return null;
   const keyArray = key.split('.');
+  if (
+    (relations && relations[keyArray[0]]) ||
+    (associations && associations[keyArray[0]])
+  )
+    return null;
   let embeddedJson = {};
   for (let i = keyArray.length - 1; i >= 0; i--) {
     const k = i !== 0 ? `"${keyArray[i]}"` : keyArray[i];

--- a/modules/database/src/adapters/sequelize-adapter/parser/index.ts
+++ b/modules/database/src/adapters/sequelize-adapter/parser/index.ts
@@ -138,7 +138,8 @@ function _parseQuery(
             matched,
             associations?.associations,
             associations?.associationsDirectory,
-          ) || { [key]: matched }),
+          ) ||
+          handleEmbeddedJson(key, matched, dialect) || { [key]: matched }),
       });
     }
   }
@@ -193,6 +194,18 @@ function handleRelation(
       return { [`${key}Id`]: value };
     }
   }
+}
+
+function handleEmbeddedJson(key: string, value: any, dialect: string) {
+  if (dialect === 'postgres' || key.indexOf('.') === -1) return null;
+  const keyArray = key.split('.');
+  let embeddedJson = {};
+  for (let i = keyArray.length - 1; i >= 0; i--) {
+    const k = i !== 0 ? `"${keyArray[i]}"` : keyArray[i];
+    const v = i !== keyArray.length - 1 ? embeddedJson : value;
+    embeddedJson = { [k]: v };
+  }
+  return embeddedJson;
 }
 
 export function parseQuery(

--- a/modules/database/src/adapters/sequelize-adapter/utils/collectionUtils.ts
+++ b/modules/database/src/adapters/sequelize-adapter/utils/collectionUtils.ts
@@ -37,8 +37,6 @@ export function tableFetch(
       return sqliteTableFetch(sequelize, sqlSchemaName);
     case 'mariadb':
       return mysqlTableFetch(sequelize, sqlSchemaName);
-    case 'mssql':
-      return mysqlTableFetch(sequelize, sqlSchemaName);
     default:
       return Promise.resolve([]);
   }


### PR DESCRIPTION
With this PR, now, querying an embedded json key in sql (besides postgres that didn't have any problem anyway) is possible.
Mssql won't be supported (at least for now), due to lack of proper JSON datatype.  

**What kind of change does this PR introduce?** <!--(check at least one)-->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [x] Refactor
- [ ] Build-related changes
- [ ] Other (please describe)

**Does this PR introduce a breaking change?** <!-- (check one) -->

- [ ] Yes
- [x] No

<!-- If yes, please describe the impact and migration path for existing applications. -->

**The PR fulfills these requirements:**

- [x] It's submitted to the `main` branch
- [ ] When resolving a specific issue, it's referenced in the PR's description  (e.g. `fix #xxx`, where "xxx" is the issue number)

