### PR TITLE
feat(chat): add config to delete rooms when participants have left

### DIFF
--- a/modules/chat/src/config/config.ts
+++ b/modules/chat/src/config/config.ts
@@ -11,7 +11,8 @@ export default {
     format: 'Boolean',
     default: true,
   },
-  destroyRoomWhenEmpty: {
+  deleteEmptyRooms: {
+    doc: 'Defines whether rooms should be automatically deleted after all participants have left',
     format: 'Boolean',
     default: false,
   },

--- a/modules/chat/src/config/config.ts
+++ b/modules/chat/src/config/config.ts
@@ -11,6 +11,10 @@ export default {
     format: 'Boolean',
     default: true,
   },
+  destroyRoomWhenEmpty: {
+    format: 'Boolean',
+    default: false,
+  },
   explicit_room_joins: {
     enabled: {
       doc: 'Defines whether users should explicitly accept an invitation before being introduced into a chat room',

--- a/modules/chat/src/routes/index.ts
+++ b/modules/chat/src/routes/index.ts
@@ -186,7 +186,7 @@ export class ChatRoutes {
       room.participants.splice(index, 1);
       if (
         room.participants.length === 1 &&
-        ConfigController.getInstance().config.destroyRoomWhenEmpty
+        ConfigController.getInstance().config.deleteEmptyRooms
       ) {
         await ChatRoom.getInstance().deleteOne({ _id: room._id });
         this.grpcSdk.bus?.publish('chat:deleteRoom:ChatRoom', JSON.stringify({ roomId }));


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/ConduitPlatform/Conduit/blob/main/.github/CONTRIBUTING.md#pull-request-guidelines
-->
One extra idea, that we should probably think about implementing, is the "auditing" of the chats. This could be enabled optionally, so when a chat is deleted, then it would only be flagged as deleted and not removed from the database. It should also keep track of who and when, entered or left the chat, along with their messages, so that an admin can audit the messages for abuse.

Thinking even more long-term, even if end-to-end encryption was introduced in an app, the user could be able to share encryption keys in order read the actual messages for such cases.

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** <!--(check at least one)-->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other (please describe)

**Does this PR introduce a breaking change?** <!-- (check one) -->

- [ ] Yes
- [x] No

<!-- If yes, please describe the impact and migration path for existing applications. -->

**The PR fulfills these requirements:**

- [x] It's submitted to the `main` branch
- [x] When resolving a specific issue, it's referenced in the PR's description  (e.g. `fix #xxx`, where "xxx" is the issue number)

If adding a **new feature**, the PR's description includes:

- [x] A convincing reason for adding this feature <!-- to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it -->

**Other information:**
