### PR TITLE
fix(database): permission checks for extensions

### DIFF
--- a/modules/database/src/Database.ts
+++ b/modules/database/src/Database.ts
@@ -442,7 +442,13 @@ export default class DatabaseModule extends ManagedModule<void> {
     const { schemaName } = call.request;
     try {
       const schemaAdapter = this._activeAdapter.getSchemaModel(schemaName);
-      if (!(await canModify(moduleName, schemaAdapter.model))) {
+      if (
+        !(await canModify(
+          moduleName,
+          schemaAdapter.model,
+          JSON.parse(call.request.query),
+        ))
+      ) {
         return callback({
           code: status.PERMISSION_DENIED,
           message: `Module ${moduleName} is not authorized to modify ${schemaName} entries!`,
@@ -553,7 +559,13 @@ export default class DatabaseModule extends ManagedModule<void> {
     const { schemaName } = call.request;
     try {
       const schemaAdapter = this._activeAdapter.getSchemaModel(schemaName);
-      if (!(await canModify(moduleName, schemaAdapter.model))) {
+      if (
+        !(await canModify(
+          moduleName,
+          schemaAdapter.model,
+          JSON.parse(call.request.query),
+        ))
+      ) {
         return callback({
           code: status.PERMISSION_DENIED,
           message: `Module ${moduleName} is not authorized to modify ${schemaName} entries!`,
@@ -590,7 +602,13 @@ export default class DatabaseModule extends ManagedModule<void> {
     const { schemaName } = call.request;
     try {
       const schemaAdapter = this._activeAdapter.getSchemaModel(schemaName);
-      if (!(await canModify(moduleName, schemaAdapter.model))) {
+      if (
+        !(await canModify(
+          moduleName,
+          schemaAdapter.model,
+          JSON.parse(call.request.query),
+        ))
+      ) {
         return callback({
           code: status.PERMISSION_DENIED,
           message: `Module ${moduleName} is not authorized to modify ${schemaName} entries!`,

--- a/modules/database/src/permissions/index.ts
+++ b/modules/database/src/permissions/index.ts
@@ -23,14 +23,14 @@ export async function canModify(moduleName: string, schema: Schema, data?: Index
       'ExtensionOnly' &&
     data
   ) {
-    let extensionFields = schema.originalSchema.extensions
+    const extensionFields = schema.originalSchema.extensions
       .filter(
         (extension: DeclaredSchemaExtension) =>
           extension.ownerModule === moduleName || extension.ownerModule === 'database',
       )
       .map((extension: DeclaredSchemaExtension) => extension.fields)
       .map((fields: ConduitModel) => Object.keys(fields));
-    let dataFields = Object.keys(data);
+    const dataFields = Object.keys(data);
     return dataFields.every((field: string) => extensionFields.includes(field));
   }
   return false;

--- a/modules/database/src/permissions/index.ts
+++ b/modules/database/src/permissions/index.ts
@@ -24,6 +24,10 @@ export async function canModify(moduleName: string, schema: Schema, data?: Index
     data
   ) {
     let extensionFields = schema.originalSchema.extensions
+      .filter(
+        (extension: DeclaredSchemaExtension) =>
+          extension.ownerModule === moduleName || extension.ownerModule === 'database',
+      )
       .map((extension: DeclaredSchemaExtension) => extension.fields)
       .map((fields: ConduitModel) => Object.keys(fields));
     let dataFields = Object.keys(data);

--- a/modules/database/src/permissions/index.ts
+++ b/modules/database/src/permissions/index.ts
@@ -1,22 +1,35 @@
-import { Schema } from '../interfaces';
+import { DeclaredSchemaExtension, Schema } from '../interfaces';
+import { ConduitModel, Indexable } from '@conduitplatform/grpc-sdk';
 
 export async function canCreate(moduleName: string, schema: Schema) {
   if (moduleName === 'database' && schema.originalSchema.name === '_DeclaredSchema')
     return true;
   return (
     schema.originalSchema.ownerModule === moduleName ||
-    schema.originalSchema.modelOptions.conduit!.permissions!.extendable
+    schema.originalSchema.modelOptions.conduit!.permissions!.canCreate
   );
 }
 
-export async function canModify(moduleName: string, schema: Schema) {
+export async function canModify(moduleName: string, schema: Schema, data?: Indexable) {
   if (moduleName === 'database' && schema.originalSchema.name === '_DeclaredSchema')
     return true;
-  return (
+  if (
     schema.originalSchema.ownerModule === moduleName ||
     schema.originalSchema.modelOptions.conduit!.permissions!.canModify === 'Everything'
-    // TODO: Handle 'ExtensionOnly' once we get extensions
-  );
+  )
+    return true;
+  if (
+    schema.originalSchema.modelOptions.conduit!.permissions!.canModify ===
+      'ExtensionOnly' &&
+    data
+  ) {
+    let extensionFields = schema.originalSchema.extensions
+      .map((extension: DeclaredSchemaExtension) => extension.fields)
+      .map((fields: ConduitModel) => Object.keys(fields));
+    let dataFields = Object.keys(data);
+    return dataFields.every((field: string) => extensionFields.includes(field));
+  }
+  return false;
 }
 
 export async function canDelete(moduleName: string, schema: Schema) {


### PR DESCRIPTION
fix(database): canCreate permission check using wrong field
fix(database): canModify not checking for extension permissions
refactor(database): rpc queries use new canModify arg when modify but not when replace

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/ConduitPlatform/Conduit/blob/main/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** <!--(check at least one)-->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other (please describe)

**Does this PR introduce a breaking change?** <!-- (check one) -->

- [ ] Yes
- [x] No

<!-- If yes, please describe the impact and migration path for existing applications. -->

**The PR fulfills these requirements:**

- [x] It's submitted to the `main` branch
- [x] When resolving a specific issue, it's referenced in the PR's description  (e.g. `fix #xxx`, where "xxx" is the issue number)

If adding a **new feature**, the PR's description includes:

- [x] A convincing reason for adding this feature <!-- to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it -->

**Other information:**
