### PR TITLE
fix(database): SQL createSchemaFromAdapter() drop views on schema view exists constraint

### DIFF
--- a/modules/database/src/adapters/sequelize-adapter/index.ts
+++ b/modules/database/src/adapters/sequelize-adapter/index.ts
@@ -275,6 +275,11 @@ export abstract class SequelizeAdapter extends DatabaseAdapter<SequelizeSchema> 
     saveToDb: boolean = true,
     options?: { parentSchema: string },
   ): Promise<SequelizeSchema> {
+    for (const [key, value] of Object.entries(this.views)) {
+      if (value.originalSchema.name === schema.name) {
+        await this.deleteView(key);
+      }
+    }
     const compiledSchema = compileSchema(
       schema,
       this.registeredSchemas,


### PR DESCRIPTION
This PR resolves a Postgres/SQL adapter issue where `createSchemaFromAdapter()` would fail due to an underlying engine constraint whenever schema views already exist for the model.
This looks up and **deletes any views for target schema**.

I'm making the following assumptions:
1) Views are a `Database` mechanism that's (currently) **exclusively used by `Authorization`**
2) Views are automatically recreated by `Authorization` on followup queries

We would ideally automatically recreate the views upon recreating the schemas, but it's somewhat complicated.
We can safely recreate any views for schema creations with unchanged fields (or even schema updates that don't affect any relevant fields), but we can't really reuse the stored query string to recreate views with modified fields.

`Authorization` is currently the only user of views and it safely recreates these whenever required, with the only drawback of added query delay on the first request.
If/when we actually expose view support, we could calculate an affected field diff, allowing us to:
- automatically recreate unaffected views
- set a `disabled` `View` schema field flag for any views not managed by `Authorization` (alerting admins regarding required intervention via `UI`)
- (_debatable_) ask `Authorization` to recreate the views early

On large production deployments making extended use of views, repetitively looping through the `views` member object keys/values (during schema imports) will probably prove to be somewhat problematic.
We could optimize this by categorizing the views per schema (eg `Map<string, SequelizeSchema[]>`) and/or fetching all the affected view keys in a single loop for multi-create operations (code legibility will suffer though).

I should note how views are only recovered after schema recovery.
Thus initial `Database` startup times are unaffected by this change.

**What kind of change does this PR introduce?** <!--(check at least one)-->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other (please describe)

**Does this PR introduce a breaking change?** <!-- (check one) -->

- [ ] Yes
- [ ] No

<!-- If yes, please describe the impact and migration path for existing applications. -->

**The PR fulfills these requirements:**

- [ ] It's submitted to the `main` branch
- [ ] When resolving a specific issue, it's referenced in the PR's description  (e.g. `fix #xxx`, where "xxx" is the issue number)

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature <!-- to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it -->

**Other information:**
