### PR TITLE
feat(grpc-sdk): url remap object config

### DIFF
--- a/libraries/grpc-sdk/src/classes/ModuleManager.ts
+++ b/libraries/grpc-sdk/src/classes/ModuleManager.ts
@@ -1,9 +1,4 @@
-import ConduitGrpcSdk, {
-  ConfigController,
-  getJsonEnv,
-  Indexable,
-  ManagedModule,
-} from '..';
+import ConduitGrpcSdk, { ConfigController, Indexable, ManagedModule } from '..';
 
 const convictConfigParser = (config: Indexable) => {
   if (typeof config === 'object') {

--- a/libraries/grpc-sdk/src/classes/ModuleManager.ts
+++ b/libraries/grpc-sdk/src/classes/ModuleManager.ts
@@ -1,4 +1,9 @@
-import ConduitGrpcSdk, { ConfigController, Indexable, ManagedModule } from '..';
+import ConduitGrpcSdk, {
+  ConfigController,
+  getJsonEnv,
+  Indexable,
+  ManagedModule,
+} from '..';
 
 const convictConfigParser = (config: Indexable) => {
   if (typeof config === 'object') {
@@ -26,7 +31,6 @@ export class ModuleManager<T> {
     this.serviceAddress =
       // @compat (v0.15): SERVICE_IP -> SERVICE_URL
       process.env.SERVICE_URL || process.env.SERVICE_IP || '0.0.0.0:' + this.servicePort;
-    const urlRemap = process.env.URL_REMAP;
     try {
       this.grpcSdk = new ConduitGrpcSdk(
         process.env.CONDUIT_SERVER,
@@ -35,7 +39,6 @@ export class ModuleManager<T> {
         },
         module.name,
         true,
-        urlRemap,
       );
     } catch {
       throw new Error('Failed to initialize grpcSdk');

--- a/libraries/grpc-sdk/src/index.ts
+++ b/libraries/grpc-sdk/src/index.ts
@@ -22,7 +22,7 @@ import { CompatServiceDefinition } from 'nice-grpc/lib/service-definitions';
 import { ConduitModule } from './classes/ConduitModule';
 import { Client } from 'nice-grpc';
 import { status } from '@grpc/grpc-js';
-import { sleep } from './utilities';
+import { getJsonEnv, sleep } from './utilities';
 import {
   HealthCheckResponse_ServingStatus,
   HealthDefinition,
@@ -38,7 +38,6 @@ import { ConduitLogger, setupLoki } from './utilities/Logger';
 import winston from 'winston';
 import path from 'path';
 import { ConduitMetrics } from './metrics';
-import fs from 'fs-extra';
 import { ClusterOptions, RedisOptions } from 'ioredis';
 
 export default class ConduitGrpcSdk {
@@ -362,22 +361,7 @@ export default class ConduitGrpcSdk {
   initializeEventBus(): Promise<EventBus> {
     let promise = Promise.resolve();
     if (process.env.REDIS_CONFIG) {
-      const redisConfig = process.env.REDIS_CONFIG;
-      let redisJson;
-      if (redisConfig.startsWith('{')) {
-        try {
-          redisJson = JSON.parse(redisConfig);
-        } catch (e) {
-          throw new Error('Invalid JSON in REDIS_CONFIG');
-        }
-      } else {
-        try {
-          redisJson = JSON.parse(fs.readFileSync(redisConfig).toString());
-        } catch (e) {
-          throw new Error('Invalid JSON in REDIS_CONFIG');
-        }
-      }
-      this._redisDetails = redisJson;
+      this._redisDetails = getJsonEnv('REDIS_CONFIG');
     } else if (process.env.REDIS_HOST && process.env.REDIS_PORT) {
       this._redisDetails = {
         host: process.env.REDIS_HOST!,

--- a/libraries/grpc-sdk/src/index.ts
+++ b/libraries/grpc-sdk/src/index.ts
@@ -378,11 +378,7 @@ export default class ConduitGrpcSdk {
         }
       }
       this._redisDetails = redisJson;
-    } else if (
-      process.env.REDIS_HOST &&
-      process.env.REDIS_PORT &&
-      !process.env.REDIS_CONFIG
-    ) {
+    } else if (process.env.REDIS_HOST && process.env.REDIS_PORT) {
       this._redisDetails = {
         host: process.env.REDIS_HOST!,
         port: parseInt(process.env.REDIS_PORT!, 10),

--- a/libraries/grpc-sdk/src/index.ts
+++ b/libraries/grpc-sdk/src/index.ts
@@ -410,7 +410,7 @@ export default class ConduitGrpcSdk {
         if (this._redisDetails!.hasOwnProperty('nodes')) {
           this._redisManager = new RedisManager(this._redisDetails);
         } else {
-          const redisHost = this.urlRemap ?? (this._redisDetails as RedisOptions).host;
+          const redisHost = (this._redisDetails as RedisOptions).host;
           this._redisManager = new RedisManager({
             ...this._redisDetails,
             host: redisHost,

--- a/libraries/grpc-sdk/src/utilities/env.ts
+++ b/libraries/grpc-sdk/src/utilities/env.ts
@@ -1,6 +1,10 @@
 import fs from 'fs-extra';
 
-export function getJsonEnv(envName: string, envValue?: string) {
+export function getJsonEnv<JsonFormat extends object>(
+  envName: string,
+  envValue?: string,
+  handleString?: (value: string) => object,
+): JsonFormat | undefined {
   envValue ??= process.env[envName];
   if (!envValue) return undefined;
   let jsonConfig: object;
@@ -14,8 +18,12 @@ export function getJsonEnv(envName: string, envValue?: string) {
     try {
       jsonConfig = JSON.parse(fs.readFileSync(envValue).toString());
     } catch (e) {
-      throw new Error('Invalid JSON in REDIS_CONFIG');
+      if (handleString) {
+        jsonConfig = handleString(envValue);
+      } else {
+        throw new Error(`Invalid JSON in ${envName}`);
+      }
     }
   }
-  return jsonConfig;
+  return jsonConfig as JsonFormat;
 }

--- a/libraries/grpc-sdk/src/utilities/env.ts
+++ b/libraries/grpc-sdk/src/utilities/env.ts
@@ -1,0 +1,21 @@
+import fs from 'fs-extra';
+
+export function getJsonEnv(envName: string, envValue?: string) {
+  envValue ??= process.env[envName];
+  if (!envValue) return undefined;
+  let jsonConfig: object;
+  if (envValue.startsWith('{')) {
+    try {
+      jsonConfig = JSON.parse(envValue);
+    } catch (e) {
+      throw new Error(`Invalid JSON in ${envName}`);
+    }
+  } else {
+    try {
+      jsonConfig = JSON.parse(fs.readFileSync(envValue).toString());
+    } catch (e) {
+      throw new Error('Invalid JSON in REDIS_CONFIG');
+    }
+  }
+  return jsonConfig;
+}

--- a/libraries/grpc-sdk/src/utilities/env.ts
+++ b/libraries/grpc-sdk/src/utilities/env.ts
@@ -16,7 +16,7 @@ export function getJsonEnv<JsonFormat extends object>(
     }
   } else {
     try {
-      jsonConfig = JSON.parse(fs.readFileSync(envValue).toString());
+      jsonConfig = JSON.parse(fs.readFileSync(envValue).toString().trimEnd());
     } catch (e) {
       if (handleString) {
         jsonConfig = handleString(envValue);

--- a/libraries/grpc-sdk/src/utilities/index.ts
+++ b/libraries/grpc-sdk/src/utilities/index.ts
@@ -1,3 +1,4 @@
+export * from './env';
 export * from './linearBackoffTimeout';
 export * from './merge';
 export * from './sleep';


### PR DESCRIPTION
This PR updates url remapping functionality so as to support explicit domain remap pairs.
The `URL_REMAP` env optionally accepts any of the following:
- a stringified JSON object containing the mappings (format: `{ [url: string]: string }` where url key is the original url and value is the remapped url)
- a path string pointing to a JSON file containing the same configuration as above
- a **single** host address value to remap every client with, keeping the original port (mirroring previous implementation)

Configuration may explicitly contain a wildcard key (`*`) to remap every non-explicitly mapped host address (preserving original ports). This may be used in conjunction with explicit remap pairs.

Url remap functionality no longer affects Redis host configuration (use `REDIS_HOST`/`REDIS_CONFIG` instead).

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** <!--(check at least one)-->

- [ ] Bugfix
- [X] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other (please describe)

**Does this PR introduce a breaking change?** <!-- (check one) -->

- [ ] Yes
- [X] No

<!-- If yes, please describe the impact and migration path for existing applications. -->

**The PR fulfills these requirements:**

- [X] It's submitted to the `main` branch
- [ ] When resolving a specific issue, it's referenced in the PR's description  (e.g. `fix #xxx`, where "xxx" is the issue number)

If adding a **new feature**, the PR's description includes:

- [X] A convincing reason for adding this feature <!-- to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it -->
