### PR TITLE
fix(database): authorized SQL findMany() queries

### DIFF
--- a/modules/database/src/adapters/mongoose-adapter/MongooseSchema.ts
+++ b/modules/database/src/adapters/mongoose-adapter/MongooseSchema.ts
@@ -260,7 +260,7 @@ export class MongooseSchema extends SchemaAdapter<Model<any>> {
       scope?: string;
     },
   ): Promise<any> {
-    let { parsedQuery, modified } = await this.getPaginatedAuthorizedQuery(
+    const { query: filter, modified } = await this.getPaginatedAuthorizedQuery(
       'read',
       parseQuery(this.parseStringToQuery(query)),
       options?.userId,
@@ -269,10 +269,10 @@ export class MongooseSchema extends SchemaAdapter<Model<any>> {
       options?.limit,
       options?.sort,
     );
-    if (isNil(parsedQuery)) {
+    if (isNil(filter)) {
       return [];
     }
-    let finalQuery = this.model.find(parsedQuery, options?.select);
+    let finalQuery = this.model.find(filter, options?.select);
     if (!isNil(options?.skip) && !modified) {
       finalQuery = finalQuery.skip(options?.skip!);
     }

--- a/modules/database/src/adapters/sequelize-adapter/SequelizeSchema.ts
+++ b/modules/database/src/adapters/sequelize-adapter/SequelizeSchema.ts
@@ -369,27 +369,26 @@ export class SequelizeSchema extends SchemaAdapter<ModelStatic<any>> {
       scope?: string;
     },
   ) {
-    const { filter, parsingResult } = parseQueryFilter(
+    const { query: filter, modified } = await this.getPaginatedAuthorizedQuery(
+      'read',
+      query as Indexable,
+      options?.userId,
+      options?.scope,
+      options?.skip,
+      options?.limit,
+      options?.sort,
+    );
+    if (isNil(filter)) {
+      return [];
+    }
+    const { filter: parsedFilter, parsingResult } = parseQueryFilter(
       this,
-      this.parseStringToQuery(query),
+      this.parseStringToQuery(filter),
       {
         populate: options?.populate,
         select: options?.select,
       },
     );
-    const { parsedQuery: parsedFilter, modified } =
-      await this.getPaginatedAuthorizedQuery(
-        'read',
-        filter,
-        options?.userId,
-        options?.scope,
-        options?.skip,
-        options?.limit,
-        options?.sort,
-      );
-    if (isNil(parsedFilter)) {
-      return [];
-    }
     const findOptions: FindOptions = {
       where: parsedFilter,
       nest: true,


### PR DESCRIPTION
This PR resolves an SQL adapter issue where authorized `findMany()` calls would parse native Sequelize queries (containing operator symbols as opposed to object keys), resulting in the final queries getting stripped off of any such conditions (eg `$and`, `$or` etc).

**What kind of change does this PR introduce?** <!--(check at least one)-->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other (please describe)

**Does this PR introduce a breaking change?** <!-- (check one) -->

- [ ] Yes
- [X] No

<!-- If yes, please describe the impact and migration path for existing applications. -->

**The PR fulfills these requirements:**

- [X] It's submitted to the `main` branch
- [ ] When resolving a specific issue, it's referenced in the PR's description  (e.g. `fix #xxx`, where "xxx" is the issue number)
