### PR TITLE
feat(storage): recursive folder creation

### DIFF
--- a/modules/storage/src/Storage.ts
+++ b/modules/storage/src/Storage.ts
@@ -4,7 +4,6 @@ import ConduitGrpcSdk, {
   GrpcRequest,
   GrpcResponse,
   HealthCheckStatus,
-  ParsedRouterRequest,
 } from '@conduitplatform/grpc-sdk';
 import AppConfigSchema, { Config } from './config';
 import { AdminRoutes } from './admin';

--- a/modules/storage/src/admin/index.ts
+++ b/modules/storage/src/admin/index.ts
@@ -18,7 +18,6 @@ import { status } from '@grpc/grpc-js';
 import { isNil } from 'lodash';
 import { FileHandlers } from '../handlers/file';
 import { _StorageContainer, _StorageFolder, File } from '../models';
-import { deepCreateFolders } from '../utils';
 
 export class AdminRoutes {
   private readonly routingManager: RoutingManager;
@@ -88,11 +87,10 @@ export class AdminRoutes {
         throw new GrpcError(status.INTERNAL, e.message);
       });
     }
-    const createdFolders = await deepCreateFolders(
+    const createdFolders = await this.fileHandlers.findOrCreateFolders(
       name,
       container,
       isPublic,
-      this.fileHandlers,
       () => {
         throw new GrpcError(status.ALREADY_EXISTS, 'Folder already exists');
       },

--- a/modules/storage/src/admin/index.ts
+++ b/modules/storage/src/admin/index.ts
@@ -18,6 +18,7 @@ import { status } from '@grpc/grpc-js';
 import { isNil } from 'lodash';
 import { FileHandlers } from '../handlers/file';
 import { _StorageContainer, _StorageFolder, File } from '../models';
+import { normalizeFolderPath } from '../utils';
 
 export class AdminRoutes {
   private readonly routingManager: RoutingManager;
@@ -78,7 +79,11 @@ export class AdminRoutes {
   }
 
   async createFolder(call: ParsedRouterRequest): Promise<UnparsedRouterResponse> {
-    const { name, container, isPublic } = call.request.params;
+    const { container, isPublic } = call.request.params;
+    const name = normalizeFolderPath(call.request.params.name);
+    if (name === '/') {
+      throw new GrpcError(status.INVALID_ARGUMENT, 'Folder name may not be empty');
+    }
     const containerDocument = await _StorageContainer
       .getInstance()
       .findOne({ name: container });

--- a/modules/storage/src/handlers/file.ts
+++ b/modules/storage/src/handlers/file.ts
@@ -284,7 +284,7 @@ export class FileHandlers {
   ): Promise<_StorageFolder[]> {
     const createdFolders: _StorageFolder[] = [];
     let folder: _StorageFolder | null = null;
-    await deepPathHandler(folderPath, false, true, async (folderPath, isLast) => {
+    await deepPathHandler(folderPath, async (folderPath, isLast) => {
       folder = await _StorageFolder
         .getInstance()
         .findOne({ name: folderPath, container });

--- a/modules/storage/src/utils/index.ts
+++ b/modules/storage/src/utils/index.ts
@@ -1,6 +1,7 @@
 import { GetUserCommand, IAMClient } from '@aws-sdk/client-iam';
 import { StorageConfig } from '../interfaces';
 import { isNil } from 'lodash';
+import path from 'path';
 
 export async function streamToBuffer(readableStream: any): Promise<Buffer> {
   return new Promise((resolve, reject) => {
@@ -29,4 +30,34 @@ export async function getAwsAccountId(config: StorageConfig) {
     throw new Error('Unable to get AWS account ID');
   }
   return userId;
+}
+
+function getNestedPaths(
+  inputPath: string,
+  leadingSlash: boolean,
+  trailingSlash: boolean,
+): string[] {
+  const paths: string[] = [];
+  const normalizedPath = path.normalize(inputPath.trim()).replace(/^\/|\/$/g, '');
+  const prefix = leadingSlash ? '/' : '';
+  const suffix = trailingSlash ? '/' : '';
+  const pathSegments = normalizedPath.split('/');
+  let currentPath = '';
+  for (const segment of pathSegments) {
+    currentPath = path.join(currentPath, segment);
+    paths.push(`${prefix}${currentPath}${suffix}`);
+  }
+  return paths;
+}
+
+export async function deepPathHandler(
+  inputPath: string,
+  leadingPath: boolean,
+  trailingPath: boolean,
+  handler: (inputPath: string, isLast: boolean) => Promise<void>,
+): Promise<void> {
+  const paths = getNestedPaths(inputPath, leadingPath, trailingPath);
+  for (let i = 0; i < paths.length; i++) {
+    await handler(paths[i], i === paths.length - 1);
+  }
 }

--- a/modules/storage/src/utils/index.ts
+++ b/modules/storage/src/utils/index.ts
@@ -32,9 +32,9 @@ export async function getAwsAccountId(config: StorageConfig) {
   return userId;
 }
 
-export function normalizeFolderPath(folderPath: string) {
-  const strippedPath = path.normalize(folderPath.trim()).replace(/^\/|\/$/g, '');
-  return strippedPath === '' ? '/' : `/${strippedPath}/`;
+export function normalizeFolderPath(folderPath?: string) {
+  if (!folderPath || folderPath.trim() === '' || folderPath.trim() === '/') return '/';
+  return `/${path.normalize(folderPath.trim()).replace(/^\/|\/$/g, '')}/`;
 }
 
 function getNestedPaths(
@@ -43,14 +43,18 @@ function getNestedPaths(
   trailingSlash: boolean,
 ): string[] {
   const paths: string[] = [];
-  const normalizedPath = path.normalize(inputPath.trim()).replace(/^\/|\/$/g, '');
-  const prefix = leadingSlash ? '/' : '';
-  const suffix = trailingSlash ? '/' : '';
-  const pathSegments = normalizedPath.split('/');
-  let currentPath = '';
-  for (const segment of pathSegments) {
-    currentPath = path.join(currentPath, segment);
-    paths.push(`${prefix}${currentPath}${suffix}`);
+  const strippedPath = !inputPath.trim()
+    ? ''
+    : path.normalize(inputPath.trim()).replace(/^\/|\/$/g, '');
+  if (strippedPath !== '') {
+    const prefix = leadingSlash ? '/' : '';
+    const suffix = trailingSlash ? '/' : '';
+    const pathSegments = strippedPath.split('/');
+    let currentPath = '';
+    for (const segment of pathSegments) {
+      currentPath = path.join(currentPath, segment);
+      paths.push(`${prefix}${currentPath}${suffix}`);
+    }
   }
   return paths;
 }

--- a/modules/storage/src/utils/index.ts
+++ b/modules/storage/src/utils/index.ts
@@ -34,7 +34,7 @@ export async function getAwsAccountId(config: StorageConfig) {
 
 export function normalizeFolderPath(folderPath?: string) {
   if (!folderPath || folderPath.trim() === '' || folderPath.trim() === '/') return '/';
-  return `/${path.normalize(folderPath.trim()).replace(/^\/|\/$/g, '')}/`;
+  return `${path.normalize(folderPath.trim()).replace(/^\/|\/$/g, '')}/`;
 }
 
 function getNestedPaths(

--- a/modules/storage/src/utils/index.ts
+++ b/modules/storage/src/utils/index.ts
@@ -1,7 +1,5 @@
 import { GetUserCommand, IAMClient } from '@aws-sdk/client-iam';
 import { StorageConfig } from '../interfaces';
-import { _StorageFolder } from '../models';
-import { FileHandlers } from '../handlers/file';
 import { isNil } from 'lodash';
 import path from 'path';
 
@@ -34,6 +32,11 @@ export async function getAwsAccountId(config: StorageConfig) {
   return userId;
 }
 
+export function normalizeFolderPath(folderPath: string) {
+  const strippedPath = path.normalize(folderPath.trim()).replace(/^\/|\/$/g, '');
+  return strippedPath === '' ? '/' : `/${strippedPath}/`;
+}
+
 function getNestedPaths(
   inputPath: string,
   leadingSlash: boolean,
@@ -62,35 +65,4 @@ export async function deepPathHandler(
   for (let i = 0; i < paths.length; i++) {
     await handler(paths[i], i === paths.length - 1);
   }
-}
-
-export async function deepCreateFolders(
-  inputPath: string,
-  container: string,
-  isPublic: string,
-  fileHandlers: FileHandlers,
-  lastExistsHandler?: () => void,
-): Promise<_StorageFolder[]> {
-  const createdFolders: _StorageFolder[] = [];
-  let folder: _StorageFolder | null = null;
-  await deepPathHandler(inputPath, false, true, async (folderPath, isLast) => {
-    folder = await _StorageFolder.getInstance().findOne({ name: folderPath, container });
-    if (isNil(folder)) {
-      folder = await _StorageFolder.getInstance().create({
-        name: folderPath,
-        container,
-        isPublic,
-      });
-      createdFolders.push(folder);
-      const exists = await fileHandlers.storage
-        .container(container)
-        .folderExists(folderPath);
-      if (!exists) {
-        await fileHandlers.storage.container(container).createFolder(folderPath);
-      }
-    } else if (isLast) {
-      lastExistsHandler?.();
-    }
-  });
-  return createdFolders;
 }

--- a/modules/storage/src/utils/index.ts
+++ b/modules/storage/src/utils/index.ts
@@ -37,23 +37,17 @@ export function normalizeFolderPath(folderPath?: string) {
   return `${path.normalize(folderPath.trim()).replace(/^\/|\/$/g, '')}/`;
 }
 
-function getNestedPaths(
-  inputPath: string,
-  leadingSlash: boolean,
-  trailingSlash: boolean,
-): string[] {
+function getNestedPaths(inputPath: string): string[] {
   const paths: string[] = [];
   const strippedPath = !inputPath.trim()
     ? ''
     : path.normalize(inputPath.trim()).replace(/^\/|\/$/g, '');
   if (strippedPath !== '') {
-    const prefix = leadingSlash ? '/' : '';
-    const suffix = trailingSlash ? '/' : '';
     const pathSegments = strippedPath.split('/');
     let currentPath = '';
     for (const segment of pathSegments) {
       currentPath = path.join(currentPath, segment);
-      paths.push(`${prefix}${currentPath}${suffix}`);
+      paths.push(`${currentPath}/`);
     }
   }
   return paths;
@@ -61,11 +55,9 @@ function getNestedPaths(
 
 export async function deepPathHandler(
   inputPath: string,
-  leadingPath: boolean,
-  trailingPath: boolean,
   handler: (inputPath: string, isLast: boolean) => Promise<void>,
 ): Promise<void> {
-  const paths = getNestedPaths(inputPath, leadingPath, trailingPath);
+  const paths = getNestedPaths(inputPath);
   for (let i = 0; i < paths.length; i++) {
     await handler(paths[i], i === paths.length - 1);
   }


### PR DESCRIPTION
This PR introduces recursive folder creation via explicit folder creation, file creation and file updates across all supported API flows.

Folders are always suffixed by a slash and never prefixed by one.
Implicit folders default to a base `/` (which is never actually "created" anywhere).
The above is in line with how we already handled folders.

We should probably update `admin.createFolder()`'s input signature (`name` to `folderPath` or sth, perhaps also returning an array of created folders) at some point to reflect that, but I refrained from breaking the API at this point.


**What kind of change does this PR introduce?** <!--(check at least one)-->

- [ ] Bugfix
- [X] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other (please describe)

**Does this PR introduce a breaking change?** <!-- (check one) -->

- [ ] Yes
- [X] No

<!-- If yes, please describe the impact and migration path for existing applications. -->

**The PR fulfills these requirements:**

- [X] It's submitted to the `main` branch
- [ ] When resolving a specific issue, it's referenced in the PR's description  (e.g. `fix #xxx`, where "xxx" is the issue number)