### PR TITLE
feat(router): request rate limit configuration

### DIFF
--- a/modules/router/src/config/config.ts
+++ b/modules/router/src/config/config.ts
@@ -84,10 +84,5 @@ export default {
       default: 1,
       doc: 'Request count reset timeframe. Expressed in seconds.',
     },
-    exceedQuotaPenaltyDuration: {
-      format: 'Number',
-      default: 10,
-      doc: 'Penalty duration for which to automatically block any subsequent requests once rate limit is exceeded. Expressed in seconds.',
-    },
   },
 };

--- a/modules/router/src/config/config.ts
+++ b/modules/router/src/config/config.ts
@@ -73,4 +73,21 @@ export default {
       default: false,
     },
   },
+  rateLimit: {
+    maxRequests: {
+      format: 'Number',
+      default: 50,
+      doc: 'Maximum number of allowed user requests per reset interval.',
+    },
+    resetInterval: {
+      format: 'Number',
+      default: 1,
+      doc: 'Request count reset timeframe. Expressed in seconds.',
+    },
+    exceedQuotaPenaltyDuration: {
+      format: 'Number',
+      default: 10,
+      doc: 'Penalty duration for which to automatically block any subsequent requests once rate limit is exceeded. Expressed in seconds.',
+    },
+  },
 };

--- a/modules/router/src/security/handlers/rate-limiter/index.ts
+++ b/modules/router/src/security/handlers/rate-limiter/index.ts
@@ -17,6 +17,10 @@ export class RateLimiter {
       blockDuration: config.exceedQuotaPenaltyDuration,
       execEvenly: false,
     });
+    const redis = grpcSdk.redisManager.getClient();
+    redis.keys('mainLimiter:*').then(keys => {
+      redis.del(keys);
+    });
   }
 
   private _limiter: RateLimiterRedis;

--- a/modules/router/src/security/handlers/rate-limiter/index.ts
+++ b/modules/router/src/security/handlers/rate-limiter/index.ts
@@ -1,19 +1,20 @@
 import { Cluster, Redis } from 'ioredis';
 import { RateLimiterRedis } from 'rate-limiter-flexible';
 import ConduitGrpcSdk, { ConduitError } from '@conduitplatform/grpc-sdk';
+import { ConfigController } from '@conduitplatform/module-tools';
 
 export class RateLimiter {
   constructor(private readonly grpcSdk: ConduitGrpcSdk) {
     const redisClient: Redis | Cluster = this.grpcSdk.redisManager.getClient({
       enableOfflineQueue: false,
     });
+    const config = ConfigController.getInstance().config.rateLimit;
     this._limiter = new RateLimiterRedis({
       storeClient: redisClient,
       keyPrefix: 'mainLimiter',
-      points: 50, // 10 requests
-      duration: 1, // per 1 second by IP
-      blockDuration: 10,
-      // inmemoryBlockOnConsumed: 10,
+      points: config.maxRequests,
+      duration: config.resetInterval,
+      blockDuration: config.exceedQuotaPenaltyDuration,
       execEvenly: false,
     });
   }

--- a/modules/router/src/security/handlers/rate-limiter/index.ts
+++ b/modules/router/src/security/handlers/rate-limiter/index.ts
@@ -14,12 +14,8 @@ export class RateLimiter {
       keyPrefix: 'mainLimiter',
       points: config.maxRequests,
       duration: config.resetInterval,
-      blockDuration: config.exceedQuotaPenaltyDuration,
+      blockDuration: 10,
       execEvenly: false,
-    });
-    const redis = grpcSdk.redisManager.getClient();
-    redis.keys('mainLimiter:*').then(keys => {
-      redis.del(keys);
     });
   }
 


### PR DESCRIPTION
This PR introduces (limited) configuration options for client API request rate limiting.
Namely, it allows for configuring the maximum amount of requests per interval and interval duration.

-`maxRequests`: Maximum number of allowed user requests per reset interval.
-`resetInterval`: Request count reset timeframe. Expressed in seconds.
-~`exceedQuotaPenaltyDuration`: Penalty duration for which to automatically block any subsequent requests once rate limit is exceeded. Expressed in seconds.~

I was originally going to also expose an option for configuring the timeout period in `exceedQuotaPenaltyDuration`, but given how that could allow admins that are unfamiliar with said mechanic's internals to effectively perma-ban their own, as well as others', IPs by accident, I settled on a hardcoded `10s` setting for this.

We should revisit the latter once the UI rework is finished, enabling this option and exposing endpoints for listing and managing active blocks.

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** <!--(check at least one)-->

- [ ] Bugfix
- [X] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other (please describe)

**Does this PR introduce a breaking change?** <!-- (check one) -->

- [ ] Yes
- [X] No

<!-- If yes, please describe the impact and migration path for existing applications. -->

**The PR fulfills these requirements:**

- [X] It's submitted to the `main` branch
- [ ] When resolving a specific issue, it's referenced in the PR's description  (e.g. `fix #xxx`, where "xxx" is the issue number)

If adding a **new feature**, the PR's description includes:

- [X] A convincing reason for adding this feature <!-- to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it -->

**Other information:**
