### PR TITLE
fix(core): config schema array field parsing

### DIFF
--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -6,7 +6,16 @@ export default function parseConfigSchema(schema: Indexable) {
   delete schema.doc;
   deepdash.eachDeep(schema, (value: any, key: string | number, parentValue: any) => {
     if (key === 'format') {
-      parentValue.type = value.charAt(0).toUpperCase() + value.slice(1);
+      if (
+        Object.keys(parentValue).includes('children') &&
+        Object.keys(parentValue['children']).includes('format')
+      ) {
+        // handle Arrays
+        parentValue.type = [parentValue['children'].format];
+        delete parentValue['children'];
+      } else {
+        parentValue.type = value.charAt(0).toUpperCase() + value.slice(1);
+      }
       delete parentValue[key];
     }
   });


### PR DESCRIPTION
This PR resolves an issue around config schema array field parsing.

Bug can be reproduced via [kon14/ConduitModuleExample](https://github.com/kon14/ConduitModuleExample/).
Config schema includes an array field (`illegalNames`) that results in the issue manifesting during route schema generation (GraphQL explicitly throws as the schema is atomically treated as invalid).

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** <!--(check at least one)-->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other (please describe)

**Does this PR introduce a breaking change?** <!-- (check one) -->

- [ ] Yes
- [X] No

<!-- If yes, please describe the impact and migration path for existing applications. -->

**The PR fulfills these requirements:**

- [X] It's submitted to the `main` branch
- [ ] When resolving a specific issue, it's referenced in the PR's description  (e.g. `fix #xxx`, where "xxx" is the issue number)
