### PR TITLE
fix(database): sql like/ilike customEndpoint queries regexp escaping

### DIFF
--- a/modules/database/src/adapters/mongoose-adapter/parser/index.ts
+++ b/modules/database/src/adapters/mongoose-adapter/parser/index.ts
@@ -2,6 +2,8 @@ import { Indexable } from '@conduitplatform/grpc-sdk';
 import { ParsedQuery } from '../../../interfaces';
 import { Types } from 'mongoose';
 
+const escapeStringRegexp = require('escape-string-regexp');
+
 export function parseQuery(query: ParsedQuery): ParsedQuery {
   if (Array.isArray(query)) {
     return query.map(item => parseQuery(item));
@@ -14,9 +16,9 @@ export function parseQuery(query: ParsedQuery): ParsedQuery {
     if (Object.keys(query).length === 0) return query;
     Object.keys(query).forEach(key => {
       if (key === '$like') {
-        parsedQuery.$regex = query.$like.replace(/%/g, '.*');
+        parsedQuery.$regex = escapeStringRegexp(query.$like).replace(/%/g, '.*');
       } else if (key === '$ilike') {
-        parsedQuery.$regex = query.$ilike.replace(/%/g, '.*');
+        parsedQuery.$regex = escapeStringRegexp(query.$ilike).replace(/%/g, '.*');
         parsedQuery.$options = 'i';
       } else {
         parsedQuery[key] = parseQuery(query[key]);

--- a/modules/database/src/handlers/CustomEndpoints/utils.ts
+++ b/modules/database/src/handlers/CustomEndpoints/utils.ts
@@ -3,8 +3,6 @@ import { isNil } from 'lodash';
 import { Indexable } from '@conduitplatform/grpc-sdk';
 import { CustomEndpointsQuery } from '../../interfaces';
 
-const escapeStringRegexp = require('escape-string-regexp');
-
 interface Inputs {
   name: string;
   type: string;
@@ -141,7 +139,6 @@ function _translateQuery(
   if (isDate) {
     comparisonField = { $date: comparisonField };
   } else if (like) {
-    comparisonField = escapeStringRegexp(comparisonField);
     if (caseSensitiveLike) {
       comparisonField = { $like: `%${comparisonField}%` };
     } else {


### PR DESCRIPTION
This PR resolves PostgreSQL/SQL like/ilike customEndpoint queries escaping regexp characters.

**What kind of change does this PR introduce?** <!--(check at least one)-->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other (please describe)

**Does this PR introduce a breaking change?** <!-- (check one) -->

- [ ] Yes
- [X] No

<!-- If yes, please describe the impact and migration path for existing applications. -->

**The PR fulfills these requirements:**

- [X] It's submitted to the `main` branch
- [ ] When resolving a specific issue, it's referenced in the PR's description  (e.g. `fix #xxx`, where "xxx" is the issue number)
