### PR TITLE
feat(authentication): redirectUri overrides expansion

### DIFF
--- a/modules/authentication/src/Authentication.ts
+++ b/modules/authentication/src/Authentication.ts
@@ -135,6 +135,11 @@ export default class Authentication extends ManagedModule<Config> {
 
   async onConfig() {
     const config = ConfigController.getInstance().config;
+    if (config.redirectUris.allowAny && process.env.NODE_ENV === 'production') {
+      ConduitGrpcSdk.Logger.warn(
+        `Config option redirectUris.allowAny shouldn't be used in production!`,
+      );
+    }
     if (!config.active) {
       this.destroyMonitors();
       this.updateHealth(HealthCheckStatus.NOT_SERVING);

--- a/modules/authentication/src/config/config.ts
+++ b/modules/authentication/src/config/config.ts
@@ -79,7 +79,10 @@ export default {
       default: false,
     },
     whitelistedUris: {
-      format: ['String'],
+      format: 'Array',
+      children: {
+        format: 'String',
+      },
       default: [],
     },
   },

--- a/modules/authentication/src/config/config.ts
+++ b/modules/authentication/src/config/config.ts
@@ -73,8 +73,14 @@ export default {
       },
     },
   },
-  customRedirectUris: {
-    format: 'Boolean',
-    default: false,
+  redirectUris: {
+    allowAny: {
+      format: 'Boolean',
+      default: false,
+    },
+    whitelistedUris: {
+      format: ['String'],
+      default: [],
+    },
   },
 };

--- a/modules/authentication/src/handlers/magicLink.ts
+++ b/modules/authentication/src/handlers/magicLink.ts
@@ -9,7 +9,6 @@ import ConduitGrpcSdk, {
   ParsedRouterRequest,
   UnparsedRouterResponse,
 } from '@conduitplatform/grpc-sdk';
-
 import {
   ConduitString,
   ConfigController,

--- a/modules/authentication/src/handlers/magicLink.ts
+++ b/modules/authentication/src/handlers/magicLink.ts
@@ -20,6 +20,7 @@ import { status } from '@grpc/grpc-js';
 import { IAuthenticationStrategy } from '../interfaces';
 import { TokenProvider } from './tokenProvider';
 import { MagicLinkTemplate as magicLinkTemplate } from '../templates';
+import { AuthUtils } from '../utils';
 
 export class MagicLinkHandlers implements IAuthenticationStrategy {
   private emailModule: Email;
@@ -54,12 +55,10 @@ export class MagicLinkHandlers implements IAuthenticationStrategy {
         path: '/magic-link',
         action: ConduitRouteActions.POST,
         description: `Send magic link to a user.`,
-        bodyParams: config.customRedirectUris
-          ? {
-              email: ConduitString.Required,
-              redirectUri: ConduitString.Optional,
-            }
-          : { email: ConduitString.Required },
+        bodyParams: {
+          email: ConduitString.Required,
+          redirectUri: ConduitString.Optional,
+        },
       },
       new ConduitRouteReturnDefinition('MagicLinkSendResponse', 'String'),
       this.sendMagicLink.bind(this),
@@ -100,11 +99,9 @@ export class MagicLinkHandlers implements IAuthenticationStrategy {
 
   async sendMagicLink(call: ParsedRouterRequest): Promise<UnparsedRouterResponse> {
     const email = call.request.params.email.toLowerCase();
-    const config = ConfigController.getInstance().config;
-    const redirectUri =
-      config.customRedirectUris && !isEmpty(call.request.bodyParams.redirectUri)
-        ? call.request.bodyParams.redirectUri
-        : undefined;
+    const redirectUri = AuthUtils.validateRedirectUri(
+      call.request.bodyParams.redirectUri,
+    );
     const { clientId } = call.request.context;
     const user: User | null = await User.getInstance().findOne({ email });
     if (isNil(user)) throw new GrpcError(status.NOT_FOUND, 'User not found');
@@ -128,9 +125,8 @@ export class MagicLinkHandlers implements IAuthenticationStrategy {
     const config = ConfigController.getInstance().config;
     const { user, data } = await this.redeemMagicToken(verificationToken);
     const redirectUri =
-      config.customRedirectUris && data.redirectUri
-        ? data.redirectUri
-        : config.magic_link.redirect_uri.replace(/\/$/, '');
+      AuthUtils.validateRedirectUri(data.redirectUri) ??
+      config.magic_link.redirect_uri.replace(/\/$/, '');
     return TokenProvider.getInstance().provideUserTokens(
       {
         user,

--- a/modules/authentication/src/handlers/oauth2/apple/apple.ts
+++ b/modules/authentication/src/handlers/oauth2/apple/apple.ts
@@ -28,6 +28,7 @@ import {
   RoutingManager,
 } from '@conduitplatform/module-tools';
 import { isNil } from 'lodash';
+import { AuthUtils } from '../../../utils';
 
 export class AppleHandlers extends OAuth2<AppleUser, AppleOAuth2Settings> {
   constructor(grpcSdk: ConduitGrpcSdk, config: { apple: AppleProviderConfig }) {
@@ -135,14 +136,16 @@ export class AppleHandlers extends OAuth2<AppleUser, AppleOAuth2Settings> {
     await Token.getInstance().deleteOne(stateToken);
     ConduitGrpcSdk.Metrics?.increment('logged_in_users_total');
 
-    const uri = stateToken.data.customRedirectUri;
+    const redirectUri =
+      AuthUtils.validateRedirectUri(stateToken.data.customRedirectUri) ??
+      this.settings.finalRedirect;
     return TokenProvider.getInstance()!.provideUserTokens(
       {
         user,
         clientId,
         config,
       },
-      config.customRedirectUris && !isNil(uri) ? uri : this.settings.finalRedirect,
+      redirectUri,
     );
   }
 

--- a/modules/authentication/src/utils/index.ts
+++ b/modules/authentication/src/utils/index.ts
@@ -241,7 +241,7 @@ export namespace AuthUtils {
       .redirectUris as RedirectUris;
     if (!allowAny && !whitelistedUris.includes(redirectUri)) {
       throw new GrpcError(
-        status.ABORTED,
+        status.PERMISSION_DENIED,
         `Invalid redirectUri provided! Check the redirectUris section in Authentication's config.`,
       );
     }


### PR DESCRIPTION
This PR extends the usability of `Authentication`'s `redirectUri` req params.
As far as the API is concerned, redirect URIs are now always overridable, in supported endpoints.
Provided URIs however, must be explicitly whitelisted.

Alternatively, custom redirect URIs may be enabled unconditionally.
This option is meant to be used for dev purposes. A warning will be logged while in `production` mode.

The `customRedirectUris` config option has been succeeded by:
`redirectUris: { allowAny: boolean; whitelistedUris: string[] }`
This is technically a minor **Breaking Change**, config-wise as `allowAny` defaults to false and the previous config toggle no longer applies.

**What kind of change does this PR introduce?** <!--(check at least one)-->

- [ ] Bugfix
- [X] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other (please describe)

**Does this PR introduce a breaking change?** <!-- (check one) -->

- [X] Yes
- [ ] No

**The PR fulfills these requirements:**

- [X] It's submitted to the `main` branch
- [ ] When resolving a specific issue, it's referenced in the PR's description  (e.g. `fix #xxx`, where "xxx" is the issue number)

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature <!-- to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it -->

**Other information:**
