### PR TITLE
fix: ts-proto snake_case to camelCase, Chat.gRPC.createRoom() empty id res field

### DIFF
--- a/libraries/grpc-sdk/build.sh
+++ b/libraries/grpc-sdk/build.sh
@@ -13,6 +13,7 @@ protoc \
   --ts_proto_opt=esModuleInterop=true \
   --ts_proto_opt=outputServices=generic-definitions,exportCommonSymbols=false,useExactTypes=false \
   --ts_proto_out=./ \
+  --ts_proto_opt=snakeToCamel=false \
   ./*.proto
 
 # Initialize the content of the index.ts file

--- a/libraries/grpc-sdk/src/modules/chat/index.ts
+++ b/libraries/grpc-sdk/src/modules/chat/index.ts
@@ -2,7 +2,11 @@ import { ConduitModule } from '../../classes/ConduitModule';
 import { ChatDefinition, Room, SendMessageRequest } from '../../protoUtils/chat';
 
 export class Chat extends ConduitModule<typeof ChatDefinition> {
-  constructor(private readonly moduleName: string, url: string, grpcToken?: string) {
+  constructor(
+    private readonly moduleName: string,
+    url: string,
+    grpcToken?: string,
+  ) {
     super(moduleName, 'chat', url, grpcToken);
     this.initializeClient(ChatDefinition);
   }
@@ -16,6 +20,6 @@ export class Chat extends ConduitModule<typeof ChatDefinition> {
   }
 
   deleteRoom(id: string): Promise<Room> {
-    return this.client!.deleteRoom({ id });
+    return this.client!.deleteRoom({ _id: id });
   }
 }

--- a/libraries/testing-tools/build.sh
+++ b/libraries/testing-tools/build.sh
@@ -12,6 +12,7 @@ protoc \
   --ts_proto_opt=esModuleInterop=true \
   --ts_proto_opt=outputServices=generic-definitions,useExactTypes=false \
   --ts_proto_out=./ \
+  --ts_proto_opt=snakeToCamel=false \
   ./*.proto
 
 echo "Cleaning up protofiles"

--- a/modules/authentication/build.sh
+++ b/modules/authentication/build.sh
@@ -11,7 +11,8 @@ protoc \
   --plugin=../../node_modules/.bin/protoc-gen-ts_proto\
   --ts_proto_opt=esModuleInterop=true \
   --ts_proto_out=./ \
-  --ts_proto_opt=outputServices=generic-definitions,useExactTypes=false\
+  --ts_proto_opt=outputServices=generic-definitions,useExactTypes=false \
+  --ts_proto_opt=snakeToCamel=false \
   ./*.proto
 
 echo "Cleaning up folders"

--- a/modules/authorization/build.sh
+++ b/modules/authorization/build.sh
@@ -11,7 +11,8 @@ protoc \
   --plugin=../../node_modules/.bin/protoc-gen-ts_proto\
   --ts_proto_opt=esModuleInterop=true \
   --ts_proto_out=./ \
-  --ts_proto_opt=outputServices=generic-definitions,useExactTypes=false\
+  --ts_proto_opt=outputServices=generic-definitions,useExactTypes=false \
+  --ts_proto_opt=snakeToCamel=false \
   ./*.proto
 
 echo "Cleaning up folders"

--- a/modules/authorization/src/authorization.proto
+++ b/modules/authorization/src/authorization.proto
@@ -4,13 +4,13 @@ package authorization;
 
 message Resource {
   string name = 1;
-  repeated _Relation relations = 2;
-  repeated _Permission permissions = 3;
-  message _Relation {
+  repeated Relation relations = 2;
+  repeated Permission permissions = 3;
+  message Relation {
     string name = 1;
     repeated string resourceType = 2;
   }
-  message _Permission {
+  message Permission {
     string name = 1;
     repeated string roles = 2;
   }

--- a/modules/chat/build.sh
+++ b/modules/chat/build.sh
@@ -10,7 +10,8 @@ protoc \
   --plugin=../../node_modules/.bin/protoc-gen-ts_proto\
   --ts_proto_opt=esModuleInterop=true \
   --ts_proto_out=./ \
-  --ts_proto_opt=outputServices=generic-definitions,useExactTypes=false\
+  --ts_proto_opt=outputServices=generic-definitions,useExactTypes=false \
+  --ts_proto_opt=snakeToCamel=false \
   ./*.proto
 
 echo "Cleaning up folders"

--- a/modules/chat/src/Chat.ts
+++ b/modules/chat/src/Chat.ts
@@ -151,7 +151,7 @@ export default class Chat extends ManagedModule<Config> {
       }),
     );
     callback(null, {
-      Id: room._id,
+      _id: room._id,
       name: room.name,
       participants: room.participants as string[],
     });
@@ -203,13 +203,11 @@ export default class Chat extends ManagedModule<Config> {
   }
 
   async deleteRoom(call: GrpcRequest<DeleteRoomRequest>, callback: GrpcCallback<Room>) {
-    const { id } = call.request;
+    const { _id } = call.request;
 
     let errorMessage: string | null = null;
     const room: models.ChatRoom = await models.ChatRoom.getInstance()
-      .deleteOne({
-        _id: id,
-      })
+      .deleteOne({ _id })
       .catch((e: Error) => {
         errorMessage = e.message;
       });
@@ -219,7 +217,7 @@ export default class Chat extends ManagedModule<Config> {
 
     models.ChatMessage.getInstance()
       .deleteMany({
-        room: id,
+        room: _id,
       })
       .catch((e: Error) => {
         errorMessage = e.message;
@@ -237,7 +235,7 @@ export default class Chat extends ManagedModule<Config> {
       }),
     );
     callback(null, {
-      Id: room._id,
+      _id: room._id,
       name: room.name,
       participants: room.participants as string[],
     });

--- a/modules/chat/src/chat.proto
+++ b/modules/chat/src/chat.proto
@@ -14,7 +14,7 @@ message SendMessageRequest {
 }
 
 message DeleteRoomRequest {
-  string id = 1;
+  string _id = 1;
 }
 
 message Room {

--- a/modules/database/build.sh
+++ b/modules/database/build.sh
@@ -11,7 +11,8 @@ protoc \
   --plugin=../../node_modules/.bin/protoc-gen-ts_proto\
   --ts_proto_opt=esModuleInterop=true \
   --ts_proto_out=./ \
-  --ts_proto_opt=outputServices=generic-definitions,useExactTypes=false\
+  --ts_proto_opt=outputServices=generic-definitions,useExactTypes=false \
+  --ts_proto_opt=snakeToCamel=false \
   ./*.proto
 
 echo "Cleaning up folders"

--- a/modules/email/build.sh
+++ b/modules/email/build.sh
@@ -11,7 +11,8 @@ protoc \
   --plugin=../../node_modules/.bin/protoc-gen-ts_proto\
   --ts_proto_opt=esModuleInterop=true \
   --ts_proto_out=./ \
-  --ts_proto_opt=outputServices=generic-definitions,useExactTypes=false\
+  --ts_proto_opt=outputServices=generic-definitions,useExactTypes=false \
+  --ts_proto_opt=snakeToCamel=false \
   ./*.proto
 
 echo "Cleaning up folders"

--- a/modules/functions/build.sh
+++ b/modules/functions/build.sh
@@ -11,7 +11,8 @@ protoc \
   --plugin=../../node_modules/.bin/protoc-gen-ts_proto\
   --ts_proto_opt=esModuleInterop=true \
   --ts_proto_out=./ \
-  --ts_proto_opt=outputServices=generic-definitions,useExactTypes=false\
+  --ts_proto_opt=outputServices=generic-definitions,useExactTypes=false \
+  --ts_proto_opt=snakeToCamel=false \
   ./*.proto
 
 echo "Cleaning up folders"

--- a/modules/push-notifications/build.sh
+++ b/modules/push-notifications/build.sh
@@ -11,7 +11,8 @@ protoc \
   --plugin=../../node_modules/.bin/protoc-gen-ts_proto\
   --ts_proto_opt=esModuleInterop=true \
   --ts_proto_out=./ \
-  --ts_proto_opt=outputServices=generic-definitions,useExactTypes=false\
+  --ts_proto_opt=outputServices=generic-definitions,useExactTypes=false \
+  --ts_proto_opt=snakeToCamel=false \
   ./*.proto
 
 echo "Cleaning up folders"

--- a/modules/router/build.sh
+++ b/modules/router/build.sh
@@ -11,7 +11,8 @@ protoc \
   --plugin=../../node_modules/.bin/protoc-gen-ts_proto\
   --ts_proto_opt=esModuleInterop=true \
   --ts_proto_out=./ \
-  --ts_proto_opt=outputServices=generic-definitions,useExactTypes=false\
+  --ts_proto_opt=outputServices=generic-definitions,useExactTypes=false \
+  --ts_proto_opt=snakeToCamel=false \
   ./*.proto
 
 echo "Cleaning up folders"

--- a/modules/sms/build.sh
+++ b/modules/sms/build.sh
@@ -11,7 +11,8 @@ protoc \
   --plugin=../../node_modules/.bin/protoc-gen-ts_proto\
   --ts_proto_opt=esModuleInterop=true \
   --ts_proto_out=./ \
-  --ts_proto_opt=outputServices=generic-definitions,useExactTypes=false\
+  --ts_proto_opt=outputServices=generic-definitions,useExactTypes=false \
+  --ts_proto_opt=snakeToCamel=false \
   ./*.proto
 
 echo "Cleaning up folders"

--- a/modules/storage/build.sh
+++ b/modules/storage/build.sh
@@ -11,7 +11,8 @@ protoc \
   --plugin=../../node_modules/.bin/protoc-gen-ts_proto\
   --ts_proto_opt=esModuleInterop=true \
   --ts_proto_out=./ \
-  --ts_proto_opt=outputServices=generic-definitions,useExactTypes=false\
+  --ts_proto_opt=outputServices=generic-definitions,useExactTypes=false \
+  --ts_proto_opt=snakeToCamel=false \
   ./*.proto
 
 echo "Cleaning up folders"

--- a/packages/commons/build.sh
+++ b/packages/commons/build.sh
@@ -10,7 +10,8 @@ protoc \
   --plugin=../../node_modules/.bin/protoc-gen-ts_proto\
   --ts_proto_opt=esModuleInterop=true \
   --ts_proto_out=./ \
-  --ts_proto_opt=outputServices=generic-definitions,useExactTypes=false\
+  --ts_proto_opt=outputServices=generic-definitions,useExactTypes=false \
+  --ts_proto_opt=snakeToCamel=false \
   ./*.proto
 
 echo "Cleaning up folders"


### PR DESCRIPTION
This PR disables `ts-proto`'s snake_case to camelCase conversions.
For whatever reason, `ts-proto` seems to match leading underscores as snake_case, even though they're technically not.

Example: message field `_id` would become `Id`
Besides being a nuisance, this resulted in generated types not really working as expected across server/client.
Eg: `Chat` module's `createRoom` was expected to return `Id` server-side and receive the same field client-side, but we actually received an empty string (default gRPC value) instead.

While at it, I also modified `DeleteRoomRequest`s signature to also return `_id` (previously `id` as a workaround).
This should make the API consistent, while also matching the underlying db doc field naming.

The modifications in `Chat`'s proto file are technically a breaking change, but I'm not denoting this via conventional commits as we're already in an alpha stage and the previous behavior was also sketchy at best.
At least node users of `grpc-sdk` should become aware of this following an SDK bump.

This change shouldn't break any in-code generated types usage as we only ever build internal Conduit protos + the [official gRPC health check proto file](https://github.com/grpc/grpc/blob/master/doc/health-checking.md), neither of which make use of snake_case naming.

I only slightly modified `Authorization`'s nested `Resource.Relation` and `Resource.Permission` message types, removing the explicit underscore prefix (`ts-proto` doesn't use namespaces), which shouldn't really affect anything.
Relevant generated types are never explicitly referenced either anyway. 

**What kind of change does this PR introduce?** <!--(check at least one)-->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [X] Build-related changes
- [ ] Other (please describe)

**Does this PR introduce a breaking change?** <!-- (check one) -->

- [X] Yes
- [ ] No

<!-- If yes, please describe the impact and migration path for existing applications. -->

**The PR fulfills these requirements:**

- [X] It's submitted to the `main` branch
- [ ] When resolving a specific issue, it's referenced in the PR's description  (e.g. `fix #xxx`, where "xxx" is the issue number)