### PR TITLE
fix(database): SQL create/createMany relation parsing, group unwrapping

### DIFF
--- a/modules/database/src/adapters/sequelize-adapter/SequelizeSchema.ts
+++ b/modules/database/src/adapters/sequelize-adapter/SequelizeSchema.ts
@@ -279,6 +279,7 @@ export class SequelizeSchema extends SchemaAdapter<ModelStatic<any>> {
     const t = await this.sequelize.transaction({ type: Transaction.TYPES.IMMEDIATE });
     for (let i = 0; i < parsedQuery.length; i++) {
       processCreateQuery(parsedQuery[i], this.objectPaths);
+      extractRelationsModification(this, parsedQuery[i]);
     }
     const docs = await this.model
       .bulkCreate(parsedQuery, { transaction: t })

--- a/modules/database/src/adapters/sequelize-adapter/SequelizeSchema.ts
+++ b/modules/database/src/adapters/sequelize-adapter/SequelizeSchema.ts
@@ -256,8 +256,9 @@ export class SequelizeSchema extends SchemaAdapter<ModelStatic<any>> {
         }
         return doc;
       })
-      .then(doc => doc.toJSON())
-      .then(doc => parseCreateRelations(doc, this.extractedRelations))
+      .then(doc =>
+        doc ? parseCreateRelations(doc.toJSON(), this.extractedRelations) : doc,
+      )
       .catch(err => {
         if (!transactionProvided) {
           t!.rollback();

--- a/modules/database/src/adapters/sequelize-adapter/SequelizeSchema.ts
+++ b/modules/database/src/adapters/sequelize-adapter/SequelizeSchema.ts
@@ -264,6 +264,7 @@ export class SequelizeSchema extends SchemaAdapter<ModelStatic<any>> {
         }
         throw err;
       });
+    unwrap(obj, this.objectPaths);
     await this.addPermissionToData(obj, options);
     return obj;
   }
@@ -291,7 +292,9 @@ export class SequelizeSchema extends SchemaAdapter<ModelStatic<any>> {
       .then(docs => {
         const parsedDocs: Indexable[] = [];
         for (const doc of docs) {
-          parsedDocs.push(parseCreateRelations(doc.toJSON(), this.extractedRelations));
+          const document = parseCreateRelations(doc.toJSON(), this.extractedRelations);
+          unwrap(document, this.objectPaths);
+          parsedDocs.push(document);
         }
         return parsedDocs;
       })

--- a/modules/database/src/adapters/sequelize-adapter/parser/index.ts
+++ b/modules/database/src/adapters/sequelize-adapter/parser/index.ts
@@ -411,7 +411,7 @@ export function parseCreateRelations(
   for (const relation in relations) {
     const dbName = `${relation}Id`;
     if (doc.hasOwnProperty(dbName)) {
-      doc[relation] = { _id: doc[dbName] };
+      doc[relation] = doc[dbName];
       delete doc[dbName];
     }
   }

--- a/modules/database/src/adapters/sequelize-adapter/parser/index.ts
+++ b/modules/database/src/adapters/sequelize-adapter/parser/index.ts
@@ -403,3 +403,17 @@ export function renameRelations(
     exclude,
   };
 }
+
+export function parseCreateRelations(
+  doc: Indexable,
+  relations: { [key: string]: SequelizeSchema | SequelizeSchema[] },
+) {
+  for (const relation in relations) {
+    const dbName = `${relation}Id`;
+    if (doc.hasOwnProperty(dbName)) {
+      doc[relation] = { _id: doc[dbName] };
+      delete doc[dbName];
+    }
+  }
+  return doc;
+}

--- a/modules/database/src/adapters/sequelize-adapter/utils/pathUtils.ts
+++ b/modules/database/src/adapters/sequelize-adapter/utils/pathUtils.ts
@@ -73,13 +73,13 @@ export function unwrap(
   keyMapping: {
     [key: string]: { parentKey: string; childKey: string };
   },
-  relations: {
+  relations?: {
     [key: string]: SequelizeSchema | SequelizeSchema[];
   },
 ) {
   for (const key in object) {
     if (potentialNesting(object[key])) {
-      if (relations.hasOwnProperty(key)) {
+      if (relations?.hasOwnProperty(key)) {
         unwrap(
           object[key],
           (relations[key] as SequelizeSchema).objectPaths,
@@ -91,7 +91,7 @@ export function unwrap(
       unwrapNestedKeys(object[key], keyMapping);
     }
     if (isArray(object[key])) {
-      if (relations.hasOwnProperty(key)) {
+      if (relations?.hasOwnProperty(key)) {
         for (const element of object[key]) {
           unwrap(
             element,


### PR DESCRIPTION
This PR resolves the following issues in SQL:
- `createMany()` not parsing relation field inputs (eg `user -> `userId`)
- `create()`/`createMany()` not reverse parsing relation field responses
- `create()`/`createMany()` not reverse parsing group field responses (eg `group_field` -> `{ group: { field: ... } }`)

**What kind of change does this PR introduce?** <!--(check at least one)-->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other (please describe)

**Does this PR introduce a breaking change?** <!-- (check one) -->

- [ ] Yes
- [X] No

<!-- If yes, please describe the impact and migration path for existing applications. -->

**The PR fulfills these requirements:**

- [X] It's submitted to the `main` branch
- [ ] When resolving a specific issue, it's referenced in the PR's description  (e.g. `fix #xxx`, where "xxx" is the issue number)