### PR TITLE
feat(authentication): rm oldPassword body param from /local/change-password

### DIFF
--- a/modules/authentication/src/handlers/local.ts
+++ b/modules/authentication/src/handlers/local.ts
@@ -26,13 +26,8 @@ import {
 export class LocalHandlers implements IAuthenticationStrategy {
   private emailModule: Email;
   private initialized: boolean = false;
-  private clientValidation: boolean;
 
-  constructor(private readonly grpcSdk: ConduitGrpcSdk) {
-    grpcSdk.config.get('router').then(config => {
-      this.clientValidation = config.security.clientValidation;
-    });
-  }
+  constructor(private readonly grpcSdk: ConduitGrpcSdk) {}
 
   async declareRoutes(routingManager: RoutingManager): Promise<void> {
     const captchaConfig = ConfigController.getInstance().config.captcha;
@@ -126,8 +121,7 @@ export class LocalHandlers implements IAuthenticationStrategy {
       {
         path: '/local/change-password',
         action: ConduitRouteActions.POST,
-        description: `Changes the user's password (requires sudo access).
-                 If 2FA is enabled then a message will be returned asking for token input.`,
+        description: `Changes the user's password (requires sudo access).`,
         bodyParams: {
           newPassword: ConduitString.Required,
         },

--- a/modules/authentication/src/utils/index.ts
+++ b/modules/authentication/src/utils/index.ts
@@ -139,12 +139,12 @@ export namespace AuthUtils {
     const { relations, search, sort, populate } = params;
     const skip = params.skip ?? 0;
     const limit = params.limit ?? 25;
-    let query: any = {
+    const query: Indexable = {
       _id: { $in: relations.relations.map(r => r.subject.split(':')[1]) },
     };
     if (!isNil(search)) {
       if (search.match(/^[a-fA-F0-9]{24}$/)) {
-        let included = relations.relations
+        const included = relations.relations
           .map(r => r.subject.split(':')[1])
           .includes(search);
         if (included) {
@@ -184,12 +184,12 @@ export namespace AuthUtils {
     const { relations, search, sort, populate } = params;
     const skip = params.skip ?? 0;
     const limit = params.limit ?? 25;
-    let query: any = {
+    const query: Indexable = {
       _id: { $in: relations.relations.map(r => r.resource.split(':')[1]) },
     };
     if (!isNil(search)) {
       if (search.match(/^[a-fA-F0-9]{24}$/)) {
-        let included = relations.relations
+        const included = relations.relations
           .map(r => r.subject.split(':')[1])
           .includes(search);
         if (included) {

--- a/modules/authentication/src/utils/index.ts
+++ b/modules/authentication/src/utils/index.ts
@@ -69,33 +69,6 @@ export namespace AuthUtils {
     });
   }
 
-  export async function dbUserChecks(user: User, password: string) {
-    const dbUser: User | null = await User.getInstance().findOne(
-      { _id: user._id },
-      '+hashedPassword',
-    );
-    const isNilDbUser = isNil(dbUser);
-    if (isNilDbUser) {
-      throw new GrpcError(status.UNAUTHENTICATED, 'User does not exist');
-    }
-    const isNilHashedPassword = isNil(dbUser.hashedPassword);
-    if (isNilHashedPassword) {
-      throw new GrpcError(
-        status.PERMISSION_DENIED,
-        'User does not use password authentication',
-      );
-    }
-
-    const passwordsMatch = await AuthUtils.checkPassword(
-      password,
-      dbUser.hashedPassword!,
-    );
-    if (!passwordsMatch) {
-      throw new GrpcError(status.UNAUTHENTICATED, 'Invalid password');
-    }
-    return dbUser;
-  }
-
   export function verify(token: string, secret: string): string | object | null {
     try {
       return jwt.verify(token, secret);


### PR DESCRIPTION
This PR removes the need for providing the old `User` password during pass change via the `Local` auth strategy.
The route already required `sudo` access (aka a fresh, un-rotated, `accessToken`) so this shouldn't be an issue.

This isn't really breaking any APIs either as `Router` doesn't currently throw on additional body params.
Therefore any outdated applications should still remain functional as-is.

**What kind of change does this PR introduce?** <!--(check at least one)-->

- [ ] Bugfix
- [X] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other (please describe)

**Does this PR introduce a breaking change?** <!-- (check one) -->

- [ ] Yes
- [X] No

**The PR fulfills these requirements:**

- [X] It's submitted to the `main` branch
- [ ] When resolving a specific issue, it's referenced in the PR's description  (e.g. `fix #xxx`, where "xxx" is the issue number)

If adding a **new feature**, the PR's description includes:

- [X] A convincing reason for adding this feature <!-- to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it -->