### PR TITLE
fix(database): fix mongoose & sequelize parseQuery & query param types

### DIFF
--- a/modules/database/src/adapters/mongoose-adapter/parser/index.ts
+++ b/modules/database/src/adapters/mongoose-adapter/parser/index.ts
@@ -8,7 +8,7 @@ export function parseQuery(query: ParsedQuery): ParsedQuery {
   } else if (
     typeof query === 'object' &&
     query !== null &&
-    !(query instanceof Types.ObjectId)
+    !(query instanceof Types.ObjectId || query instanceof Buffer || query instanceof Date)
   ) {
     const parsedQuery: Indexable = {};
     Object.keys(query).forEach(key => {

--- a/modules/database/src/adapters/mongoose-adapter/parser/index.ts
+++ b/modules/database/src/adapters/mongoose-adapter/parser/index.ts
@@ -1,10 +1,15 @@
 import { Indexable } from '@conduitplatform/grpc-sdk';
 import { ParsedQuery } from '../../../interfaces';
+import { Types } from 'mongoose';
 
 export function parseQuery(query: ParsedQuery): ParsedQuery {
   if (Array.isArray(query)) {
     return query.map(item => parseQuery(item));
-  } else if (typeof query === 'object' && query !== null) {
+  } else if (
+    typeof query === 'object' &&
+    query !== null &&
+    !(query instanceof Types.ObjectId)
+  ) {
     const parsedQuery: Indexable = {};
     Object.keys(query).forEach(key => {
       if (key === '$like') {

--- a/modules/database/src/adapters/sequelize-adapter/parser/index.ts
+++ b/modules/database/src/adapters/sequelize-adapter/parser/index.ts
@@ -100,7 +100,14 @@ function _parseQuery(
   },
 ) {
   const parsed: Indexable = isArray(query) ? [] : {};
-  if (isString(query) || isBoolean(query) || isNumber(query)) return query;
+  if (
+    isString(query) ||
+    isBoolean(query) ||
+    isNumber(query) ||
+    query instanceof Buffer ||
+    query instanceof Date
+  )
+    return query;
   for (const key in query) {
     if (key === '$or') {
       Object.assign(parsed, {

--- a/modules/database/src/admin/index.ts
+++ b/modules/database/src/admin/index.ts
@@ -163,8 +163,8 @@ export class AdminHandlers {
         action: ConduitRouteActions.DELETE,
         description: `Deletes queried schemas.`,
         queryParams: {
-          ids: [ConduitString.Required], // handler array check is still required
-          deleteData: ConduitBoolean.Required,
+          ids: { type: [TYPE.String], required: true }, // handler array check is still required
+          deleteData: { type: TYPE.Boolean, required: true },
         },
       },
       new ConduitRouteReturnDefinition('DeleteSchemas', 'String'),
@@ -583,7 +583,7 @@ export class AdminHandlers {
           id: { type: RouteOptionType.String, required: true },
         },
         queryParams: {
-          indexNames: [ConduitString.Required],
+          indexNames: { type: [TYPE.String], required: true },
         },
       },
       new ConduitRouteReturnDefinition('deleteIndexes', 'String'),


### PR DESCRIPTION
**Fixes:** 
- ObjectId cast error when parsing query in mongoose
- The type of [ConduitString.Required] in query params causes a param to be returned as a string and not as an array of strings


**What kind of change does this PR introduce?** <!--(check at least one)-->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other (please describe)

**Does this PR introduce a breaking change?** <!-- (check one) -->

- [ ] Yes
- [x] No

<!-- If yes, please describe the impact and migration path for existing applications. -->

**The PR fulfills these requirements:**

- [x] It's submitted to the `main` branch
- [ ] When resolving a specific issue, it's referenced in the PR's description  (e.g. `fix #xxx`, where "xxx" is the issue number)

