### PR TITLE
fix(database): _parseQuery() dropping query fields

### DIFF
--- a/modules/database/src/adapters/sequelize-adapter/parser/index.ts
+++ b/modules/database/src/adapters/sequelize-adapter/parser/index.ts
@@ -117,7 +117,8 @@ function _parseQuery(
     isBoolean(query) ||
     isNumber(query) ||
     query instanceof Buffer ||
-    query instanceof Date
+    query instanceof Date ||
+    query === null
   )
     return query;
   for (const key in query) {


### PR DESCRIPTION
Eg: `{ foo: { $eq: null }}` -> `{}`

**What kind of change does this PR introduce?** <!--(check at least one)-->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other (please describe)

**Does this PR introduce a breaking change?** <!-- (check one) -->

- [ ] Yes
- [X] No

<!-- If yes, please describe the impact and migration path for existing applications. -->

**The PR fulfills these requirements:**

- [X] It's submitted to the `main` branch
- [ ] When resolving a specific issue, it's referenced in the PR's description  (e.g. `fix #xxx`, where "xxx" is the issue number)