### PR TITLE
feat(authorization): constructRelationIndexes() bulk variant

### DIFF
--- a/modules/authorization/src/controllers/index.controller.ts
+++ b/modules/authorization/src/controllers/index.controller.ts
@@ -448,7 +448,7 @@ export class IndexController {
 
     const objectDefinition = await ObjectIndex.getInstance().findOne({
       subject: object + '#' + action,
-      entity: { $in: [...subjectDefinition?.map(index => index.entity), '*'] },
+      entity: { $in: [...subjectDefinition.map(index => index.entity), '*'] },
     });
     return !!objectDefinition;
   }
@@ -467,7 +467,7 @@ export class IndexController {
     const objectDefinition = await ObjectIndex.getInstance().findMany(
       {
         subject: { $like: `${objectType}:%#${action}` },
-        entity: { $in: [...subjectDefinition?.map(index => index.entity), '*'] },
+        entity: { $in: [...subjectDefinition.map(index => index.entity), '*'] },
       },
       undefined,
       skip,
@@ -483,7 +483,7 @@ export class IndexController {
 
     return await ObjectIndex.getInstance().countDocuments({
       subject: { $like: `${objectType}:%#${action}` },
-      entity: { $in: [...subjectDefinition?.map(index => index.entity), '*'] },
+      entity: { $in: [...subjectDefinition.map(index => index.entity), '*'] },
     });
   }
 }

--- a/modules/authorization/src/controllers/index.controller.ts
+++ b/modules/authorization/src/controllers/index.controller.ts
@@ -166,19 +166,17 @@ export class IndexController {
         o => o.name === r.object.split(':')[0],
       )!;
       const permissions = Object.keys(objectDefinition.permissions);
-      const subjectType = r.subject.split(':')[0];
-      const subjectPermission = r.subject.split('#')[1];
       for (const permission of permissions) {
         const roles = objectDefinition.permissions[permission];
         for (const role of roles) {
           if (role.indexOf('->') === -1) {
             obj.push({
-              subject: r.object + '#' + permission,
-              subjectType,
-              subjectPermission,
-              entity: role === '*' ? `*` : `${r.object}#${role}`,
-              entityType: r.object.split(':')[0],
-              relation: role,
+              subject: `${r.object}#${permission}`,
+              subjectType: `${r.object}#${permission}`.split(':')[0],
+              subjectPermission: `${r.object}#${permission}`.split('#')[1],
+              entity: `${r.object}#${role}`,
+              entityType: `${r.object}#${role}`.split(':')[0],
+              relation: `${r.object}#${role}`.split('#')[1],
             });
           } else if (role !== '*') {
             const [relatedSubject, action] = role.split('->');
@@ -188,12 +186,12 @@ export class IndexController {
             );
             for (const connection of relationConnections) {
               obj.push({
-                subject: r.object + '#' + permission,
-                subjectType,
-                subjectPermission,
+                subject: `${r.object}#${permission}`,
+                subjectType: `${r.object}#${permission}`.split(':')[0],
+                subjectPermission: `${r.object}#${permission}`.split('#')[1],
                 entity: connection.entity,
                 entityType: connection.entity.split(':')[0],
-                relation: role,
+                relation: connection.entity.split('#')[1],
               });
             }
           }

--- a/modules/authorization/src/controllers/index.controller.ts
+++ b/modules/authorization/src/controllers/index.controller.ts
@@ -123,8 +123,7 @@ export class IndexController {
     const possibleConnectionSubjects = [];
     const actorsToCreate = [];
     for (const r of relations) {
-      const entities: string[] = [];
-      entities.push(`${r.object}#${r.relation}`);
+      const entity = `${r.object}#${r.relation}`;
       const objectDefinition = objectDefinitions.find(
         o => o.name === r.object.split(':')[0],
       )!;
@@ -141,21 +140,18 @@ export class IndexController {
         }
       }
       const found = await ActorIndex.getInstance().findMany({
-        $and: [{ subject: { $eq: r.subject } }, { entity: { $in: entities } }],
+        $and: [{ subject: r.subject }, { entity }],
       });
-      actorsToCreate.push(
-        ...entities.flatMap(e => {
-          const exists = found.find(f => f.entity === e);
-          if (exists) return [];
-          return {
-            subject: r.subject,
-            subjectType: r.subject.split(':')[0],
-            entity: e,
-            entityType: e.split(':')[0],
-            relation: r.relation,
-          };
-        }),
-      );
+      const exists = found.find(f => f.entity === entity);
+      if (!exists) {
+        actorsToCreate.push({
+          subject: r.subject,
+          subjectType: r.subject.split(':')[0],
+          entity,
+          entityType: entity.split(':')[0],
+          relation: r.relation,
+        });
+      }
     }
     await ActorIndex.getInstance().createMany(actorsToCreate);
     const possibleConnections = await ObjectIndex.getInstance().findMany({

--- a/modules/authorization/src/controllers/index.controller.ts
+++ b/modules/authorization/src/controllers/index.controller.ts
@@ -111,19 +111,22 @@ export class IndexController {
     }
   }
 
-  async constructRelationIndexes(subject: string, relation: string, resources: string[]) {
+  async constructRelationIndexes(
+    relations: { subject: string; relation: string; object: string }[],
+  ) {
     // Note: bulk variant does not perform recursive index creation!
-    const objectNames = resources.map(r => r.split(':')[0]);
+    const objectNames = relations.map(r => r.object.split(':')[0]);
     const objectDefinitions = await ResourceDefinition.getInstance().findMany({
       name: { $in: objectNames },
     });
     const obj = [];
     const possibleConnectionSubjects = [];
     const actorsToCreate = [];
-    for (const resource of resources) {
-      const entity = `${resource}#${relation}`;
+    for (const r of relations) {
+      const entities: string[] = [];
+      entities.push(`${r.object}#${r.relation}`);
       const objectDefinition = objectDefinitions.find(
-        o => o.name === resource.split(':')[0],
+        o => o.name === r.object.split(':')[0],
       )!;
       const permissions = Object.keys(objectDefinition.permissions);
       for (const permission of permissions) {
@@ -131,33 +134,36 @@ export class IndexController {
         for (const role of roles) {
           if (role.indexOf('->') !== -1 && role !== '*') {
             const [relatedSubject, action] = role.split('->');
-            if (relation === relatedSubject) {
-              possibleConnectionSubjects.push(`${subject}#${action}`);
+            if (r.relation === relatedSubject) {
+              possibleConnectionSubjects.push(`${r.subject}#${action}`);
             }
           }
         }
       }
       const found = await ActorIndex.getInstance().findMany({
-        $and: [{ subject }, { entity }],
+        $and: [{ subject: { $eq: r.subject } }, { entity: { $in: entities } }],
       });
-      const exists = found.find(f => f.entity === entity);
-      if (!exists) {
-        actorsToCreate.push({
-          subject,
-          subjectType: subject.split(':')[0],
-          entity,
-          entityType: entity.split(':')[0],
-          relation,
-        });
-      }
+      actorsToCreate.push(
+        ...entities.flatMap(e => {
+          const exists = found.find(f => f.entity === e);
+          if (exists) return [];
+          return {
+            subject: r.subject,
+            subjectType: r.subject.split(':')[0],
+            entity: e,
+            entityType: e.split(':')[0],
+            relation: r.relation,
+          };
+        }),
+      );
     }
     await ActorIndex.getInstance().createMany(actorsToCreate);
     const possibleConnections = await ObjectIndex.getInstance().findMany({
       subject: { $in: possibleConnectionSubjects },
     });
-    for (const resource of resources) {
+    for (const r of relations) {
       const objectDefinition = objectDefinitions.find(
-        o => o.name === resource.split(':')[0],
+        o => o.name === r.object.split(':')[0],
       )!;
       const permissions = Object.keys(objectDefinition.permissions);
       for (const permission of permissions) {
@@ -165,24 +171,24 @@ export class IndexController {
         for (const role of roles) {
           if (role.indexOf('->') === -1) {
             obj.push({
-              subject: `${resource}#${permission}`,
-              subjectType: `${resource}#${permission}`.split(':')[0],
-              subjectPermission: `${resource}#${permission}`.split('#')[1],
-              entity: `${resource}#${role}`,
-              entityType: `${resource}#${role}`.split(':')[0],
-              relation: `${resource}#${role}`.split('#')[1],
+              subject: `${r.object}#${permission}`,
+              subjectType: `${r.object}#${permission}`.split(':')[0],
+              subjectPermission: `${r.object}#${permission}`.split('#')[1],
+              entity: `${r.object}#${role}`,
+              entityType: `${r.object}#${role}`.split(':')[0],
+              relation: `${r.object}#${role}`.split('#')[1],
             });
           } else if (role !== '*') {
             const [relatedSubject, action] = role.split('->');
-            if (relation !== relatedSubject) continue;
+            if (r.relation !== relatedSubject) continue;
             const relationConnections = possibleConnections.filter(
-              connection => connection.subject === `${subject}#${action}`,
+              connection => connection.subject === `${r.subject}#${action}`,
             );
             for (const connection of relationConnections) {
               obj.push({
-                subject: `${resource}#${permission}`,
-                subjectType: `${resource}#${permission}`.split(':')[0],
-                subjectPermission: `${resource}#${permission}`.split('#')[1],
+                subject: `${r.object}#${permission}`,
+                subjectType: `${r.object}#${permission}`.split(':')[0],
+                subjectPermission: `${r.object}#${permission}`.split('#')[1],
                 entity: connection.entity,
                 entityType: connection.entity.split(':')[0],
                 relation: connection.entity.split('#')[1],

--- a/modules/authorization/src/controllers/relations.controller.ts
+++ b/modules/authorization/src/controllers/relations.controller.ts
@@ -1,6 +1,6 @@
 import ConduitGrpcSdk from '@conduitplatform/grpc-sdk';
 import { checkRelation, computeRelationTuple } from '../utils';
-import { ActorIndex, Relationship, ResourceDefinition } from '../models';
+import { Relationship, ResourceDefinition } from '../models';
 import { IndexController } from './index.controller';
 
 export class RelationsController {

--- a/modules/authorization/src/controllers/relations.controller.ts
+++ b/modules/authorization/src/controllers/relations.controller.ts
@@ -100,12 +100,7 @@ export class RelationsController {
       };
     });
     const relationDocs = await Relationship.getInstance().createMany(relations);
-    const relationEntries = relations.map(r => ({
-      subject: r.subject,
-      relation: r.relation,
-      object: r.resource,
-    }));
-    await this.indexController.constructRelationIndexes(relationEntries);
+    await this.indexController.constructRelationIndexes(subject, relation, resources);
     return relationDocs;
   }
 

--- a/modules/authorization/src/controllers/relations.controller.ts
+++ b/modules/authorization/src/controllers/relations.controller.ts
@@ -100,7 +100,12 @@ export class RelationsController {
       };
     });
     const relationDocs = await Relationship.getInstance().createMany(relations);
-    await this.indexController.constructRelationIndexes(subject, relation, resources);
+    const relationEntries = relations.map(r => ({
+      subject: r.subject,
+      relation: r.relation,
+      object: r.resource,
+    }));
+    await this.indexController.constructRelationIndexes(relationEntries);
     return relationDocs;
   }
 

--- a/modules/authorization/src/controllers/relations.controller.ts
+++ b/modules/authorization/src/controllers/relations.controller.ts
@@ -121,11 +121,12 @@ export class RelationsController {
       };
     });
     await ActorIndex.getInstance().createMany(toCreate);
-    await Promise.all(
-      relations.map(r =>
-        this.indexController.constructRelationIndex(r.subject, r.relation, r.resource),
-      ),
-    );
+    const relationEntries = relations.map(r => ({
+      subject: r.subject,
+      relation: r.relation,
+      object: r.resource,
+    }));
+    await this.indexController.constructRelationIndexes(relationEntries);
     return relationResource;
   }
 


### PR DESCRIPTION
This PR introduces a bulk variant for relation index construction.
`ActorIndex.findMany()` calls should probably be squashed into a single `findMany()` query with multiple `AND` cases instead, but I'm opening this one for _constructive criticism_ before handling that.

Co-authored by @Renc17.

**What kind of change does this PR introduce?** <!--(check at least one)-->

- [ ] Bugfix
- [X] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other (please describe)

**Does this PR introduce a breaking change?** <!-- (check one) -->

- [ ] Yes
- [X] No
