### PR TITLE
fix(module-tools,storage):  gRPC int64 long types

### DIFF
--- a/libraries/grpc-sdk/build.sh
+++ b/libraries/grpc-sdk/build.sh
@@ -13,6 +13,7 @@ protoc \
   --ts_proto_opt=esModuleInterop=true \
   --ts_proto_opt=outputServices=generic-definitions,exportCommonSymbols=false,useExactTypes=false \
   --ts_proto_out=./ \
+  --ts_proto_opt=forceLong=long \
   ./*.proto
 
 # Initialize the content of the index.ts file

--- a/libraries/module-tools/build.sh
+++ b/libraries/module-tools/build.sh
@@ -11,6 +11,7 @@ protoc \
   --ts_proto_opt=esModuleInterop=true \
   --ts_proto_opt=outputServices=generic-definitions,useExactTypes=false \
   --ts_proto_out=./ \
+  --ts_proto_opt=forceLong=long \
   ./*.proto
 
 echo "Cleaning up protofiles"

--- a/libraries/module-tools/src/helpers/GrpcHelper.ts
+++ b/libraries/module-tools/src/helpers/GrpcHelper.ts
@@ -4,6 +4,8 @@ import {
   ServerCredentials,
   UntypedServiceImplementation,
 } from '@grpc/grpc-js';
+import { util as protoUtil } from 'protobufjs';
+import Long = protoUtil.Long;
 
 const protoLoader = require('@grpc/proto-loader');
 
@@ -34,7 +36,7 @@ export function addServiceToServer(
 ) {
   const packageDefinition = protoLoader.loadSync(protoPath, {
     keepCase: true,
-    longs: String,
+    longs: Long,
     enums: String,
     defaults: true,
     oneofs: true,

--- a/libraries/testing-tools/build.sh
+++ b/libraries/testing-tools/build.sh
@@ -12,6 +12,7 @@ protoc \
   --ts_proto_opt=esModuleInterop=true \
   --ts_proto_opt=outputServices=generic-definitions,useExactTypes=false \
   --ts_proto_out=./ \
+  --ts_proto_opt=forceLong=long \
   ./*.proto
 
 echo "Cleaning up protofiles"

--- a/modules/authentication/build.sh
+++ b/modules/authentication/build.sh
@@ -11,7 +11,8 @@ protoc \
   --plugin=../../node_modules/.bin/protoc-gen-ts_proto\
   --ts_proto_opt=esModuleInterop=true \
   --ts_proto_out=./ \
-  --ts_proto_opt=outputServices=generic-definitions,useExactTypes=false\
+  --ts_proto_opt=outputServices=generic-definitions,useExactTypes=false \
+  --ts_proto_opt=forceLong=long \
   ./*.proto
 
 echo "Cleaning up folders"

--- a/modules/authorization/build.sh
+++ b/modules/authorization/build.sh
@@ -11,7 +11,8 @@ protoc \
   --plugin=../../node_modules/.bin/protoc-gen-ts_proto\
   --ts_proto_opt=esModuleInterop=true \
   --ts_proto_out=./ \
-  --ts_proto_opt=outputServices=generic-definitions,useExactTypes=false\
+  --ts_proto_opt=outputServices=generic-definitions,useExactTypes=false \
+  --ts_proto_opt=forceLong=long \
   ./*.proto
 
 echo "Cleaning up folders"

--- a/modules/chat/build.sh
+++ b/modules/chat/build.sh
@@ -10,7 +10,8 @@ protoc \
   --plugin=../../node_modules/.bin/protoc-gen-ts_proto\
   --ts_proto_opt=esModuleInterop=true \
   --ts_proto_out=./ \
-  --ts_proto_opt=outputServices=generic-definitions,useExactTypes=false\
+  --ts_proto_opt=outputServices=generic-definitions,useExactTypes=false \
+  --ts_proto_opt=forceLong=long \
   ./*.proto
 
 echo "Cleaning up folders"

--- a/modules/database/build.sh
+++ b/modules/database/build.sh
@@ -11,7 +11,8 @@ protoc \
   --plugin=../../node_modules/.bin/protoc-gen-ts_proto\
   --ts_proto_opt=esModuleInterop=true \
   --ts_proto_out=./ \
-  --ts_proto_opt=outputServices=generic-definitions,useExactTypes=false\
+  --ts_proto_opt=outputServices=generic-definitions,useExactTypes=false \
+  --ts_proto_opt=forceLong=long \
   ./*.proto
 
 echo "Cleaning up folders"

--- a/modules/email/build.sh
+++ b/modules/email/build.sh
@@ -11,7 +11,8 @@ protoc \
   --plugin=../../node_modules/.bin/protoc-gen-ts_proto\
   --ts_proto_opt=esModuleInterop=true \
   --ts_proto_out=./ \
-  --ts_proto_opt=outputServices=generic-definitions,useExactTypes=false\
+  --ts_proto_opt=outputServices=generic-definitions,useExactTypes=false \
+  --ts_proto_opt=forceLong=long \
   ./*.proto
 
 echo "Cleaning up folders"

--- a/modules/functions/build.sh
+++ b/modules/functions/build.sh
@@ -11,7 +11,8 @@ protoc \
   --plugin=../../node_modules/.bin/protoc-gen-ts_proto\
   --ts_proto_opt=esModuleInterop=true \
   --ts_proto_out=./ \
-  --ts_proto_opt=outputServices=generic-definitions,useExactTypes=false\
+  --ts_proto_opt=outputServices=generic-definitions,useExactTypes=false \
+  --ts_proto_opt=forceLong=long \
   ./*.proto
 
 echo "Cleaning up folders"

--- a/modules/router/build.sh
+++ b/modules/router/build.sh
@@ -11,7 +11,8 @@ protoc \
   --plugin=../../node_modules/.bin/protoc-gen-ts_proto\
   --ts_proto_opt=esModuleInterop=true \
   --ts_proto_out=./ \
-  --ts_proto_opt=outputServices=generic-definitions,useExactTypes=false\
+  --ts_proto_opt=outputServices=generic-definitions,useExactTypes=false \
+  --ts_proto_opt=forceLong=long \
   ./*.proto
 
 echo "Cleaning up folders"

--- a/modules/sms/build.sh
+++ b/modules/sms/build.sh
@@ -11,7 +11,8 @@ protoc \
   --plugin=../../node_modules/.bin/protoc-gen-ts_proto\
   --ts_proto_opt=esModuleInterop=true \
   --ts_proto_out=./ \
-  --ts_proto_opt=outputServices=generic-definitions,useExactTypes=false\
+  --ts_proto_opt=outputServices=generic-definitions,useExactTypes=false \
+  --ts_proto_opt=forceLong=long \
   ./*.proto
 
 echo "Cleaning up folders"

--- a/modules/storage/build.sh
+++ b/modules/storage/build.sh
@@ -11,7 +11,8 @@ protoc \
   --plugin=../../node_modules/.bin/protoc-gen-ts_proto\
   --ts_proto_opt=esModuleInterop=true \
   --ts_proto_out=./ \
-  --ts_proto_opt=outputServices=generic-definitions,useExactTypes=false\
+  --ts_proto_opt=outputServices=generic-definitions,useExactTypes=false \
+  --ts_proto_opt=forceLong=long \
   ./*.proto
 
 echo "Cleaning up folders"

--- a/modules/storage/src/Storage.ts
+++ b/modules/storage/src/Storage.ts
@@ -214,7 +214,10 @@ export default class Storage extends ManagedModule<Config> {
         code: status.INTERNAL,
         message: 'File handlers not initiated',
       });
-    const request = this.storageParamAdapter.createParsedRouterRequest(call.request);
+    const request = this.storageParamAdapter.createParsedRouterRequest({
+      ...call.request,
+      size: call.request.size?.toNumber(),
+    });
     const result = await this._fileHandlers.createFileUploadUrl(request);
     const response = this.storageParamAdapter.getFileByUrlResponse(result);
     callback(null, response);
@@ -229,7 +232,10 @@ export default class Storage extends ManagedModule<Config> {
         code: status.INTERNAL,
         message: 'File handlers not initiated',
       });
-    const request = this.storageParamAdapter.createParsedRouterRequest(call.request);
+    const request = this.storageParamAdapter.createParsedRouterRequest({
+      ...call.request,
+      size: call.request.size?.toNumber(),
+    });
     const result = await this._fileHandlers.updateFileUploadUrl(request);
     const response = this.storageParamAdapter.getFileByUrlResponse(result);
     callback(null, response);

--- a/packages/commons/build.sh
+++ b/packages/commons/build.sh
@@ -10,7 +10,8 @@ protoc \
   --plugin=../../node_modules/.bin/protoc-gen-ts_proto\
   --ts_proto_opt=esModuleInterop=true \
   --ts_proto_out=./ \
-  --ts_proto_opt=outputServices=generic-definitions,useExactTypes=false\
+  --ts_proto_opt=outputServices=generic-definitions,useExactTypes=false \
+  --ts_proto_opt=forceLong=long \
   ./*.proto
 
 echo "Cleaning up folders"


### PR DESCRIPTION
This PR fixes int64 types being typed as `number` without getting implicitly decoded from `string` long repr.
These proto fields are now treated as `protobufjs::Long` instead and explicitly decoded as required.
This resolves `Storage`'s `createFileByUrl`/`updateFileByUrl` `size` fields causing a db create operation crash due to invalid data types in cases where `size` does not get auto-cast.

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** <!--(check at least one)-->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other (please describe)

**Does this PR introduce a breaking change?** <!-- (check one) -->

- [ ] Yes
- [X] No

<!-- If yes, please describe the impact and migration path for existing applications. -->

**The PR fulfills these requirements:**

- [X] It's submitted to the `main` branch
- [ ] When resolving a specific issue, it's referenced in the PR's description  (e.g. `fix #xxx`, where "xxx" is the issue number)
