### PR TITLE
fix(database): gRPC findMany() empty sort handling

### DIFF
--- a/modules/database/src/Database.ts
+++ b/modules/database/src/Database.ts
@@ -343,16 +343,19 @@ export default class DatabaseModule extends ManagedModule<void> {
   async findMany(call: GrpcRequest<FindRequest>, callback: GrpcResponse<QueryResponse>) {
     try {
       const { skip, limit, select, populate } = call.request;
-      const sort = call.request.sort as { [key: string]: -1 | 1 | number } | undefined;
-      if (sort) {
-        Object.keys(sort).forEach(field => {
-          if (sort[field] !== 1 && sort[field] !== -1) {
+      const _sort = call.request.sort as { [field: string]: -1 | 1 | number };
+      // gRPC undefined object field values fall back to  empty objects...
+      let sort: { [field: string]: -1 | 1 } | undefined = undefined;
+      if (_sort && !!Object.keys(_sort).length) {
+        Object.keys(_sort).forEach(field => {
+          if (_sort[field] !== 1 && _sort[field] !== -1) {
             return callback({
               code: status.INVALID_ARGUMENT,
-              message: `Invalid sort field value "${sort[field]}" in field "${field}", should be -1 or 1.`,
+              message: `Invalid sort field value "${_sort[field]}" in field "${field}", should be -1 or 1.`,
             });
           }
         });
+        sort = _sort as { [field: string]: -1 | 1 };
       }
       const schemaAdapter = this._activeAdapter.getSchemaModel(call.request.schemaName);
       const docs = await schemaAdapter.model.findMany(call.request.query, {

--- a/modules/database/src/adapters/mongoose-adapter/MongooseSchema.ts
+++ b/modules/database/src/adapters/mongoose-adapter/MongooseSchema.ts
@@ -262,7 +262,7 @@ export class MongooseSchema extends SchemaAdapter<Model<any>> {
       skip?: number;
       limit?: number;
       select?: string;
-      sort?: any;
+      sort?: { [field: string]: -1 | 1 };
       populate?: string[];
       userId?: string;
       scope?: string;
@@ -282,16 +282,16 @@ export class MongooseSchema extends SchemaAdapter<Model<any>> {
     }
     let finalQuery = this.model.find(filter, options?.select);
     if (!isNil(options?.skip) && !modified) {
-      finalQuery = finalQuery.skip(options?.skip!);
+      finalQuery = finalQuery.skip(options!.skip!);
     }
     if (!isNil(options?.limit) && !modified) {
-      finalQuery = finalQuery.limit(options?.limit!);
+      finalQuery = finalQuery.limit(options!.limit!);
     }
     if (!isNil(options?.populate)) {
-      finalQuery = this.populate(finalQuery, options?.populate ?? []);
+      finalQuery = this.populate(finalQuery, options!.populate ?? []);
     }
     if (!isNil(options?.sort)) {
-      finalQuery = finalQuery.sort(this.parseSort(options?.sort));
+      finalQuery = finalQuery.sort(this.parseSort(options!.sort));
     }
     return finalQuery.lean().exec();
   }

--- a/modules/database/src/adapters/sequelize-adapter/SequelizeSchema.ts
+++ b/modules/database/src/adapters/sequelize-adapter/SequelizeSchema.ts
@@ -662,7 +662,7 @@ export class SequelizeSchema extends SchemaAdapter<ModelStatic<any>> {
   }
 
   parseStringToQuery(
-    query: Query | SingleDocQuery | MultiDocQuery,
+    query: Query | SingleDocQuery | MultiDocQuery | null,
   ): ParsedQuery | ParsedQuery[] {
     return typeof query === 'string' ? JSON.parse(query) : query;
   }

--- a/modules/database/src/adapters/sequelize-adapter/SequelizeSchema.ts
+++ b/modules/database/src/adapters/sequelize-adapter/SequelizeSchema.ts
@@ -395,7 +395,7 @@ export class SequelizeSchema extends SchemaAdapter<ModelStatic<any>> {
       skip?: number;
       limit?: number;
       select?: string;
-      sort?: any;
+      sort?: { [field: string]: -1 | 1 };
       populate?: string[];
       userId?: string;
       scope?: string;
@@ -432,13 +432,13 @@ export class SequelizeSchema extends SchemaAdapter<ModelStatic<any>> {
       ),
     };
     if (!isNil(options?.skip) && !modified) {
-      findOptions.offset = options?.skip;
+      findOptions.offset = options!.skip;
     }
     if (!isNil(options?.limit) && !modified) {
-      findOptions.limit = options?.limit;
+      findOptions.limit = options!.limit;
     }
     if (!isNil(options?.sort)) {
-      findOptions.order = this.parseSort(options?.sort);
+      findOptions.order = this.parseSort(options!.sort);
     }
 
     return this.model.findAll(findOptions).then(docs => {


### PR DESCRIPTION
This issue was caused by gRPC server implementations not allowing for undefined object values.
According to the gRPC spec, any optional fields that are omitted from the request are to be coalesced with their respective type's default value.
For objects, that would be an empty object.

**What kind of change does this PR introduce?** <!--(check at least one)-->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other (please describe)

**Does this PR introduce a breaking change?** <!-- (check one) -->

- [ ] Yes
- [X] No

<!-- If yes, please describe the impact and migration path for existing applications. -->

**The PR fulfills these requirements:**

- [X] It's submitted to the `main` branch
- [ ] When resolving a specific issue, it's referenced in the PR's description  (e.g. `fix #xxx`, where "xxx" is the issue number)
