### PR TITLE
fix(functions,sms): admin route registration before module registration errors

### DIFF
--- a/modules/sms/src/Sms.ts
+++ b/modules/sms/src/Sms.ts
@@ -42,10 +42,6 @@ export default class Sms extends ManagedModule<Config> {
     this.updateHealth(HealthCheckStatus.UNKNOWN, true);
   }
 
-  async onServerStart() {
-    this.adminRouter = new AdminHandlers(this.grpcServer, this.grpcSdk, this._provider);
-  }
-
   async preConfig(config: any) {
     if (
       isNil(config.active) ||
@@ -61,6 +57,7 @@ export default class Sms extends ManagedModule<Config> {
     if (!ConfigController.getInstance().config.active) {
       this.updateHealth(HealthCheckStatus.NOT_SERVING);
     } else {
+      this.adminRouter = new AdminHandlers(this.grpcServer, this.grpcSdk, this._provider);
       await this.initProvider();
     }
   }


### PR DESCRIPTION
This PR resolves a startup error where admin route registrations would be attempted before module service registration, resulting in `getModuleUrlByName()` failing to retrieve the service url.

**What kind of change does this PR introduce?** <!--(check at least one)-->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other (please describe)

**Does this PR introduce a breaking change?** <!-- (check one) -->

- [ ] Yes
- [X] No

<!-- If yes, please describe the impact and migration path for existing applications. -->

**The PR fulfills these requirements:**

- [X] It's submitted to the `main` branch
- [ ] When resolving a specific issue, it's referenced in the PR's description  (e.g. `fix #xxx`, where "xxx" is the issue number)