### PR TITLE
fix(grpc-sdk): ConduitQueryParams type disallowing required object-formatted array param definition

### DIFF
--- a/libraries/grpc-sdk/src/interfaces/Route.ts
+++ b/libraries/grpc-sdk/src/interfaces/Route.ts
@@ -18,7 +18,8 @@ export type ConduitUrlParam = AllowedTypes | { type: AllowedTypes; required?: bo
 export type ConduitQueryParam =
   | ConduitUrlParam
   | AllowedTypes[]
-  | { type: AllowedTypes[]; required?: boolean };
+  | { type: AllowedTypes[]; required: boolean }
+  | { type: AllowedTypes; required?: boolean }[];
 
 export type ConduitUrlParams = {
   [field in string]: ConduitUrlParam;


### PR DESCRIPTION
There's currently 2 ways to define a route param field representing an array of types (assuming str):
- a) `[{ type: [TYPE.String], required: true }]` (shorthand: `[ConduitString.Required]`)
- b) `{ type: [TYPE.String], required: true }`

We generally use both of these interchangeably, with Swagger and GraphQL both currently interpreting them in their own fashion. Namely:
- Swagger handles `(a)` as `string` and `(b)` as `required string[]`
- GraphQL handles both as `[String]!`

We should eventually fix the parsers and consistently infer `(a)` as a nullable array of required strings (aka as in GQL: `[String!]`) and `(b)` as a non-null array of strings (aka `[String]!`) across transports and query/body params.

This PR resolves `ConduitQueryParams` not accepting `(a)` on a type-level.

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** <!--(check at least one)-->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other (please describe)

**Does this PR introduce a breaking change?** <!-- (check one) -->

- [ ] Yes
- [X] No

<!-- If yes, please describe the impact and migration path for existing applications. -->

**The PR fulfills these requirements:**

- [X] It's submitted to the `main` branch
- [ ] When resolving a specific issue, it's referenced in the PR's description  (e.g. `fix #xxx`, where "xxx" is the issue number)
