### PR TITLE
refactor(grpc-sdk,core): getRedisDetails()

### DIFF
--- a/libraries/grpc-sdk/src/index.ts
+++ b/libraries/grpc-sdk/src/index.ts
@@ -363,9 +363,9 @@ export default class ConduitGrpcSdk {
         .then(() => this.config.getRedisDetails())
         .then(r => {
           if (r.standalone) {
-            this._redisDetails = JSON.parse(r.standalone);
+            this._redisDetails = r.standalone;
           } else {
-            this._redisDetails = JSON.parse(r.cluster!);
+            this._redisDetails = r.cluster!;
           }
         });
     }

--- a/libraries/grpc-sdk/src/index.ts
+++ b/libraries/grpc-sdk/src/index.ts
@@ -20,7 +20,6 @@ import { Client } from 'nice-grpc';
 import { status } from '@grpc/grpc-js';
 import {
   ConduitModuleDefinition,
-  GetRedisDetailsResponse,
   HealthCheckResponse_ServingStatus,
   HealthDefinition,
   ModuleListResponse_ModuleResponse,
@@ -355,22 +354,18 @@ export default class ConduitGrpcSdk {
       this._redisDetails = {
         host: process.env.REDIS_HOST!,
         port: parseInt(process.env.REDIS_PORT!, 10),
-        username: process.env.REDIS_USERNAME,
-        password: process.env.REDIS_PASSWORD,
+        db: parseInt(process.env.REDIS_DB!, 10) || 0,
+        ...(process.env.REDIS_USERNAME ? { username: process.env.REDIS_USERNAME } : {}),
+        ...(process.env.REDIS_PASSWORD ? { username: process.env.REDIS_PASSWORD } : {}),
       };
     } else {
       promise = promise
         .then(() => this.config.getRedisDetails())
-        .then((r: GetRedisDetailsResponse) => {
-          if (r.redisConfig) {
-            this._redisDetails = JSON.parse(r.redisConfig);
+        .then(r => {
+          if (r.standalone) {
+            this._redisDetails = JSON.parse(r.standalone);
           } else {
-            this._redisDetails = {
-              host: r.redisHost,
-              port: r.redisPort,
-              username: r.redisUsername,
-              password: r.redisPassword,
-            };
+            this._redisDetails = JSON.parse(r.cluster!);
           }
         });
     }

--- a/libraries/grpc-sdk/src/modules/config/index.ts
+++ b/libraries/grpc-sdk/src/modules/config/index.ts
@@ -8,6 +8,7 @@ import {
 } from '../../protoUtils/core';
 import { Indexable } from '../../interfaces';
 import ConduitGrpcSdk from '../../index';
+import { ClusterOptions, RedisOptions } from 'ioredis';
 
 export class Config extends ConduitModule<typeof ConfigDefinition> {
   private readonly emitter = new EventEmitter();
@@ -76,9 +77,27 @@ export class Config extends ConduitModule<typeof ConfigDefinition> {
       });
   }
 
-  getRedisDetails() {
+  async getRedisDetails(): Promise<{
+    standalone?: RedisOptions;
+    cluster?: ClusterOptions;
+    redisHost?: string;
+    redisPort?: number;
+    redisUsername?: string;
+    redisPassword?: string;
+    redisConfig?: string;
+  }> {
     const request: Indexable = {};
-    return this.client!.getRedisDetails(request);
+    const r = await this.client!.getRedisDetails(request);
+    return {
+      ...(r.standalone ? { standalone: JSON.parse(r.standalone) } : undefined),
+      ...(r.cluster ? { cluster: JSON.parse(r.cluster) } : undefined),
+      // maintain backwards compatibility with <=grpc-sdk-v0.16.0-alpha.20
+      redisHost: r.redisHost,
+      redisPort: r.redisPort,
+      redisUsername: r.redisUsername,
+      redisPassword: r.redisPassword,
+      redisConfig: r.redisConfig,
+    };
   }
 
   registerModule(

--- a/packages/core/README.mdx
+++ b/packages/core/README.mdx
@@ -29,6 +29,7 @@ to find out more about Conduit's internals.
 |:-------------------:|:-----------------------------------------------------------|:--------:|:-----------:|
 |     `REDIS_HOST`    | Redis Address                                              |   True   | `localhost` |
 |     `REDIS_PORT`    | Redis Port                                                 |   True   |    `6379`   |
+|      `REDIS_DB`     | Redis Database                                             |  False   |     `0`     |
 |  `ADMIN_HTTP_PORT`  | Port to be used by admin REST and GrahpQL APIs             |  False   |    `3030`   |
 | `ADMIN_SOCKET_PORT` | Port to be used by admin WebSockets API                    |  False   |    `3030`   |
 |     `GRPC_PORT`      | The port number the gRPC server will listen to                      |  False   |  `55190`           |

--- a/packages/core/src/config-manager/index.ts
+++ b/packages/core/src/config-manager/index.ts
@@ -21,8 +21,7 @@ import { ConfigStorage } from './config-storage';
 import parseConfigSchema from '../utils';
 import { IModuleConfig } from '../interfaces/IModuleConfig';
 import convict from 'convict';
-import fs from 'fs-extra';
-import { isNil, merge } from 'lodash';
+import { merge } from 'lodash';
 import { GrpcServer } from '@conduitplatform/module-tools';
 
 export default class ConfigManager implements IConfigManager {
@@ -148,39 +147,14 @@ export default class ConfigManager implements IConfigManager {
     call: GrpcRequest<null>,
     callback: GrpcCallback<GetRedisDetailsResponse>,
   ) {
-    let redisJson;
-    const redisConfig = process.env.REDIS_CONFIG;
-    if (redisConfig) {
-      if (redisConfig.startsWith('{')) {
-        try {
-          redisJson = JSON.parse(redisConfig);
-        } catch (e) {
-          return callback({
-            code: status.INTERNAL,
-            message: 'Failed to parse redis config',
-          });
-        }
-      } else {
-        try {
-          redisJson = JSON.parse(fs.readFileSync(redisConfig, 'utf8'));
-        } catch (e) {
-          return callback({
-            code: status.INTERNAL,
-            message: 'Failed to parse redis config',
-          });
-        }
-      }
-    }
-    if (!isNil(redisJson)) {
+    const redisDetails = this.grpcSdk.redisDetails;
+    if (redisDetails.hasOwnProperty('nodes')) {
       callback(null, {
-        redisConfig: JSON.stringify(redisJson),
+        cluster: JSON.stringify(redisDetails),
       });
     } else {
       callback(null, {
-        redisHost: process.env.REDIS_HOST!,
-        redisPort: parseInt(process.env.REDIS_PORT!),
-        redisPassword: process.env.REDIS_PASSWORD,
-        redisUsername: process.env.REDIS_USERNAME,
+        standalone: JSON.stringify(redisDetails),
       });
     }
   }

--- a/packages/core/src/config-manager/index.ts
+++ b/packages/core/src/config-manager/index.ts
@@ -23,6 +23,7 @@ import { IModuleConfig } from '../interfaces/IModuleConfig';
 import convict from 'convict';
 import { merge } from 'lodash';
 import { GrpcServer } from '@conduitplatform/module-tools';
+import { RedisOptions } from 'ioredis';
 
 export default class ConfigManager implements IConfigManager {
   grpcSdk: ConduitGrpcSdk;
@@ -155,6 +156,11 @@ export default class ConfigManager implements IConfigManager {
     } else {
       callback(null, {
         standalone: JSON.stringify(redisDetails),
+        // maintain backwards compatibility with <=grpc-sdk-v0.16.0-alpha.20
+        redisHost: (redisDetails as RedisOptions).host,
+        redisPort: (redisDetails as RedisOptions).port,
+        redisUsername: (redisDetails as RedisOptions).username,
+        redisPassword: (redisDetails as RedisOptions).password,
       });
     }
   }

--- a/packages/core/src/core.proto
+++ b/packages/core/src/core.proto
@@ -121,13 +121,11 @@ message GetConfigRequest {
   string key = 1;
 }
 
-
 message GetRedisDetailsResponse {
-  optional string redisHost = 1;
-  optional int32 redisPort = 2;
-  optional string redisUsername = 3;
-  optional string redisPassword = 4;
-  optional string redisConfig = 5;
+  oneof config {
+    string standalone = 1;
+    string cluster = 2;
+  }
 }
 
 message GetConfigResponse {

--- a/packages/core/src/core.proto
+++ b/packages/core/src/core.proto
@@ -122,9 +122,16 @@ message GetConfigRequest {
 }
 
 message GetRedisDetailsResponse {
+  optional string redisHost = 1;
+  optional int32 redisPort = 2;
+  optional string redisUsername = 3;
+  optional string redisPassword = 4;
+  optional string redisConfig = 5;
+  // temporarily keeping these^ around to avoid a breaking change
+
   oneof config {
-    string standalone = 1;
-    string cluster = 2;
+    string standalone = 6;
+    string cluster = 7;
   }
 }
 


### PR DESCRIPTION
This PR improves Redis configuration in the following ways:

- Modules no longer need to explicitly provide Redis cluster configuration details as that's now directly retrievable through `Core`.
- `grpc-sdk` / `Core` code cleanup around `getRedisDetails()`

It also introduces a `REDIS_DB` env in `grpc-sdk`.
Providing an explicit database option was previously only doable via the `REDIS_CONFIG` stringified config object env.

Backwards compatibility is currently maintained for users of `<=grpc-sdk-v0.16.0-alpha.20`.

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** <!--(check at least one)-->

- [ ] Bugfix
- [X] Feature
- [ ] Code style update
- [X] Refactor
- [ ] Build-related changes
- [ ] Other (please describe)

**Does this PR introduce a breaking change?** <!-- (check one) -->

- [ ] Yes
- [X] No

<!-- If yes, please describe the impact and migration path for existing applications. -->

**The PR fulfills these requirements:**

- [X] It's submitted to the `main` branch
- [ ] When resolving a specific issue, it's referenced in the PR's description  (e.g. `fix #xxx`, where "xxx" is the issue number)