### PR TITLE
fix(hermes,router,admin): Swagger missing optional authMiddleware headers, conditional security client headers

### DIFF
--- a/libraries/hermes/src/Rest/Swagger.ts
+++ b/libraries/hermes/src/Rest/Swagger.ts
@@ -9,18 +9,15 @@ import { processSwaggerParams } from './SimpleTypeParamUtils';
 export class SwaggerGenerator {
   private _swaggerDoc: Indexable;
   private _routerMetadata: SwaggerRouterMetadata;
-  private readonly _stringifiedGlobalSecurityHeaders: string;
   private readonly _parser: SwaggerParser;
 
-  constructor(private readonly initialRouterMetadata: SwaggerRouterMetadata) {
+  constructor(readonly getSwaggerRouterMetadata: () => SwaggerRouterMetadata) {
     this.cleanup();
     this._parser = new SwaggerParser();
-    this._stringifiedGlobalSecurityHeaders = JSON.stringify(
-      this._routerMetadata.globalSecurityHeaders,
-    );
   }
 
   cleanup() {
+    this._routerMetadata = this.getSwaggerRouterMetadata();
     this._swaggerDoc = {
       openapi: '3.0.0',
       info: {
@@ -35,10 +32,9 @@ export class SwaggerGenerator {
             format: 'uuid',
           },
         },
-        securitySchemes: this.initialRouterMetadata.securitySchemes,
+        securitySchemes: this._routerMetadata.securitySchemes,
       },
     };
-    this._routerMetadata = cloneDeep(this.initialRouterMetadata);
   }
 
   get swaggerDoc() {
@@ -73,7 +69,7 @@ export class SwaggerGenerator {
           },
         },
       },
-      security: JSON.parse(this._stringifiedGlobalSecurityHeaders),
+      security: cloneDeep(this._routerMetadata.globalSecurityHeaders),
     };
 
     if (

--- a/libraries/hermes/src/index.ts
+++ b/libraries/hermes/src/index.ts
@@ -41,7 +41,7 @@ export class ConduitRoutingController {
     private readonly baseUrl: string,
     private readonly grpcSdk: ConduitGrpcSdk,
     cleanupTimeoutMs: number = 0,
-    private readonly swaggerMetadata?: SwaggerRouterMetadata,
+    private readonly getSwaggerMetadata?: () => SwaggerRouterMetadata,
     private readonly metrics?: {
       registeredRoutes?: {
         name: string;
@@ -99,7 +99,7 @@ export class ConduitRoutingController {
     if (this._restRouter) return;
     this._restRouter = new RestController(
       this.grpcSdk,
-      this.swaggerMetadata,
+      this.getSwaggerMetadata,
       this.metrics,
     );
   }

--- a/modules/router/src/Router.ts
+++ b/modules/router/src/Router.ts
@@ -27,7 +27,7 @@ import {
 import { isNaN } from 'lodash';
 import AppConfigSchema, { Config } from './config';
 import * as models from './models';
-import { protoTemplate, swaggerMetadata } from './hermes';
+import { protoTemplate, getSwaggerMetadata } from './hermes';
 import { runMigrations } from './migrations';
 import SecurityModule from './security';
 import { AdminHandlers } from './admin';
@@ -85,7 +85,7 @@ export default class ConduitDefaultRouter extends ManagedModule<Config> {
       '',
       this.grpcSdk,
       1000,
-      swaggerMetadata,
+      getSwaggerMetadata,
       { registeredRoutes: { name: 'client_routes_total' } },
     );
     this.registerGlobalMiddleware(

--- a/modules/router/src/hermes/swaggerMetadata.ts
+++ b/modules/router/src/hermes/swaggerMetadata.ts
@@ -32,7 +32,10 @@ export const swaggerMetadata: SwaggerRouterMetadata = {
     },
   ],
   setExtraRouteHeaders(route: ConduitRoute, swaggerRouteDoc: Indexable): void {
-    if (route.input.middlewares?.includes('authMiddleware')) {
+    if (
+      route.input.middlewares?.includes('authMiddleware') ||
+      route.input.middlewares?.includes('authMiddleware?')
+    ) {
       swaggerRouteDoc.security[0].userToken = [];
     }
   },

--- a/modules/router/src/hermes/swaggerMetadata.ts
+++ b/modules/router/src/hermes/swaggerMetadata.ts
@@ -35,15 +35,23 @@ export const getSwaggerMetadata: () => SwaggerRouterMetadata = () => ({
       ]
     : [],
   setExtraRouteHeaders(route: ConduitRoute, swaggerRouteDoc: Indexable): void {
-    if (
-      route.input.middlewares?.includes('authMiddleware') ||
-      route.input.middlewares?.includes('authMiddleware?')
-    ) {
-      if (swaggerRouteDoc.security.length > 0) {
-        swaggerRouteDoc.security[0].userToken = [];
-      } else {
-        swaggerRouteDoc.security = [{ userToken: [] }];
-      }
+    // https://swagger.io/docs/specification/authentication/#multiple
+    if (route.input.middlewares?.includes('authMiddleware')) {
+      // Logical AND
+      swaggerRouteDoc.security = swaggerRouteDoc.security.map(
+        (originalSecEntry: { [field: string]: string }) => ({
+          ...originalSecEntry,
+          userToken: [],
+        }),
+      );
+    }
+    if (route.input.middlewares?.includes('authMiddleware?')) {
+      // Logical OR
+      swaggerRouteDoc.security.forEach(
+        (originalSecEntry: { [field: string]: string }) => {
+          swaggerRouteDoc.security.push({ ...originalSecEntry, userToken: [] });
+        },
+      );
     }
   },
 });

--- a/modules/router/src/hermes/swaggerMetadata.ts
+++ b/modules/router/src/hermes/swaggerMetadata.ts
@@ -1,7 +1,8 @@
 import { Indexable } from '@conduitplatform/grpc-sdk';
+import { ConfigController } from '@conduitplatform/module-tools';
 import { ConduitRoute, SwaggerRouterMetadata } from '@conduitplatform/hermes';
 
-export const swaggerMetadata: SwaggerRouterMetadata = {
+export const getSwaggerMetadata: () => SwaggerRouterMetadata = () => ({
   urlPrefix: '',
   securitySchemes: {
     clientId: {
@@ -25,18 +26,24 @@ export const swaggerMetadata: SwaggerRouterMetadata = {
         'A user authentication token, retrievable through [POST] /authentication/local or [POST] /authentication/renew',
     },
   },
-  globalSecurityHeaders: [
-    {
-      clientId: [],
-      clientSecret: [],
-    },
-  ],
+  globalSecurityHeaders: ConfigController.getInstance().config.security.clientValidation
+    ? [
+        {
+          clientId: [],
+          clientSecret: [],
+        },
+      ]
+    : [],
   setExtraRouteHeaders(route: ConduitRoute, swaggerRouteDoc: Indexable): void {
     if (
       route.input.middlewares?.includes('authMiddleware') ||
       route.input.middlewares?.includes('authMiddleware?')
     ) {
-      swaggerRouteDoc.security[0].userToken = [];
+      if (swaggerRouteDoc.security.length > 0) {
+        swaggerRouteDoc.security[0].userToken = [];
+      } else {
+        swaggerRouteDoc.security = [{ userToken: [] }];
+      }
     }
   },
-};
+});

--- a/packages/admin/src/hermes/swaggerMetadata.ts
+++ b/packages/admin/src/hermes/swaggerMetadata.ts
@@ -25,7 +25,12 @@ export const getSwaggerMetadata: () => SwaggerRouterMetadata = () => ({
   ],
   setExtraRouteHeaders(route: ConduitRoute, swaggerRouteDoc: Indexable): void {
     if (route.input.path !== '/login' && route.input.path !== '/modules') {
-      swaggerRouteDoc.security[0].adminToken = [];
+      swaggerRouteDoc.security = swaggerRouteDoc.security.map(
+        (originalSecEntry: { [field: string]: string }) => ({
+          ...originalSecEntry,
+          adminToken: [],
+        }),
+      );
     }
   },
 });

--- a/packages/admin/src/hermes/swaggerMetadata.ts
+++ b/packages/admin/src/hermes/swaggerMetadata.ts
@@ -1,7 +1,7 @@
 import { Indexable } from '@conduitplatform/grpc-sdk';
 import { ConduitRoute, SwaggerRouterMetadata } from '@conduitplatform/hermes';
 
-export const swaggerMetadata: SwaggerRouterMetadata = {
+export const getSwaggerMetadata: () => SwaggerRouterMetadata = () => ({
   urlPrefix: '',
   securitySchemes: {
     masterKey: {
@@ -28,4 +28,4 @@ export const swaggerMetadata: SwaggerRouterMetadata = {
       swaggerRouteDoc.security[0].adminToken = [];
     }
   },
-};
+});

--- a/packages/admin/src/index.ts
+++ b/packages/admin/src/index.ts
@@ -24,7 +24,7 @@ import * as middleware from './middleware';
 import * as adminRoutes from './routes';
 import * as models from './models';
 import { AdminMiddleware } from './models';
-import { protoTemplate, swaggerMetadata } from './hermes';
+import { protoTemplate, getSwaggerMetadata } from './hermes';
 import path from 'path';
 import {
   ConduitMiddleware,
@@ -88,7 +88,7 @@ export default class AdminModule extends IConduitAdmin {
       '/',
       this.grpcSdk,
       1000,
-      swaggerMetadata,
+      getSwaggerMetadata,
       { registeredRoutes: { name: 'admin_routes_total' } },
     );
     this._grpcRoutes = {};


### PR DESCRIPTION
This PR resolves the following Swagger issues:

- Endpoints using optional `authMiddleware?` not listing auth header.
- Security client headers always showing up

I've cleaned up the Swagger refresh logic a bit, while also enabling support for security schemes to be re-evaluated on router refresh (allowing for config updates to effectively affect these).

"Duplicated" security scheme arrays around optional `authMiddleware` are due to [OpenAPI's multi-auth](https://swagger.io/docs/specification/authentication/#multiple).
Essentially an optional header may (array including it) or may not (array omitting it) be required by target scheme.

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** <!--(check at least one)-->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update
- [X] Refactor
- [ ] Build-related changes
- [ ] Other (please describe)

**Does this PR introduce a breaking change?** <!-- (check one) -->

- [ ] Yes
- [ ] No

<!-- If yes, please describe the impact and migration path for existing applications. -->

**The PR fulfills these requirements:**

- [X] It's submitted to the `main` branch
- [ ] When resolving a specific issue, it's referenced in the PR's description  (e.g. `fix #xxx`, where "xxx" is the issue number)
