### PR TITLE
fix(authorization): ResourceDefinition relations/permissions nullable MongoDB fields handling

### DIFF
--- a/modules/authorization/src/controllers/relations.controller.ts
+++ b/modules/authorization/src/controllers/relations.controller.ts
@@ -34,6 +34,9 @@ export class RelationsController {
         if (!resourceDefinition) {
           throw new Error('Object resource definition not found');
         }
+        if (!resourceDefinition.relations) {
+          throw new Error('Relation not allowed');
+        }
         if (resourceDefinition.relations[relation].indexOf('*') !== -1) return;
         if (
           !resourceDefinition.relations[relation] ||
@@ -81,6 +84,9 @@ export class RelationsController {
       const resourceDefinition = definitions.find(d => d.name === resource.split(':')[0]);
       if (!resourceDefinition) {
         throw new Error('Object resource definition not found');
+      }
+      if (!resourceDefinition.relations) {
+        throw new Error('Relation not allowed');
       }
       if (resourceDefinition.relations[relation].indexOf('*') !== -1) return;
       if (

--- a/modules/authorization/src/models/ResourceDefinition.schema.ts
+++ b/modules/authorization/src/models/ResourceDefinition.schema.ts
@@ -44,7 +44,7 @@ const schema: ConduitModel = {
    */
   permissions: {
     type: TYPE.JSON,
-    required: true,
+    required: false,
   },
   version: {
     type: TYPE.Number,
@@ -71,8 +71,8 @@ export class ResourceDefinition extends ConduitActiveSchema<ResourceDefinition> 
   private static _instance: ResourceDefinition;
   _id: string;
   name: string;
-  relations: { [key: string]: string[] };
-  permissions: { [key: string]: string[] };
+  relations?: { [key: string]: string[] };
+  permissions?: { [key: string]: string[] };
   version: number;
   createdAt: Date;
   updatedAt: Date;


### PR DESCRIPTION
This PR resolves an `Authorization` bug around `MongoDB` deployments.
`ResourceDefinition`'s model controller would previously brand `relations` and `permissions` fields as non-nullable (code-wise), alas `MongoDB` would minimize empty object fields by default.

As a result, doc queries would often come up with `undefined` field values where TypeScript would expect to be working with a non-nullable type field.
Example:  the `User` resource defines no relations by default.

This PR introduces updates the model controller and schema definition to reflect that these fields may actually be missing and introduces relevant checks to accommodate this behavior.

**Possible Alternative:**
Setting MongoDB's `minimize` model option to `false` for any affected schemas.

**Considerations:**
The gRPC spec allows for the optimization of data transfer sizes by dropping missing/default field values from client requests, expecting the server to fill them back in.
This is often not the case, with different client/server implementations not handling this gracefully.
We should at the very least consider the possibility that our non-nullable gRPC `relations` and `permissions` array fields could actually end up as null, before we even attempt to convert them to the internal map-like object representations.
`grpc-js` might(?) not be affected right now, but it, or whatever server implementation we could possibly migrate to, might not handle this case as expected in the future.

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/ConduitPlatform/Conduit/blob/main/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** <!--(check at least one)-->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other (please describe)

**Does this PR introduce a breaking change?** <!-- (check one) -->

- [ ] Yes
- [ ] No

<!-- If yes, please describe the impact and migration path for existing applications. -->

**The PR fulfills these requirements:**

- [ ] It's submitted to the `main` branch
- [ ] When resolving a specific issue, it's referenced in the PR's description  (e.g. `fix #xxx`, where "xxx" is the issue number)

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature <!-- to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it -->

**Other information:**
