### PR TITLE
fix(email): EmailTemplate model subject/body SQL field size

### DIFF
--- a/modules/email/src/models/EmailTemplate.schema.ts
+++ b/modules/email/src/models/EmailTemplate.schema.ts
@@ -1,4 +1,9 @@
-import { ConduitModel, DatabaseProvider, TYPE } from '@conduitplatform/grpc-sdk';
+import {
+  ConduitModel,
+  DatabaseProvider,
+  SQLDataType,
+  TYPE,
+} from '@conduitplatform/grpc-sdk';
 import { ConduitActiveSchema } from '@conduitplatform/module-tools';
 
 const schema: ConduitModel = {
@@ -11,10 +16,12 @@ const schema: ConduitModel = {
   subject: {
     type: TYPE.String,
     required: true,
+    sqlType: SQLDataType.TEXT,
   },
   body: {
     type: TYPE.String,
     required: true,
+    sqlType: SQLDataType.TEXT,
   },
   variables: {
     type: [TYPE.String],


### PR DESCRIPTION
This PR allows for larger email template `subject` and `body` field values in SQL databases.

While most email clients impose a fairly smaller subject size, I decided on also bumping that one to accommodate for `handlebars` formatting that could severely enlarge the pre-formatted text as stored in the database.

**What kind of change does this PR introduce?** <!--(check at least one)-->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other (please describe)

**Does this PR introduce a breaking change?** <!-- (check one) -->

- [ ] Yes
- [X] No

<!-- If yes, please describe the impact and migration path for existing applications. -->

**The PR fulfills these requirements:**

- [X] It's submitted to the `main` branch
- [ ] When resolving a specific issue, it's referenced in the PR's description  (e.g. `fix #xxx`, where "xxx" is the issue number)