### PR TITLE
refactor(authentication): support tenant-only AD login

### DIFF
--- a/modules/authentication/src/config/microsoft.config.ts
+++ b/modules/authentication/src/config/microsoft.config.ts
@@ -4,12 +4,12 @@ export default {
   microsoft: {
     ...oauth2Schema,
     accountLinking: {
-      doc: 'When enabled, if a new microsoft user matches with an existing email on the database, they will be enriched with microsoft details',
+      doc: 'When enabled, if a new Microsoft user matches with an existing email on the database, they will be enriched with Microsoft details',
       format: 'Boolean',
       default: true,
     },
     tenantId: {
-      doc: 'The tenant id for the microsoft app. Used ONLY when app is not multi-tenant.',
+      doc: 'The tenant id for the Microsoft app. Used ONLY when app is not multi-tenant.',
       format: 'String',
       default: '',
     },

--- a/modules/authentication/src/config/microsoft.config.ts
+++ b/modules/authentication/src/config/microsoft.config.ts
@@ -8,5 +8,10 @@ export default {
       format: 'Boolean',
       default: true,
     },
+    tenantId: {
+      doc: 'The tenant id for the microsoft app. Used ONLY when app is not multi-tenant.',
+      format: 'String',
+      default: '',
+    },
   },
 };

--- a/modules/authentication/src/handlers/oauth2/microsoft/microsoft.ts
+++ b/modules/authentication/src/handlers/oauth2/microsoft/microsoft.ts
@@ -9,6 +9,7 @@ import { Payload } from '../interfaces/Payload';
 import { ConnectionParams } from '../interfaces/ConnectionParams';
 import { OAuth2Settings } from '../interfaces/OAuth2Settings';
 import { makeRequest } from '../utils';
+import { ConfigController } from '@conduitplatform/module-tools';
 
 export class MicrosoftHandlers extends OAuth2<MicrosoftUser, OAuth2Settings> {
   constructor(grpcSdk: ConduitGrpcSdk, config: { microsoft: ProviderConfig }) {
@@ -17,6 +18,18 @@ export class MicrosoftHandlers extends OAuth2<MicrosoftUser, OAuth2Settings> {
       'microsoft',
       new OAuth2Settings(config.microsoft, microsoftParameters),
     );
+    const msConfig = ConfigController.getInstance().config.microsoft;
+    if (msConfig.tenantId) {
+      this.settings.tokenUrl = this.settings.tokenUrl.replace(
+        'common',
+        msConfig.tenantId,
+      );
+      this.settings.authorizeUrl = this.settings.authorizeUrl.replace(
+        'common',
+        msConfig.tenantId,
+      );
+    }
+
     this.defaultScopes = ['openid'];
   }
 


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/ConduitPlatform/Conduit/blob/main/.github/CONTRIBUTING.md#pull-request-guidelines
-->

Currently, AD authentication only supports multi-tenant applications. With this change you can specify the Tenant ID of the application so that single-tenant apps can work.

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** <!--(check at least one)-->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other (please describe)

**Does this PR introduce a breaking change?** <!-- (check one) -->

- [ ] Yes
- [x] No

<!-- If yes, please describe the impact and migration path for existing applications. -->

**The PR fulfills these requirements:**

- [x] It's submitted to the `main` branch
- [x] When resolving a specific issue, it's referenced in the PR's description  (e.g. `fix #xxx`, where "xxx" is the issue number)

If adding a **new feature**, the PR's description includes:

- [x] A convincing reason for adding this feature <!-- to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it -->

**Other information:**
