### PR TITLE
fix(hermes): cumulative middleware context

### DIFF
--- a/libraries/hermes/src/Rest/Rest.ts
+++ b/libraries/hermes/src/Rest/Rest.ts
@@ -166,8 +166,7 @@ export class RestController extends ConduitRouter {
       };
       self
         .checkMiddlewares(context, route.input.middlewares)
-        .then(r => {
-          Object.assign(context.context, r);
+        .then(() => {
           if (route.input.action !== ConduitRouteActions.GET) {
             return route.executeRequest(context);
           }

--- a/libraries/hermes/src/Router.ts
+++ b/libraries/hermes/src/Router.ts
@@ -80,24 +80,24 @@ export abstract class ConduitRouter {
     this._middlewareOwners.set(middleware.name, moduleUrl);
   }
 
-  checkMiddlewares(params: ConduitRouteParameters, middlewares?: string[]) {
-    let primaryPromise = new Promise(resolve => {
-      resolve({});
-    });
+  async checkMiddlewares(params: ConduitRouteParameters, middlewares?: string[]) {
+    let primaryPromise = new Promise<void>(resolve => resolve());
     middlewares?.forEach(m => {
       const middleware = m.split('?')[0];
       if (!this._middlewares?.hasOwnProperty(middleware)) {
         primaryPromise = Promise.reject('Middleware does not exist');
       } else {
-        primaryPromise = primaryPromise.then(r => {
+        primaryPromise = primaryPromise.then(() => {
           return this._middlewares![middleware].executeRequest.bind(
             this._middlewares![middleware],
           )(params)
             .then(p => {
               if (p.result) {
-                Object.assign(r as Record<string, unknown>, JSON.parse(p.result));
+                Object.assign(
+                  params.context as Record<string, unknown>,
+                  JSON.parse(p.result),
+                );
               }
-              return r;
             })
             .catch((err: Error) => {
               if (!m.includes('?')) throw err;

--- a/libraries/hermes/src/Router.ts
+++ b/libraries/hermes/src/Router.ts
@@ -81,7 +81,7 @@ export abstract class ConduitRouter {
   }
 
   async checkMiddlewares(params: ConduitRouteParameters, middlewares?: string[]) {
-    let primaryPromise = new Promise<void>(resolve => resolve());
+    let primaryPromise = Promise.resolve();
     middlewares?.forEach(m => {
       const middleware = m.split('?')[0];
       if (!this._middlewares?.hasOwnProperty(middleware)) {


### PR DESCRIPTION
This PR resolves a `Hermes` issue around route middleware not updating context values until after the complete middleware chain has finished executing.
In layman's terms, stacked middleware handlers would all access the original context values instead of the the cumulative assignments taking place during middleware chain execution.

**What kind of change does this PR introduce?** <!--(check at least one)-->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other (please describe)

**Does this PR introduce a breaking change?** <!-- (check one) -->

- [ ] Yes
- [X] No

<!-- If yes, please describe the impact and migration path for existing applications. -->

**The PR fulfills these requirements:**

- [X] It's submitted to the `main` branch
- [ ] When resolving a specific issue, it's referenced in the PR's description  (e.g. `fix #xxx`, where "xxx" is the issue number)
