### PR TITLE
fix(database): schema/extension creation timestamp field values mismatch

### DIFF
--- a/modules/database/src/adapters/DatabaseAdapter.ts
+++ b/modules/database/src/adapters/DatabaseAdapter.ts
@@ -323,12 +323,13 @@ export abstract class DatabaseAdapter<T extends Schema> {
     if (extIndex === -1 && extFieldsCount === 0) {
       return Promise.resolve(schema as unknown as Schema); // @dirty-type-cast
     } else if (extIndex === -1) {
+      const date = new Date(); // TODO FORMAT
       // Create Extension
       schema.extensions.push({
         fields: extFields,
         ownerModule: extOwner,
-        createdAt: new Date(), // TODO FORMAT
-        updatedAt: new Date(), // TODO FORMAT
+        createdAt: date,
+        updatedAt: date,
       });
     } else {
       if (extFieldsCount === 0) {

--- a/modules/database/src/adapters/mongoose-adapter/MongooseSchema.ts
+++ b/modules/database/src/adapters/mongoose-adapter/MongooseSchema.ts
@@ -70,11 +70,7 @@ export class MongooseSchema extends SchemaAdapter<Model<any>> {
     },
   ) {
     await this.createPermissionCheck(options?.userId, options?.scope);
-    const parsedQuery = {
-      ...this.parseStringToQuery(query),
-      createdAt: new Date(),
-      updatedAt: new Date(),
-    };
+    const parsedQuery = this.parseStringToQuery(query);
 
     const obj = await this.model.create(parsedQuery).then(r => r.toObject());
     await this.addPermissionToData(obj, options);
@@ -140,7 +136,6 @@ export class MongooseSchema extends SchemaAdapter<Model<any>> {
     if (parsedQuery.hasOwnProperty('$set')) {
       parsedQuery = parsedQuery['$set'];
     }
-    parsedQuery['updatedAt'] = new Date();
     let finalQuery = this.model.findOneAndReplace(parsedFilter!, parsedQuery, {
       new: true,
     });
@@ -171,7 +166,6 @@ export class MongooseSchema extends SchemaAdapter<Model<any>> {
     if (parsedQuery.hasOwnProperty('$set')) {
       parsedQuery = parsedQuery['$set'];
     }
-    parsedQuery['updatedAt'] = new Date();
     let finalQuery = this.model.findOneAndUpdate(parsedFilter!, parsedQuery, {
       new: true,
     });
@@ -205,7 +199,6 @@ export class MongooseSchema extends SchemaAdapter<Model<any>> {
     if (parsedQuery.hasOwnProperty('$set')) {
       parsedQuery = parsedQuery['$set'];
     }
-    parsedQuery['updatedAt'] = new Date();
     return this.model.updateMany(parsedFilter, parsedQuery).exec();
   }
 


### PR DESCRIPTION
This PR resolves the following `Database` timestamps (`createdAt`, `updatedAt`) issues:

1) SQL schema doc creation timestamp mismatch (`create()`, `createMany()`)
2) SQL/Mongo adapter operations explicitly setting timestamp field values regardless of `modelOptions.timestamp`
3) Schema extension creation timestamps mismatch

In regards to [2]:
`Sequelize` completely ignored explicit query timestamp values.
`Mongoose` would use provided values, but doesn't really require setting them anyway.

**What kind of change does this PR introduce?** <!--(check at least one)-->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other (please describe)

**Does this PR introduce a breaking change?** <!-- (check one) -->

- [ ] Yes
- [X] No

<!-- If yes, please describe the impact and migration path for existing applications. -->

**The PR fulfills these requirements:**

- [X] It's submitted to the `main` branch
- [ ] When resolving a specific issue, it's referenced in the PR's description  (e.g. `fix #xxx`, where "xxx" is the issue number)
