### PR TITLE
fix(database): missed null parsedQuery case in mongoose findOne()

### DIFF
--- a/modules/database/src/adapters/mongoose-adapter/MongooseSchema.ts
+++ b/modules/database/src/adapters/mongoose-adapter/MongooseSchema.ts
@@ -313,6 +313,7 @@ export class MongooseSchema extends SchemaAdapter<Model<any>> {
       options?.userId,
       options?.scope,
     );
+    if (isNil(parsedQuery)) return null;
     let finalQuery = this.model.findOne(parsedQuery!, options?.select);
     if (options?.populate !== undefined && options?.populate !== null) {
       finalQuery = this.populate(finalQuery, options?.populate);


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/ConduitPlatform/Conduit/blob/main/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

This PR fixes a bug in authorized findOne mongoose queries. By giving null query value to mongoose findOne() the first found doc of the model was returned instead of a null value.

**What kind of change does this PR introduce?** <!--(check at least one)-->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other (please describe)

**Does this PR introduce a breaking change?** <!-- (check one) -->

- [ ] Yes
- [x] No

<!-- If yes, please describe the impact and migration path for existing applications. -->

**The PR fulfills these requirements:**

- [x] It's submitted to the `main` branch
- [ ] When resolving a specific issue, it's referenced in the PR's description  (e.g. `fix #xxx`, where "xxx" is the issue number)

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature <!-- to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it -->

**Other information:**
