### PR TITLE
fix(hermes): Swagger/GraphQL parsers not pulling related db schema types

### DIFF
--- a/libraries/hermes/src/GraphQl/GraphQlParser.ts
+++ b/libraries/hermes/src/GraphQl/GraphQlParser.ts
@@ -163,6 +163,7 @@ export class GraphQlParser extends ConduitParser<ParseResult, ProcessingObject> 
     isArray: boolean,
   ): void {
     this.addToRelation(this.result, value);
+    this.requestedTypes.add(value);
     this.constructResolver(resolverName, name, true);
     processingObject.typeString +=
       name +

--- a/libraries/hermes/src/Rest/SwaggerParser.ts
+++ b/libraries/hermes/src/Rest/SwaggerParser.ts
@@ -187,6 +187,7 @@ export class SwaggerParser extends ConduitParser<ParseResult, ProcessingObject> 
         format: 'uuid',
       };
     } else {
+      this.requestedTypes.add(value);
       processingObject.properties[name] = {
         oneOf: [
           {


### PR DESCRIPTION
This PR resolves a Hermes bug where Swagger and GraphQL parsers wouldn't flag related schema types as requested, resulting in said types never getting fetched from the db schema type registry.

Example:
Create schemas A (no CRUD or custom endpoints), B (contains a relation to A and a CRUD endpoint).
Parsers will generate schemas for B, mentioning the relation to A, but A wouldn't get it's own type declared in the schema.

**What kind of change does this PR introduce?** <!--(check at least one)-->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other (please describe)

**Does this PR introduce a breaking change?** <!-- (check one) -->

- [ ] Yes
- [X] No

<!-- If yes, please describe the impact and migration path for existing applications. -->

**The PR fulfills these requirements:**

- [X] It's submitted to the `main` branch
- [ ] When resolving a specific issue, it's referenced in the PR's description  (e.g. `fix #xxx`, where "xxx" is the issue number)
