### PR TITLE
fix(database): update/delete operations authz checks, sql authz/dialect parsing order

### DIFF
--- a/modules/database/src/adapters/SchemaAdapter.ts
+++ b/modules/database/src/adapters/SchemaAdapter.ts
@@ -34,6 +34,10 @@ export abstract class SchemaAdapter<T> {
     readonly isView: boolean = false,
   ) {}
 
+  get authzEnabled() {
+    return this.originalSchema.modelOptions.conduit?.authorization?.enabled;
+  }
+
   transformViewName(...names: string[]): string {
     return createHash('sha256').update(names.join('_')).digest('hex');
   }
@@ -47,10 +51,7 @@ export abstract class SchemaAdapter<T> {
     if (this.isView) {
       return undefined;
     }
-    if (
-      (!userId && !scope) ||
-      !this.originalSchema.modelOptions.conduit?.authorization?.enabled
-    ) {
+    if ((!userId && !scope) || !this.authzEnabled) {
       return undefined;
     }
     const isAvailable = this.grpcSdk.isAvailable('authorization');
@@ -92,11 +93,7 @@ export abstract class SchemaAdapter<T> {
     if (this.isView) {
       throw new Error('Cannot create on view');
     }
-    if (
-      (!userId && !scope) ||
-      !this.originalSchema.modelOptions.conduit?.authorization?.enabled
-    )
-      return;
+    if ((!userId && !scope) || !this.authzEnabled) return;
     const isAvailable = this.grpcSdk.isAvailable('authorization');
     if (!isAvailable) {
       throw new Error('Authorization service is not available');
@@ -131,11 +128,7 @@ export abstract class SchemaAdapter<T> {
     userId?: string,
     scope?: string,
   ) {
-    if (
-      !this.originalSchema.modelOptions.conduit?.authorization?.enabled ||
-      (isNil(userId) && isNil(scope))
-    )
-      return query;
+    if (!this.authzEnabled || (isNil(userId) && isNil(scope))) return query;
     const view = await this.permissionCheck(operation, userId, scope);
     if (!view) return query;
     if (many) {
@@ -173,10 +166,7 @@ export abstract class SchemaAdapter<T> {
     limit?: number,
     sort?: Indexable,
   ) {
-    if (
-      !this.originalSchema.modelOptions.conduit?.authorization?.enabled ||
-      (isNil(userId) && isNil(scope))
-    )
+    if (!this.authzEnabled || (isNil(userId) && isNil(scope)))
       return { query, modified: false };
     const view = await this.permissionCheck(operation, userId, scope);
     if (!view) return { query, modified: false };
@@ -201,7 +191,7 @@ export abstract class SchemaAdapter<T> {
     data: Indexable | Indexable[],
     options?: { userId?: string; scope?: string },
   ) {
-    if (!this.originalSchema.modelOptions.conduit?.authorization?.enabled) return;
+    if (!this.authzEnabled) return;
     if (!options || (!options?.userId && options?.scope)) {
       return;
     }

--- a/modules/database/src/adapters/SchemaAdapter.ts
+++ b/modules/database/src/adapters/SchemaAdapter.ts
@@ -2,7 +2,7 @@ import ConduitGrpcSdk, { ConduitSchema, Indexable } from '@conduitplatform/grpc-
 import { MongooseSchema } from './mongoose-adapter/MongooseSchema';
 import { SequelizeSchema } from './sequelize-adapter/SequelizeSchema';
 import { DatabaseAdapter } from './DatabaseAdapter';
-import { isNil } from 'lodash';
+import { isEmpty, isNil } from 'lodash';
 import { createHash } from 'crypto';
 import { Op } from 'sequelize';
 
@@ -137,7 +137,7 @@ export abstract class SchemaAdapter<T> {
         userId: undefined,
         scope: undefined,
       });
-      if (isNil(docs)) {
+      if (isEmpty(docs)) {
         return null;
       }
       if (this.adapter.getDatabaseType() === 'MongoDB') {

--- a/modules/database/src/adapters/mongoose-adapter/MongooseSchema.ts
+++ b/modules/database/src/adapters/mongoose-adapter/MongooseSchema.ts
@@ -217,7 +217,13 @@ export class MongooseSchema extends SchemaAdapter<Model<any>> {
       options?.userId,
       options?.scope,
     );
-    return this.model.deleteOne(parsedQuery!).exec();
+    if (isNil(parsedQuery)) {
+      return { deletedCount: 0 };
+    }
+    return this.model
+      .deleteOne(parsedQuery!)
+      .exec()
+      .then(r => ({ deletedCount: r.deletedCount }));
   }
 
   async deleteMany(

--- a/modules/database/src/adapters/mongoose-adapter/MongooseSchema.ts
+++ b/modules/database/src/adapters/mongoose-adapter/MongooseSchema.ts
@@ -133,9 +133,7 @@ export class MongooseSchema extends SchemaAdapter<Model<any>> {
       options?.scope,
     );
     if (isNil(parsedFilter)) {
-      throw new Error(
-        `Document doesn't exist in schema '${this.originalSchema.name}' or can't be modified by user.`,
-      );
+      throw new Error("Document doesn't exist or can't be modified by user.");
     }
     let parsedQuery: ParsedQuery = this.parseStringToQuery(query);
     if (parsedQuery.hasOwnProperty('$set')) {
@@ -168,9 +166,7 @@ export class MongooseSchema extends SchemaAdapter<Model<any>> {
       options?.scope,
     );
     if (isNil(parsedFilter)) {
-      throw new Error(
-        `Document doesn't exist in schema '${this.originalSchema.name}' or can't be modified by user.`,
-      );
+      throw new Error("Document doesn't exist or can't be modified by user.");
     }
     let parsedQuery: ParsedQuery = this.parseStringToQuery(query);
     if (parsedQuery.hasOwnProperty('$set')) {

--- a/modules/database/src/adapters/mongoose-adapter/MongooseSchema.ts
+++ b/modules/database/src/adapters/mongoose-adapter/MongooseSchema.ts
@@ -133,7 +133,9 @@ export class MongooseSchema extends SchemaAdapter<Model<any>> {
       options?.scope,
     );
     if (isNil(parsedFilter)) {
-      throw new Error(`Document doesn't exist or can't be modified by user.`);
+      throw new Error(
+        `Document doesn't exist in schema '${this.originalSchema.name}' or can't be modified by user.`,
+      );
     }
     let parsedQuery: ParsedQuery = this.parseStringToQuery(query);
     if (parsedQuery.hasOwnProperty('$set')) {
@@ -166,7 +168,9 @@ export class MongooseSchema extends SchemaAdapter<Model<any>> {
       options?.scope,
     );
     if (isNil(parsedFilter)) {
-      throw new Error(`Document doesn't exist or can't be modified by user.`);
+      throw new Error(
+        `Document doesn't exist in schema '${this.originalSchema.name}' or can't be modified by user.`,
+      );
     }
     let parsedQuery: ParsedQuery = this.parseStringToQuery(query);
     if (parsedQuery.hasOwnProperty('$set')) {

--- a/modules/database/src/adapters/mongoose-adapter/MongooseSchema.ts
+++ b/modules/database/src/adapters/mongoose-adapter/MongooseSchema.ts
@@ -132,6 +132,9 @@ export class MongooseSchema extends SchemaAdapter<Model<any>> {
       options?.userId,
       options?.scope,
     );
+    if (isNil(parsedFilter)) {
+      throw new Error(`Document doesn't exist or can't be modified by user.`);
+    }
     let parsedQuery: ParsedQuery = this.parseStringToQuery(query);
     if (parsedQuery.hasOwnProperty('$set')) {
       parsedQuery = parsedQuery['$set'];
@@ -162,6 +165,9 @@ export class MongooseSchema extends SchemaAdapter<Model<any>> {
       options?.userId,
       options?.scope,
     );
+    if (isNil(parsedFilter)) {
+      throw new Error(`Document doesn't exist or can't be modified by user.`);
+    }
     let parsedQuery: ParsedQuery = this.parseStringToQuery(query);
     if (parsedQuery.hasOwnProperty('$set')) {
       parsedQuery = parsedQuery['$set'];

--- a/modules/database/src/adapters/mongoose-adapter/MongooseSchema.ts
+++ b/modules/database/src/adapters/mongoose-adapter/MongooseSchema.ts
@@ -242,9 +242,12 @@ export class MongooseSchema extends SchemaAdapter<Model<any>> {
       options?.scope,
     );
     if (isNil(parsedQuery)) {
-      return [];
+      return { deletedCount: 0 };
     }
-    return this.model.deleteMany(parsedQuery).exec();
+    return this.model
+      .deleteMany(parsedQuery)
+      .exec()
+      .then(r => ({ deletedCount: r.deletedCount }));
   }
 
   async findMany(

--- a/modules/database/src/adapters/sequelize-adapter/SequelizeSchema.ts
+++ b/modules/database/src/adapters/sequelize-adapter/SequelizeSchema.ts
@@ -136,7 +136,9 @@ export class SequelizeSchema extends SchemaAdapter<ModelStatic<any>> {
       options?.scope,
     ).then(r => {
       if (!r) {
-        throw new Error(`Record '${id}' doesn't exist or can't be modified by user.`);
+        throw new Error(
+          `Record '${id}' doesn't exist in schema '${this.schema.name}' or can't be modified by user.`,
+        );
       }
       return r._id;
     });

--- a/modules/database/src/adapters/sequelize-adapter/SequelizeSchema.ts
+++ b/modules/database/src/adapters/sequelize-adapter/SequelizeSchema.ts
@@ -136,9 +136,7 @@ export class SequelizeSchema extends SchemaAdapter<ModelStatic<any>> {
       options?.scope,
     ).then(r => {
       if (!r) {
-        throw new Error(
-          `Record '${id}' doesn't exist in schema '${this.schema.name}' or can't be modified by user.`,
-        );
+        throw new Error("Document doesn't exist or can't be modified by user.");
       }
       return r._id;
     });

--- a/modules/database/src/adapters/sequelize-adapter/SequelizeSchema.ts
+++ b/modules/database/src/adapters/sequelize-adapter/SequelizeSchema.ts
@@ -134,7 +134,12 @@ export class SequelizeSchema extends SchemaAdapter<ModelStatic<any>> {
       false,
       options?.userId,
       options?.scope,
-    ).then(r => r!._id);
+    ).then(r => {
+      if (!r) {
+        throw new Error(`Record '${id}' doesn't exist or can't be modified by user.`);
+      }
+      return r._id;
+    });
     try {
       const parentDoc = await this.model.findByPk(parsedId, {
         nest: true,

--- a/modules/database/src/adapters/sequelize-adapter/SequelizeSchema.ts
+++ b/modules/database/src/adapters/sequelize-adapter/SequelizeSchema.ts
@@ -344,7 +344,7 @@ export class SequelizeSchema extends SchemaAdapter<ModelStatic<any>> {
     }
     const { filter: parsedFilter, parsingResult } = parseQueryFilter(
       this,
-      this.parseStringToQuery(query),
+      this.parseStringToQuery(filter),
       {
         populate: options?.populate,
         select: options?.select,

--- a/modules/database/src/adapters/sequelize-adapter/SequelizeSchema.ts
+++ b/modules/database/src/adapters/sequelize-adapter/SequelizeSchema.ts
@@ -503,6 +503,9 @@ export class SequelizeSchema extends SchemaAdapter<ModelStatic<any>> {
       options?.userId,
       options?.scope,
     );
+    if (isNil(parsedFilter)) {
+      return { deletedCount: 0 };
+    }
     return this.model
       .findOne({
         where: parsedFilter!,

--- a/modules/database/src/adapters/sequelize-adapter/SequelizeSchema.ts
+++ b/modules/database/src/adapters/sequelize-adapter/SequelizeSchema.ts
@@ -470,7 +470,7 @@ export class SequelizeSchema extends SchemaAdapter<ModelStatic<any>> {
       options?.scope,
     );
     if (isNil(parsedFilter)) {
-      return [];
+      return { deletedCount: 0 };
     }
     return this.model
       .findAll({


### PR DESCRIPTION
This PR fixes quite a lot of issues mostly around, but not limited to, authz functionality:
- invalid nullity checks (eg: `isNil([])` isn't really falsy)
- update / delete operations entirely missing Authz parsed query nullity checks
- invalid SQL.deleteMany(), Mongo.deleteOne(), Mongo.deleteMany() response formatting

These effectively end up resolving:
- SQL `findByIdAndUpdate()` missing explicit throw on no doc (db query threw down the line)
- Mongo `updateOne()`/`replaceOne()` operations updating random schema docs
- SQL / Mongo `deleteOne()`/`deleteMany()` operations deleting random schema docs

**What kind of change does this PR introduce?** <!--(check at least one)-->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other (please describe)

**Does this PR introduce a breaking change?** <!-- (check one) -->

- [ ] Yes
- [X] No

<!-- If yes, please describe the impact and migration path for existing applications. -->

**The PR fulfills these requirements:**

- [X] It's submitted to the `main` branch
- [ ] When resolving a specific issue, it's referenced in the PR's description  (e.g. `fix #xxx`, where "xxx" is the issue number)