### PR TITLE
fix(authentication): sendMagicLink missing redirectUri, magic link hook invalid redirectUri param type

### DIFF
--- a/modules/authentication/src/handlers/magicLink.ts
+++ b/modules/authentication/src/handlers/magicLink.ts
@@ -69,12 +69,12 @@ export class MagicLinkHandlers implements IAuthenticationStrategy {
         path: '/hook/magic-link/:verificationToken',
         action: ConduitRouteActions.GET,
         description: `A webhook used to verify a user who has received a magic link.`,
-        urlParams: config.customRedirectUris
-          ? {
-              verificationToken: ConduitString.Required,
-              redirectUri: ConduitString.Optional,
-            }
-          : { verificationToken: ConduitString.Required },
+        urlParams: {
+          verificationToken: ConduitString.Required,
+        },
+        queryParams: config.customRedirectUris
+          ? { redirectUri: ConduitString.Optional }
+          : {},
       },
       new ConduitRouteReturnDefinition('VerifyMagicLinkLoginResponse', {
         accessToken: ConduitString.Optional,


### PR DESCRIPTION
This PR fixes the following issues:
- Magic link creation endpoint missing custom `redirectUri` functionality
- Magic link hook endpoint declaration invalid `redirectUri` type

**What kind of change does this PR introduce?** <!--(check at least one)-->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other (please describe)

**Does this PR introduce a breaking change?** <!-- (check one) -->

- [X] Yes
- [ ] No

<!-- If yes, please describe the impact and migration path for existing applications. -->

**The PR fulfills these requirements:**

- [X] It's submitted to the `main` branch
- [ ] When resolving a specific issue, it's referenced in the PR's description  (e.g. `fix #xxx`, where "xxx" is the issue number)