### PR TITLE
fix(router): route Swagger doc missing non-global security headers

### DIFF
--- a/modules/router/src/hermes/swaggerMetadata.ts
+++ b/modules/router/src/hermes/swaggerMetadata.ts
@@ -47,8 +47,7 @@ export const getSwaggerMetadata: () => SwaggerRouterMetadata = () => ({
           userToken: [],
         }),
       );
-    }
-    if (route.input.middlewares?.includes('authMiddleware?')) {
+    } else if (route.input.middlewares?.includes('authMiddleware?')) {
       if (swaggerRouteDoc.security.length === 0) {
         swaggerRouteDoc.security.push({});
       }

--- a/modules/router/src/hermes/swaggerMetadata.ts
+++ b/modules/router/src/hermes/swaggerMetadata.ts
@@ -6,7 +6,7 @@ export const getSwaggerMetadata: () => SwaggerRouterMetadata = () => ({
   urlPrefix: '',
   securitySchemes: {
     clientId: {
-      name: 'clientid',
+      name: 'clientId',
       type: 'apiKey',
       in: 'header',
       description: 'A security client id, retrievable through [POST] /security/client',
@@ -37,6 +37,9 @@ export const getSwaggerMetadata: () => SwaggerRouterMetadata = () => ({
   setExtraRouteHeaders(route: ConduitRoute, swaggerRouteDoc: Indexable): void {
     // https://swagger.io/docs/specification/authentication/#multiple
     if (route.input.middlewares?.includes('authMiddleware')) {
+      if (swaggerRouteDoc.security.length === 0) {
+        swaggerRouteDoc.security.push({});
+      }
       // Logical AND
       swaggerRouteDoc.security = swaggerRouteDoc.security.map(
         (originalSecEntry: { [field: string]: string }) => ({
@@ -46,6 +49,9 @@ export const getSwaggerMetadata: () => SwaggerRouterMetadata = () => ({
       );
     }
     if (route.input.middlewares?.includes('authMiddleware?')) {
+      if (swaggerRouteDoc.security.length === 0) {
+        swaggerRouteDoc.security.push({});
+      }
       // Logical OR
       swaggerRouteDoc.security.forEach(
         (originalSecEntry: { [field: string]: string }) => {


### PR DESCRIPTION
This PR fixes a Swagger issue were route docs wouldn't list non-global security schemes.

This issue would show up while no other headers were globally requested (eg Security Clients) due to OpenAPI security scheme array entries being mutually exclusive, meaning that either one of the entries could be used to authorize the request, as such any headers that are always requested should be added to each security scheme entry in the array.
Given no other entries to be updated, the previous implementation would fail to append the changes.

Admin is unaffected, as `MasterKey` is always required.

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** <!--(check at least one)-->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other (please describe)

**Does this PR introduce a breaking change?** <!-- (check one) -->

- [ ] Yes
- [X] No

<!-- If yes, please describe the impact and migration path for existing applications. -->

**The PR fulfills these requirements:**

- [X] It's submitted to the `main` branch
- [ ] When resolving a specific issue, it's referenced in the PR's description  (e.g. `fix #xxx`, where "xxx" is the issue number)
