### PR TITLE
feat(authentication): configurable magicLink dispatch URI, magic token consumption endpoint

### DIFF
--- a/modules/authentication/src/config/magicLink.config.ts
+++ b/modules/authentication/src/config/magicLink.config.ts
@@ -9,5 +9,11 @@ export default {
       default: '',
       optional: true,
     },
+    link_uri: {
+      doc: 'When specified, this setting overrides the default magic link URI, allowing you to customize the destination where the magic token is sent. Used for manual consumption and token exchange.',
+      format: 'String',
+      default: '',
+      optional: true,
+    },
   },
 };

--- a/modules/authentication/src/handlers/magicLink.ts
+++ b/modules/authentication/src/handlers/magicLink.ts
@@ -179,10 +179,13 @@ export class MagicLinkHandlers implements IAuthenticationStrategy {
   }
 
   private async sendMagicLinkMail(user: User, token: Token) {
-    const authConfig = ConfigController.getInstance().config;
+    const linkUri = ConfigController.getInstance().config.magic_link.link_uri?.replace(
+      /\/$/,
+      '',
+    );
     const serverConfig = await this.grpcSdk.config.get('router');
-    const baseUrl = !isEmpty(authConfig.magic_link.link_uri)
-      ? authConfig.magic_link.link_uri.replace(/\/$/, '')
+    const baseUrl = !isEmpty(linkUri)
+      ? linkUri
       : `${serverConfig.hostUrl.replace(/\/$/, '')}/hook/authentication/magic-link`;
     const link = `${baseUrl}/${token.token}`;
     await this.emailModule.sendEmail('MagicLink', {

--- a/modules/authentication/src/handlers/magicLink.ts
+++ b/modules/authentication/src/handlers/magicLink.ts
@@ -1,4 +1,4 @@
-import { isNil } from 'lodash';
+import { isEmpty, isNil } from 'lodash';
 import { TokenType } from '../constants';
 import { v4 as uuid } from 'uuid';
 import ConduitGrpcSdk, {
@@ -85,7 +85,7 @@ export class MagicLinkHandlers implements IAuthenticationStrategy {
     const email = call.request.params.email.toLowerCase();
     const config = ConfigController.getInstance().config;
     const redirectUri =
-      config.customRedirectUris && !isNil(call.request.bodyParams.redirectUri)
+      config.customRedirectUris && !isEmpty(call.request.bodyParams.redirectUri)
         ? call.request.bodyParams.redirectUri
         : undefined;
     const { clientId } = call.request.context;

--- a/modules/authentication/src/handlers/magicLink.ts
+++ b/modules/authentication/src/handlers/magicLink.ts
@@ -83,7 +83,7 @@ export class MagicLinkHandlers implements IAuthenticationStrategy {
       routingManager.route(
         {
           path: '/magic-link/:magicToken',
-          action: ConduitRouteActions.GET,
+          action: ConduitRouteActions.POST,
           description: 'Exchange magic token for login tokens.',
           urlParams: {
             magicToken: ConduitString.Required,

--- a/modules/authentication/src/models/Client.model.ts
+++ b/modules/authentication/src/models/Client.model.ts
@@ -4,7 +4,7 @@ import { ConduitActiveSchema } from '@conduitplatform/module-tools';
 export class Client extends ConduitActiveSchema<Client> {
   private static _instance: Client;
   _id!: string;
-  clientId!: string;
+  clientId!: string | 'anonymous-client';
   clientSecret!: string;
   alias?: string;
   notes?: string;


### PR DESCRIPTION
This PR introduces a configurable magic link dispatch URI config option for customizing magic token consumption.
When provided, magic token emails will link to the specified address, instead of the default magic token hook endpoint.

I've also introduced some str nullity check fixes as well as workarounds for trailing slashes.

This PR also modifies internal `redirectUri` behavior.
These are no longer appended to the magic link as query params and are retrieved from the token doc instead.
Non-overriden `redirectUri` values are intentionally not stored in `token.data` and coalesced back into latest config values during token retrieval (in hook endpoint).

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** <!--(check at least one)-->

- [X] Bugfix
- [X] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other (please describe)

**Does this PR introduce a breaking change?** <!-- (check one) -->

- [ ] Yes
- [X] No

<!-- If yes, please describe the impact and migration path for existing applications. -->

**The PR fulfills these requirements:**

- [X] It's submitted to the `main` branch
- [ ] When resolving a specific issue, it's referenced in the PR's description  (e.g. `fix #xxx`, where "xxx" is the issue number)

If adding a **new feature**, the PR's description includes:

- [X] A convincing reason for adding this feature <!-- to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it -->
