### PR TITLE
refactor(core,admin): remove catch clauses in initialization steps

### DIFF
--- a/packages/admin/src/index.ts
+++ b/packages/admin/src/index.ts
@@ -113,12 +113,7 @@ export default class AdminModule extends IConduitAdmin {
         patchRouteMiddlewares: this.patchRouteMiddlewares.bind(this),
       },
     );
-    this.grpcSdk
-      .waitForExistence('database')
-      .then(this.handleDatabase.bind(this))
-      .catch(e => {
-        ConduitGrpcSdk.Logger.error(e.message);
-      });
+    this.grpcSdk.waitForExistence('database').then(this.handleDatabase.bind(this));
   }
 
   async subscribeToBusEvents() {

--- a/packages/core/src/GrpcServer.ts
+++ b/packages/core/src/GrpcServer.ts
@@ -23,7 +23,10 @@ export class GrpcServer {
   private readonly server: ConduitGrpcServer;
   private readonly events: EventEmitter;
 
-  constructor(private readonly commons: ConduitCommons, private readonly port: number) {
+  constructor(
+    private readonly commons: ConduitCommons,
+    private readonly port: number,
+  ) {
     this.events = new EventEmitter();
     this.events.setMaxListeners(150);
     this.server = new ConduitGrpcServer(this.port.toString());
@@ -99,10 +102,7 @@ export class GrpcServer {
     this.initializeMetrics();
     this._grpcSdk
       .waitForExistence('database')
-      .then(() => this.commons.getConfigManager().registerAppConfig())
-      .catch(e => {
-        ConduitGrpcSdk.Logger.error(e.message);
-      });
+      .then(() => this.commons.getConfigManager().registerAppConfig());
     await this.commons
       .getConfigManager()
       .configurePackage(


### PR DESCRIPTION
this is done so that initialization errors properly crash the core module, since recovery is not possible at that stage.

This fixes issues that occur if the core module fails to communicate with the database, following a temporary network disruption, resulting in core being partially functional, with no recovery paths.

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/ConduitPlatform/Conduit/blob/main/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** <!--(check at least one)-->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [x] Refactor
- [ ] Build-related changes
- [ ] Other (please describe)

**Does this PR introduce a breaking change?** <!-- (check one) -->

- [ ] Yes
- [x] No

<!-- If yes, please describe the impact and migration path for existing applications. -->

**The PR fulfills these requirements:**

- [x] It's submitted to the `main` branch
- [x] When resolving a specific issue, it's referenced in the PR's description  (e.g. `fix #xxx`, where "xxx" is the issue number)

If adding a **new feature**, the PR's description includes:

- [x] A convincing reason for adding this feature <!-- to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it -->

**Other information:**
