### PR TITLE
feat(authorization): ResourceDefinition versioning, bus event pub fixes, admin API res signature fixes

### DIFF
--- a/modules/authorization/src/Authorization.ts
+++ b/modules/authorization/src/Authorization.ts
@@ -108,7 +108,10 @@ export default class Authorization extends ManagedModule<Config> {
   async updateResource(call: GrpcRequest<Resource>, callback: GrpcResponse<Empty>) {
     const { name, relations, permissions } = call.request;
     const resource = this.createResourceObject(name, relations, permissions);
-    await this.resourceController.updateResourceDefinition(resource.name, resource);
+    await this.resourceController.updateResourceDefinition(
+      { name: resource.name },
+      resource,
+    );
     callback(null, undefined);
   }
 

--- a/modules/authorization/src/admin/relations.ts
+++ b/modules/authorization/src/admin/relations.ts
@@ -100,30 +100,16 @@ export class RelationHandler {
 
   async createRelation(call: ParsedRouterRequest): Promise<UnparsedRouterResponse> {
     const { subject, relation, object } = call.request.params;
-    const newRelation = await RelationsController.getInstance().createRelation(
-      subject,
-      relation,
-      object,
-    );
-    this.grpcSdk.bus?.publish(
-      'authentication:create:relation',
-      JSON.stringify(newRelation),
-    );
-    return newRelation;
+    return RelationsController.getInstance().createRelation(subject, relation, object);
   }
 
   async createRelations(call: ParsedRouterRequest): Promise<UnparsedRouterResponse> {
     const { subject, relation, resources } = call.request.params;
-    const newRelation = await RelationsController.getInstance().createRelations(
+    return RelationsController.getInstance().createRelations(
       subject,
       relation,
       resources,
     );
-    this.grpcSdk.bus?.publish(
-      'authentication:create:relation',
-      JSON.stringify(newRelation),
-    );
-    return newRelation;
   }
 
   async getRelation(call: ParsedRouterRequest): Promise<UnparsedRouterResponse> {

--- a/modules/authorization/src/admin/relations.ts
+++ b/modules/authorization/src/admin/relations.ts
@@ -29,10 +29,7 @@ export class RelationHandler {
           object: ConduitString.Required,
         },
       },
-      new ConduitRouteReturnDefinition(
-        'CreateRelation',
-        Relationship.getInstance().fields,
-      ),
+      new ConduitRouteReturnDefinition('CreateRelation', Relationship.name),
       this.createRelation.bind(this),
     );
     routingManager.route(
@@ -46,10 +43,7 @@ export class RelationHandler {
           resources: [ConduitString.Required],
         },
       },
-      new ConduitRouteReturnDefinition(
-        'CreateRelations',
-        Relationship.getInstance().fields,
-      ),
+      new ConduitRouteReturnDefinition('CreateRelations', Relationship.name),
       this.createRelations.bind(this),
     );
     routingManager.route(
@@ -61,7 +55,7 @@ export class RelationHandler {
           id: ConduitString.Required,
         },
       },
-      new ConduitRouteReturnDefinition('Relation', Relationship.getInstance().fields),
+      new ConduitRouteReturnDefinition('Relation', Relationship.name),
       this.getRelation.bind(this),
     );
     routingManager.route(
@@ -79,7 +73,7 @@ export class RelationHandler {
         },
       },
       new ConduitRouteReturnDefinition('GetRelations', {
-        relations: [Relationship.getInstance().fields],
+        relations: [Relationship.name],
         count: ConduitNumber.Required,
       }),
       this.getRelations.bind(this),
@@ -131,18 +125,18 @@ export class RelationHandler {
       ...(resource ?? {}),
     };
 
-    const found = await Relationship.getInstance().findMany(
+    const relations = await Relationship.getInstance().findMany(
       query,
       undefined,
       skip,
       limit,
       sort,
     );
-    if (isNil(found)) {
+    if (isNil(relations)) {
       throw new Error('Relations not found');
     }
     const count = await Relationship.getInstance().countDocuments(query);
-    return { found, count };
+    return { found: relations, count };
   }
 
   async deleteRelation(call: ParsedRouterRequest): Promise<UnparsedRouterResponse> {

--- a/modules/authorization/src/admin/resources.ts
+++ b/modules/authorization/src/admin/resources.ts
@@ -51,7 +51,7 @@ export class ResourceHandler {
         },
       },
       new ConduitRouteReturnDefinition('GetResources', {
-        resources: [ResourceDefinition.getInstance().fields],
+        resources: [ResourceDefinition.name],
         count: ConduitNumber.Required,
       }),
       this.getResources.bind(this),
@@ -65,10 +65,7 @@ export class ResourceHandler {
           id: ConduitString.Required,
         },
       },
-      new ConduitRouteReturnDefinition(
-        'Resource',
-        ResourceDefinition.getInstance().fields,
-      ),
+      new ConduitRouteReturnDefinition('Resource', ResourceDefinition.name),
       this.getResource.bind(this),
     );
     routingManager.route(

--- a/modules/authorization/src/admin/resources.ts
+++ b/modules/authorization/src/admin/resources.ts
@@ -164,8 +164,8 @@ export class ResourceHandler {
     ) {
       throw new Error('Relations and permissions must be objects');
     }
-    const resource = await ResourceController.getInstance().updateResourceDefinitionById(
-      id,
+    const resource = await ResourceController.getInstance().updateResourceDefinition(
+      { _id: id },
       { relations, permissions },
     );
     this.grpcSdk.bus?.publish('authentication:update:resource', JSON.stringify(resource));

--- a/modules/authorization/src/admin/resources.ts
+++ b/modules/authorization/src/admin/resources.ts
@@ -115,14 +115,12 @@ export class ResourceHandler {
     ) {
       throw new Error('Relations and permissions must be objects');
     }
-    const resource = await ResourceController.getInstance().createResource({
+    return ResourceController.getInstance().createResource({
       name,
       relations,
       permissions,
       version,
     });
-    this.grpcSdk.bus?.publish('authentication:create:resource', JSON.stringify(resource));
-    return resource;
   }
 
   async getResources(call: ParsedRouterRequest): Promise<UnparsedRouterResponse> {
@@ -167,12 +165,10 @@ export class ResourceHandler {
     ) {
       throw new Error('Relations and permissions must be objects');
     }
-    const resource = await ResourceController.getInstance().updateResourceDefinition(
+    return ResourceController.getInstance().updateResourceDefinition(
       { _id: id },
       { relations, permissions, version },
     );
-    this.grpcSdk.bus?.publish('authentication:update:resource', JSON.stringify(resource));
-    return resource;
   }
 
   async deleteResource(call: ParsedRouterRequest): Promise<UnparsedRouterResponse> {

--- a/modules/authorization/src/admin/resources.ts
+++ b/modules/authorization/src/admin/resources.ts
@@ -146,6 +146,7 @@ export class ResourceHandler {
     if (isNil(resources)) {
       throw new Error('Resources not found');
     }
+    resources.filter(r => isNil(r.version)).forEach(r => (r.version = 0));
     const count = await ResourceDefinition.getInstance().countDocuments(query);
     return { resources, count };
   }

--- a/modules/authorization/src/admin/resources.ts
+++ b/modules/authorization/src/admin/resources.ts
@@ -136,18 +136,18 @@ export class ResourceHandler {
         query = { name: { $regex: `.*${nameSearch}.*`, $options: 'i' } };
       }
     }
-    const found = await ResourceDefinition.getInstance().findMany(
+    const resources = await ResourceDefinition.getInstance().findMany(
       query,
       undefined,
       skip,
       limit,
       sort,
     );
-    if (isNil(found)) {
+    if (isNil(resources)) {
       throw new Error('Resources not found');
     }
     const count = await ResourceDefinition.getInstance().countDocuments(query);
-    return { found, count };
+    return { resources, count };
   }
 
   async getResource(call: ParsedRouterRequest): Promise<UnparsedRouterResponse> {

--- a/modules/authorization/src/admin/resources.ts
+++ b/modules/authorization/src/admin/resources.ts
@@ -29,12 +29,13 @@ export class ResourceHandler {
           name: ConduitString.Required,
           relations: ConduitJson.Required,
           permissions: ConduitJson.Required,
+          version: ConduitNumber.Optional,
         },
       },
-      new ConduitRouteReturnDefinition(
-        'CreateResource',
-        ResourceDefinition.getInstance().fields,
-      ),
+      new ConduitRouteReturnDefinition('CreateResource', {
+        status: ConduitString.Required,
+        resourceDefinition: ResourceDefinition.name,
+      }),
       this.createResource.bind(this),
     );
     routingManager.route(
@@ -81,12 +82,13 @@ export class ResourceHandler {
         bodyParams: {
           relations: ConduitJson.Required,
           permissions: ConduitJson.Required,
+          version: ConduitNumber.Optional,
         },
       },
-      new ConduitRouteReturnDefinition(
-        'PatchResource',
-        ResourceDefinition.getInstance().fields,
-      ),
+      new ConduitRouteReturnDefinition('PatchResource', {
+        status: ConduitString.Required,
+        resourceDefinition: ResourceDefinition.name,
+      }),
       this.patchResource.bind(this),
     );
     routingManager.route(
@@ -104,7 +106,7 @@ export class ResourceHandler {
   }
 
   async createResource(call: ParsedRouterRequest): Promise<UnparsedRouterResponse> {
-    const { name, relations, permissions } = call.request.params;
+    const { name, relations, permissions, version } = call.request.params;
     if (
       typeof relations !== 'object' ||
       Array.isArray(relations) ||
@@ -117,9 +119,10 @@ export class ResourceHandler {
       name,
       relations,
       permissions,
+      version,
     });
     this.grpcSdk.bus?.publish('authentication:create:resource', JSON.stringify(resource));
-    return resource!;
+    return resource;
   }
 
   async getResources(call: ParsedRouterRequest): Promise<UnparsedRouterResponse> {
@@ -155,7 +158,7 @@ export class ResourceHandler {
   }
 
   async patchResource(call: ParsedRouterRequest): Promise<UnparsedRouterResponse> {
-    const { id, relations, permissions } = call.request.params;
+    const { id, relations, permissions, version } = call.request.params;
     if (
       typeof relations !== 'object' ||
       Array.isArray(relations) ||
@@ -166,7 +169,7 @@ export class ResourceHandler {
     }
     const resource = await ResourceController.getInstance().updateResourceDefinition(
       { _id: id },
-      { relations, permissions },
+      { relations, permissions, version },
     );
     this.grpcSdk.bus?.publish('authentication:update:resource', JSON.stringify(resource));
     return resource;

--- a/modules/authorization/src/authorization.proto
+++ b/modules/authorization/src/authorization.proto
@@ -6,6 +6,7 @@ message Resource {
   string name = 1;
   repeated Relation relations = 2;
   repeated Permission permissions = 3;
+  optional uint32 version = 4;
   message Relation {
     string name = 1;
     repeated string resourceType = 2;
@@ -14,6 +15,15 @@ message Resource {
     string name = 1;
     repeated string roles = 2;
   }
+}
+
+message ResourceModificationAcknowledgement {
+  enum Status {
+    PROCESSED = 0;
+    ACKNOWLEDGED = 1;
+    IGNORED = 2;
+  }
+  Status status = 1;
 }
 
 message Relation {
@@ -88,9 +98,9 @@ message Decision {
 }
 
 service Authorization {
-  rpc DefineResource(Resource) returns (google.protobuf.Empty);
+  rpc DefineResource(Resource) returns (ResourceModificationAcknowledgement);
   rpc DeleteResource(DeleteResourceRequest) returns (google.protobuf.Empty);
-  rpc UpdateResource(Resource) returns (google.protobuf.Empty);
+  rpc UpdateResource(Resource) returns (ResourceModificationAcknowledgement);
   rpc CreateRelation(Relation) returns (google.protobuf.Empty);
   rpc CreateRelations(CreateRelationsRequest) returns (google.protobuf.Empty);
   rpc DeleteRelation(Relation) returns (google.protobuf.Empty);

--- a/modules/authorization/src/controllers/relations.controller.ts
+++ b/modules/authorization/src/controllers/relations.controller.ts
@@ -54,6 +54,10 @@ export class RelationsController {
       computedTuple: computeRelationTuple(subject, relation, object),
     });
     await IndexController.getInstance().constructRelationIndex(subject, relation, object);
+    this.grpcSdk.bus?.publish(
+      'authorization:create:relation',
+      JSON.stringify(relationResource),
+    );
     return relationResource;
   }
 
@@ -105,6 +109,9 @@ export class RelationsController {
       object: r.resource,
     }));
     await QueueController.getInstance().addRelationIndexJob(relationEntries);
+    relationDocs.forEach(rel => {
+      this.grpcSdk.bus?.publish('authorization:create:relation', JSON.stringify(rel));
+    });
     return relationDocs;
   }
 

--- a/modules/authorization/src/controllers/resource.controller.ts
+++ b/modules/authorization/src/controllers/resource.controller.ts
@@ -37,6 +37,7 @@ export class ResourceController {
       ...resource,
       version: 0,
     });
+    this.grpcSdk.bus?.publish('authorization:create:resource', JSON.stringify(res));
     return { resourceDefinition: res, status: 'processed' };
   }
 
@@ -139,6 +140,7 @@ export class ResourceController {
       resourceDefinition._id,
       resource,
     ))!;
+    this.grpcSdk.bus?.publish('authorization:update:resource', JSON.stringify(res));
     return { resourceDefinition: res, status: 'processed' };
   }
 

--- a/modules/authorization/src/controllers/resource.controller.ts
+++ b/modules/authorization/src/controllers/resource.controller.ts
@@ -2,6 +2,7 @@ import ConduitGrpcSdk from '@conduitplatform/grpc-sdk';
 import { ResourceDefinition } from '../models';
 import { IndexController } from './index.controller';
 import { RelationsController } from './relations.controller';
+import { isNil } from 'lodash';
 
 export class ResourceController {
   private static _instance: ResourceController;
@@ -112,7 +113,7 @@ export class ResourceController {
     const resourceDefinition = await ResourceDefinition.getInstance().findOne(query);
     if (!resourceDefinition) throw new Error('Resource not found');
 
-    if (resource.version === undefined || resource.version < resourceDefinition.version) {
+    if (isNil(resource.version) || resource.version < resourceDefinition.version) {
       return { resourceDefinition, status: 'ignored' };
     } else if (resource.version === resourceDefinition.version) {
       return { resourceDefinition, status: 'acknowledged' };

--- a/modules/authorization/src/controllers/resource.controller.ts
+++ b/modules/authorization/src/controllers/resource.controller.ts
@@ -26,7 +26,7 @@ export class ResourceController {
       name: resource.name,
     });
     if (resourceDefinition) {
-      return await this.updateResourceDefinition(resource.name, resource);
+      return await this.updateResourceDefinition({ name: resource.name }, resource);
     }
     await this.validateResourceRelations(resource.relations, resource.name);
     await this.validateResourcePermissions(resource);
@@ -95,8 +95,11 @@ export class ResourceController {
     return attr && Object.keys(attr).length !== 0;
   }
 
-  async updateResourceDefinition(name: string, resource: any) {
-    const resourceDefinition = await ResourceDefinition.getInstance().findOne({ name });
+  async updateResourceDefinition(
+    query: { _id: string } | { name: string },
+    resource: any,
+  ) {
+    const resourceDefinition = await ResourceDefinition.getInstance().findOne(query);
     if (!resourceDefinition) throw new Error('Resource not found');
 
     if (
@@ -112,30 +115,6 @@ export class ResourceController {
       this.attributeCheck(resourceDefinition.relations) &&
       resource.relations !== resourceDefinition.relations
     ) {
-      await this.validateResourceRelations(resource.relations, resource.name);
-      await this.indexController.modifyRelations(resourceDefinition, resource);
-    }
-    delete resource._id;
-    delete resource.name;
-    return await ResourceDefinition.getInstance().findByIdAndUpdate(
-      resourceDefinition._id,
-      resource,
-    );
-  }
-
-  async updateResourceDefinitionById(
-    id: string,
-    resource: any,
-  ): Promise<ResourceDefinition> {
-    const resourceDefinition = await ResourceDefinition.getInstance().findOne({
-      _id: id,
-    });
-    if (!resourceDefinition) throw new Error('Resource not found');
-    if (resource.permissions !== resourceDefinition.permissions) {
-      await this.validateResourcePermissions(resource);
-      await this.indexController.modifyPermission(resourceDefinition, resource);
-    }
-    if (resource.relations !== resourceDefinition.relations) {
       await this.validateResourceRelations(resource.relations, resource.name);
       await this.indexController.modifyRelations(resourceDefinition, resource);
     }

--- a/modules/authorization/src/models/ResourceDefinition.schema.ts
+++ b/modules/authorization/src/models/ResourceDefinition.schema.ts
@@ -45,6 +45,11 @@ const schema: ConduitModel = {
     type: TYPE.JSON,
     required: true,
   },
+  version: {
+    type: TYPE.Number,
+    required: true,
+    default: 0,
+  },
   createdAt: TYPE.Date,
   updatedAt: TYPE.Date,
 };
@@ -67,6 +72,7 @@ export class ResourceDefinition extends ConduitActiveSchema<ResourceDefinition> 
   name: string;
   relations: { [key: string]: string[] };
   permissions: { [key: string]: string[] };
+  version: number;
   createdAt: Date;
   updatedAt: Date;
 


### PR DESCRIPTION
This PR introduces support for `ResourceDefinition` versioning.
Database defaults no longer override explicit definitions.

I've also fixed the following issues:
-ResourceController.updateResourceDefinition() duplicated by-id/by-name methods
-ResourceDefinition/Relationship events using invalid module name prefix
-ResourceDefinition/Relationship events only published via admin API
-Relationship createMany() publishing invalid event data
-'Authorization`'s Admin API endpoint response signatures mismatch *

In regards to the latter:
`getRelations`/`getResources` would previously provide a response signature of `{ relations, count }` and `{ resources, count }` respectively, whilst actually returning `{ found, count }`.
The returned object signature now adheres to the documented endpoint response type.

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** <!--(check at least one)-->

- [X] Bugfix
- [X] Feature
- [ ] Code style update
- [X] Refactor
- [ ] Build-related changes
- [ ] Other (please describe)

**Does this PR introduce a breaking change?** <!-- (check one) -->

- [ ] Yes
- [X] No

<!-- If yes, please describe the impact and migration path for existing applications. -->

**The PR fulfills these requirements:**

- [X] It's submitted to the `main` branch
- [ ] When resolving a specific issue, it's referenced in the PR's description  (e.g. `fix #xxx`, where "xxx" is the issue number)

If adding a **new feature**, the PR's description includes:

- [X] A convincing reason for adding this feature <!-- to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it -->

**Other information:**
