### PR TITLE
fix(authentication): OAuth provider redirect URIs containing double query question marks

### DIFF
--- a/modules/authentication/src/handlers/oauth2/OAuth2.ts
+++ b/modules/authentication/src/handlers/oauth2/OAuth2.ts
@@ -87,7 +87,9 @@ export abstract class OAuth2<T, S extends OAuth2Settings>
         code_challenge_method: this.settings.codeChallengeMethod,
       }),
     };
-    const baseUrl = this.settings.authorizeUrl;
+    const baseUrl = this.settings.authorizeUrl.endsWith('?')
+      ? this.settings.authorizeUrl.slice(0, -1)
+      : this.settings.authorizeUrl;
     const stateToken = await Token.getInstance()
       .create({
         tokenType: TokenType.STATE_TOKEN,

--- a/modules/authentication/src/handlers/oauth2/apple/apple.json
+++ b/modules/authentication/src/handlers/oauth2/apple/apple.json
@@ -1,7 +1,7 @@
 {
   "accessTokenMethod": "POST",
   "providerName": "apple",
-  "authorizeUrl": "https://appleid.apple.com/auth/authorize?",
+  "authorizeUrl": "https://appleid.apple.com/auth/authorize",
   "tokenUrl": "https://appleid.apple.com/auth/token",
   "grantType": "authorization_code",
   "responseType": "code id_token",

--- a/modules/authentication/src/handlers/oauth2/bitbucket/bitbucket.json
+++ b/modules/authentication/src/handlers/oauth2/bitbucket/bitbucket.json
@@ -1,6 +1,6 @@
 {
   "accessTokenMethod": "POST",
-  "authorizeUrl": "https://bitbucket.org/site/oauth2/authorize?",
+  "authorizeUrl": "https://bitbucket.org/site/oauth2/authorize",
   "providerName": "bitbucket",
   "tokenUrl": "https://bitbucket.org/site/oauth2/access_token",
   "responseType": "code",

--- a/modules/authentication/src/handlers/oauth2/facebook/facebook.json
+++ b/modules/authentication/src/handlers/oauth2/facebook/facebook.json
@@ -1,6 +1,6 @@
 {
   "accessTokenMethod": "GET",
-  "authorizeUrl": "https://www.facebook.com/v11.0/dialog/oauth?",
+  "authorizeUrl": "https://www.facebook.com/v11.0/dialog/oauth",
   "tokenUrl": "https://graph.facebook.com/v12.0/oauth/access_token",
   "responseType": "code"
 }

--- a/modules/authentication/src/handlers/oauth2/figma/figma.json
+++ b/modules/authentication/src/handlers/oauth2/figma/figma.json
@@ -1,6 +1,6 @@
 {
   "accessTokenMethod": "POST",
-  "authorizeUrl": "https://www.figma.com/oauth?",
+  "authorizeUrl": "https://www.figma.com/oauth",
   "tokenUrl": "https://www.figma.com/api/oauth/token",
   "responseType": "code",
   "grantType": "authorization_code"

--- a/modules/authentication/src/handlers/oauth2/github/github.json
+++ b/modules/authentication/src/handlers/oauth2/github/github.json
@@ -1,6 +1,6 @@
 {
   "accessTokenMethod": "POST",
-  "authorizeUrl": "https://github.com/login/oauth/authorize?",
+  "authorizeUrl": "https://github.com/login/oauth/authorize",
   "providerName": "github",
   "tokenUrl": "https://github.com/login/oauth/access_token",
   "responseType": "code"

--- a/modules/authentication/src/handlers/oauth2/gitlab/gitlab.json
+++ b/modules/authentication/src/handlers/oauth2/gitlab/gitlab.json
@@ -2,7 +2,7 @@
   "accessTokenMethod": "POST",
   "providerName": "gitlab",
   "responseType": "code",
-  "authorizeUrl": "https://gitlab.com/oauth/authorize?",
+  "authorizeUrl": "https://gitlab.com/oauth/authorize",
   "tokenUrl": "https://gitlab.com/oauth/token",
   "grantType": "authorization_code"
 }

--- a/modules/authentication/src/handlers/oauth2/google/google.json
+++ b/modules/authentication/src/handlers/oauth2/google/google.json
@@ -4,5 +4,5 @@
   "tokenUrl": "https://oauth2.googleapis.com/token",
   "responseType": "code",
   "grantType": "authorization_code",
-  "authorizeUrl": "https://accounts.google.com/o/oauth2/v2/auth?"
+  "authorizeUrl": "https://accounts.google.com/o/oauth2/v2/auth"
 }

--- a/modules/authentication/src/handlers/oauth2/linkedIn/linkedin.json
+++ b/modules/authentication/src/handlers/oauth2/linkedIn/linkedin.json
@@ -2,7 +2,7 @@
   "accessTokenMethod": "POST",
   "providerName": "linkedin",
   "responseType": "code",
-  "authorizeUrl": "https://www.linkedin.com/oauth/v2/authorization?",
+  "authorizeUrl": "https://www.linkedin.com/oauth/v2/authorization",
   "tokenUrl": "https://www.linkedin.com/oauth/v2/accessToken",
   "grantType": "authorization_code"
 }

--- a/modules/authentication/src/handlers/oauth2/microsoft/microsoft.json
+++ b/modules/authentication/src/handlers/oauth2/microsoft/microsoft.json
@@ -1,6 +1,6 @@
 {
   "accessTokenMethod": "POST",
-  "authorizeUrl": "https://login.microsoftonline.com/common/oauth2/v2.0/authorize?",
+  "authorizeUrl": "https://login.microsoftonline.com/common/oauth2/v2.0/authorize",
   "providerName": "microsoft",
   "tokenUrl": "https://login.microsoftonline.com/common/oauth2/v2.0/token",
   "responseMode": "query",

--- a/modules/authentication/src/handlers/oauth2/reddit/reddit.json
+++ b/modules/authentication/src/handlers/oauth2/reddit/reddit.json
@@ -1,6 +1,6 @@
 {
   "accessTokenMethod": "POST",
-  "authorizeUrl": "https://www.reddit.com/api/v1/authorize?",
+  "authorizeUrl": "https://www.reddit.com/api/v1/authorize",
   "providerName": "reddit",
   "tokenUrl": "https://www.reddit.com/api/v1/access_token",
   "responseType": "code",

--- a/modules/authentication/src/handlers/oauth2/slack/slack.json
+++ b/modules/authentication/src/handlers/oauth2/slack/slack.json
@@ -1,6 +1,6 @@
 {
   "accessTokenMethod": "POST",
-  "authorizeUrl": "https://slack.com/oauth/authorize?",
+  "authorizeUrl": "https://slack.com/oauth/authorize",
   "providerName": "slack",
   "tokenUrl": "https://slack.com/api/oauth.access",
   "responseType": "code"

--- a/modules/authentication/src/handlers/oauth2/twitch/twitch.json
+++ b/modules/authentication/src/handlers/oauth2/twitch/twitch.json
@@ -1,6 +1,6 @@
 {
   "accessTokenMethod": "POST",
-  "authorizeUrl": "https://id.twitch.tv/oauth2/authorize?",
+  "authorizeUrl": "https://id.twitch.tv/oauth2/authorize",
   "providerName": "twitch",
   "tokenUrl": "https://id.twitch.tv/oauth2/token",
   "grantType": "authorization_code",

--- a/modules/authentication/src/handlers/oauth2/twitter/twitter.json
+++ b/modules/authentication/src/handlers/oauth2/twitter/twitter.json
@@ -1,6 +1,6 @@
 {
   "accessTokenMethod": "POST",
-  "authorizeUrl": "https://twitter.com/i/oauth2/authorize?",
+  "authorizeUrl": "https://twitter.com/i/oauth2/authorize",
   "providerName": "twitter",
   "tokenUrl": "https://api.twitter.com/2/oauth2/token",
   "responseType": "code",


### PR DESCRIPTION
This PR resolves #854 by omitting the original `?` mark in the provider param objects.
I'm also trimming these off on usage just in case anybody's implementing out-of-tree custom providers.

**What kind of change does this PR introduce?** <!--(check at least one)-->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other (please describe)

**Does this PR introduce a breaking change?** <!-- (check one) -->

- [ ] Yes
- [X] No

<!-- If yes, please describe the impact and migration path for existing applications. -->

**The PR fulfills these requirements:**

- [X] It's submitted to the `main` branch
- [ ] When resolving a specific issue, it's referenced in the PR's description  (e.g. `fix #xxx`, where "xxx" is the issue number)
