### PR TITLE
refactor(email): sender definitions in templates & requests

### DIFF
--- a/libraries/grpc-sdk/src/index.ts
+++ b/libraries/grpc-sdk/src/index.ts
@@ -439,14 +439,14 @@ export default class ConduitGrpcSdk {
         ? `${this.urlRemap['*']}:${moduleUrl.split(':')[1]}`
         : moduleUrl);
     if (this._availableModules[moduleName]) {
-      // ConduitGrpcSdk.Logger.log(`Creating gRPC client for ${moduleName}`);
+      ConduitGrpcSdk.Logger.info(`Creating gRPC client for ${moduleName}`);
       this._modules[moduleName] = new this._availableModules[moduleName](
         this.name,
         moduleUrl,
         this._grpcToken,
       );
     } else if (this._dynamicModules[moduleName]) {
-      // ConduitGrpcSdk.Logger.log(`Creating gRPC client for ${moduleName}`);
+      ConduitGrpcSdk.Logger.info(`Creating gRPC client for ${moduleName}`);
       this._modules[moduleName] = new ConduitModule(
         this.name,
         moduleName,

--- a/libraries/grpc-sdk/src/modules/email/index.ts
+++ b/libraries/grpc-sdk/src/modules/email/index.ts
@@ -16,12 +16,14 @@ export class Email extends ConduitModule<typeof EmailDefinition> {
     subject: string;
     body: string;
     variables: string[];
+    sender?: string;
   }) {
     return this.client!.registerTemplate({
       name: template.name,
       subject: template.subject,
       body: template.body,
       variables: template.variables,
+      sender: template.sender,
     }).then(res => {
       return JSON.parse(res.template);
     });

--- a/libraries/grpc-sdk/src/modules/email/index.ts
+++ b/libraries/grpc-sdk/src/modules/email/index.ts
@@ -2,7 +2,11 @@ import { ConduitModule } from '../../classes/ConduitModule';
 import { EmailDefinition } from '../../protoUtils/email';
 
 export class Email extends ConduitModule<typeof EmailDefinition> {
-  constructor(private readonly moduleName: string, url: string, grpcToken?: string) {
+  constructor(
+    private readonly moduleName: string,
+    url: string,
+    grpcToken?: string,
+  ) {
     super(moduleName, 'email', url, grpcToken);
     this.initializeClient(EmailDefinition);
   }
@@ -28,7 +32,7 @@ export class Email extends ConduitModule<typeof EmailDefinition> {
     params: {
       email: string;
       variables: any;
-      sender: string;
+      sender?: string;
       replyTo?: string;
       cc?: string[];
       attachments?: string[];

--- a/modules/authentication/src/Authentication.ts
+++ b/modules/authentication/src/Authentication.ts
@@ -282,7 +282,6 @@ export default class Authentication extends ManagedModule<Config> {
         const link = `${result.hostUrl}/hook/authentication/verify-email/${result.verificationToken.token}`;
         await this.grpcSdk.emailProvider!.sendEmail('EmailVerification', {
           email: user.email,
-          sender: 'no-reply',
           variables: {
             link,
           },

--- a/modules/authentication/src/handlers/local.ts
+++ b/modules/authentication/src/handlers/local.ts
@@ -247,7 +247,6 @@ export class LocalHandlers implements IAuthenticationStrategy {
       await this.emailModule
         .sendEmail('EmailVerification', {
           email: user.email,
-          sender: 'no-reply',
           variables: {
             link,
           },
@@ -333,7 +332,6 @@ export class LocalHandlers implements IAuthenticationStrategy {
     if (config.local.verification.send_email && this.grpcSdk.isAvailable('email')) {
       await this.emailModule.sendEmail('ForgotPassword', {
         email: user.email,
-        sender: 'no-reply',
         variables: {
           link,
         },
@@ -451,7 +449,6 @@ export class LocalHandlers implements IAuthenticationStrategy {
         await this.emailModule
           .sendEmail('ChangeEmailVerification', {
             email: newEmail,
-            sender: 'no-reply',
             variables: {
               link,
             },
@@ -583,7 +580,6 @@ export class LocalHandlers implements IAuthenticationStrategy {
     const link = `${result.hostUrl}/hook/authentication/verify-email/${result.token}`;
     await this.emailModule.sendEmail('EmailVerification', {
       email,
-      sender: 'no-reply',
       variables: {
         link,
       },

--- a/modules/authentication/src/handlers/magicLink.ts
+++ b/modules/authentication/src/handlers/magicLink.ts
@@ -185,7 +185,6 @@ export class MagicLinkHandlers implements IAuthenticationStrategy {
     const link = `${baseUrl}/${token.token}`;
     await this.emailModule.sendEmail('MagicLink', {
       email: user.email,
-      sender: 'no-reply',
       variables: {
         user,
         link,

--- a/modules/authentication/src/handlers/team.ts
+++ b/modules/authentication/src/handlers/team.ts
@@ -466,7 +466,6 @@ export class TeamsHandler implements IAuthenticationStrategy {
       await this.grpcSdk
         .emailProvider!.sendEmail('TeamInvite', {
           email: email,
-          sender: 'no-reply',
           variables: {
             link,
             teamName: team.name,

--- a/modules/chat/src/utils/index.ts
+++ b/modules/chat/src/utils/index.ts
@@ -65,7 +65,6 @@ export async function sendInvitations(
       await grpcSdk
         .emailProvider!.sendEmail('ChatRoomInvitation', {
           email: invitedUser.email,
-          sender: 'no-reply',
           variables: {
             acceptLink,
             declineLink,

--- a/modules/email/src/Email.ts
+++ b/modules/email/src/Email.ts
@@ -96,6 +96,7 @@ export default class Email extends ManagedModule<Config> {
       subject: call.request.subject,
       body: call.request.body,
       variables: call.request.variables,
+      sender: call.request.sender,
     };
     let errorMessage: string | null = null;
     const template = await this.emailService

--- a/modules/email/src/Email.ts
+++ b/modules/email/src/Email.ts
@@ -21,6 +21,7 @@ import {
 } from './protoTypes/email';
 import metricsSchema from './metrics';
 import { ConfigController, ManagedModule } from '@conduitplatform/module-tools';
+import { ISendEmailParams } from './interfaces';
 
 export default class Email extends ManagedModule<Config> {
   configSchema = AppConfigSchema;
@@ -110,19 +111,21 @@ export default class Email extends ManagedModule<Config> {
     callback: GrpcCallback<SendEmailResponse>,
   ) {
     const template = call.request.templateName;
-    const params = {
-      email: call.request.params!.email,
-      variables: JSON.parse(call.request.params!.variables),
-      sender: call.request.params!.sender,
-      cc: call.request.params!.cc,
-      replyTo: call.request.params!.replyTo,
-      attachments: call.request.params!.attachments,
-    };
     const emailConfig: Config = await this.grpcSdk.config
       .get('email')
       .catch(() => ConduitGrpcSdk.Logger.error('Failed to get sending domain'));
-    params.sender = params.sender + `@${emailConfig?.sendingDomain ?? 'conduit.com'}`;
+    const params: ISendEmailParams = {
+      email: call.request.params!.email,
+      variables: JSON.parse(call.request.params!.variables),
+      sender: call.request.params!.sender ?? '',
+      cc: call.request.params!.cc,
+      replyTo: call.request.params!.replyTo,
+      attachments: call.request.params!.attachments,
+      sendingDomain: emailConfig?.sendingDomain ?? '',
+    };
+
     let errorMessage: string | null = null;
+
     const sentMessageInfo = await this.emailService
       .sendEmail(template, params)
       .catch((e: Error) => (errorMessage = e.message));

--- a/modules/email/src/admin/index.ts
+++ b/modules/email/src/admin/index.ts
@@ -129,7 +129,7 @@ export class AdminHandlers {
       throw new GrpcError(status.NOT_FOUND, 'Template does not exist');
     }
 
-    ['name', 'subject', 'body'].forEach(key => {
+    ['name', 'subject', 'body', 'sender'].forEach(key => {
       if (call.request.params[key]) {
         // @ts-ignore
         templateDocument[key] = call.request.params[key];

--- a/modules/email/src/email.proto
+++ b/modules/email/src/email.proto
@@ -6,6 +6,7 @@ message RegisterTemplateRequest {
   string subject = 2;
   string body = 3;
   repeated string variables = 4;
+  optional string sender = 5;
 }
 
 message RegisterTemplateResponse {

--- a/modules/email/src/email.proto
+++ b/modules/email/src/email.proto
@@ -18,7 +18,7 @@ message SendEmailRequest {
   message SendEmailParams {
     string email = 1;
     string variables = 2;
-    string sender = 3;
+    optional string sender = 3;
     repeated string cc = 4;
     optional string replyTo = 5;
     repeated string attachments = 6;

--- a/modules/email/src/interfaces/RegisterTemplateParams.ts
+++ b/modules/email/src/interfaces/RegisterTemplateParams.ts
@@ -2,5 +2,6 @@ export interface IRegisterTemplateParams {
   name: string;
   subject: string;
   body: string;
+  sender?: string;
   variables: string[];
 }

--- a/modules/email/src/interfaces/SendEmailParams.ts
+++ b/modules/email/src/interfaces/SendEmailParams.ts
@@ -8,5 +8,6 @@ export interface ISendEmailParams {
   sender: string;
   cc?: string[];
   replyTo?: string;
+  sendingDomain?: string;
   attachments?: string[];
 }

--- a/modules/email/src/services/email.service.ts
+++ b/modules/email/src/services/email.service.ts
@@ -1,4 +1,4 @@
-import { isNil } from 'lodash';
+import { isEmpty, isNil } from 'lodash';
 import { EmailTemplate } from '../models';
 import { IRegisterTemplateParams, ISendEmailParams } from '../interfaces';
 import handlebars from 'handlebars';
@@ -7,6 +7,7 @@ import { CreateEmailTemplate } from '../email-provider/interfaces/CreateEmailTem
 import { UpdateEmailTemplate } from '../email-provider/interfaces/UpdateEmailTemplate';
 import { Attachment } from 'nodemailer/lib/mailer';
 import { Template } from '../email-provider/interfaces/Template';
+import ConduitGrpcSdk from '@conduitplatform/grpc-sdk';
 
 export class EmailService {
   constructor(private emailer: EmailProvider) {}
@@ -63,7 +64,7 @@ export class EmailService {
     let subjectString = subject!;
     let bodyString = body!;
     let templateFound: EmailTemplate | null;
-
+    let senderAddress: string | undefined;
     if (template) {
       templateFound = await EmailTemplate.getInstance().findOne({ name: template });
       if (isNil(templateFound)) {
@@ -80,15 +81,38 @@ export class EmailService {
       if (!isNil(templateFound.subject) && isNil(subject)) {
         subjectString = handlebars.compile(templateFound.subject)(variables);
       }
+      if (!isEmpty(templateFound.sender)) {
+        senderAddress = templateFound.sender;
+      }
     }
 
-    if (!isNil(sender)) {
-      builder.setSender(sender);
-    } else if (!isNil(templateFound!.sender)) {
-      builder.setSender(templateFound!.sender);
-    } else {
-      throw new Error(`Sender must be provided!`);
+    if (isNil(senderAddress) || isEmpty(senderAddress)) {
+      if (!isEmpty(sender)) {
+        senderAddress = sender;
+      } else {
+        senderAddress = 'no-reply';
+      }
     }
+    if (isNil(params.sendingDomain) || isEmpty(params.sendingDomain)) {
+      if (senderAddress.includes('@')) {
+        ConduitGrpcSdk.Logger.warn(
+          `Sending domain is not set, attempting to send email with provided address: ${senderAddress}`,
+        );
+      } else {
+        throw new Error(
+          `Sending domain is not set, and sender address is not valid: ${senderAddress}`,
+        );
+      }
+    } else if (!senderAddress.includes(params.sendingDomain)) {
+      if (senderAddress.includes('@')) {
+        ConduitGrpcSdk.Logger.warn(
+          `You are trying to send email from ${senderAddress} but it does not match sending domain ${params.sendingDomain}`,
+        );
+      } else {
+        senderAddress = `${senderAddress}@${params.sendingDomain}`;
+      }
+    }
+    builder.setSender(senderAddress!);
 
     builder.setContent(bodyString);
     builder.setReceiver(email);

--- a/modules/email/src/services/email.service.ts
+++ b/modules/email/src/services/email.service.ts
@@ -40,7 +40,7 @@ export class EmailService {
   }
 
   async registerTemplate(params: IRegisterTemplateParams) {
-    const { name, body, subject, variables } = params;
+    const { name, body, subject, variables, sender } = params;
 
     const existing = await EmailTemplate.getInstance().findOne({ name });
     if (!isNil(existing)) return existing;
@@ -49,6 +49,7 @@ export class EmailService {
       name,
       subject,
       body,
+      sender,
       variables,
     });
   }

--- a/modules/forms/src/routes/index.ts
+++ b/modules/forms/src/routes/index.ts
@@ -17,7 +17,10 @@ export class FormsRoutes {
   public readonly _routingManager: RoutingManager;
   private forms: UntypedArray = [];
 
-  constructor(readonly server: GrpcServer, private readonly grpcSdk: ConduitGrpcSdk) {
+  constructor(
+    readonly server: GrpcServer,
+    private readonly grpcSdk: ConduitGrpcSdk,
+  ) {
     this._routingManager = new RoutingManager(this.grpcSdk.router!, server);
   }
 
@@ -93,7 +96,6 @@ export class FormsRoutes {
     await this.grpcSdk
       .emailProvider!.sendEmail('FormSubmission', {
         email: form.forwardTo,
-        sender: 'forms',
         replyTo: form.emailField ? data[form.emailField] : null,
         variables: {
           data: text,


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/ConduitPlatform/Conduit/blob/main/.github/CONTRIBUTING.md#pull-request-guidelines
-->

This PR contains the following changes:
The email sender is filled from the template if defined, which is overriden by the send email request if a sender is provided. If neither the request nor the template contain a sender, then a default "no-reply" is added.

Furthermore, the full sender address is checked for compatibility with the registered sending domain in the configuration, and if there is a mismatch a warning is logged in the console. It also fixes an issue where template patches did not update the sender field of the template.

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** <!--(check at least one)-->

- [x] Bugfix
- [x] Feature
- [ ] Code style update
- [x] Refactor
- [ ] Build-related changes
- [ ] Other (please describe)

**Does this PR introduce a breaking change?** <!-- (check one) -->

- [ ] Yes
- [x] No

<!-- If yes, please describe the impact and migration path for existing applications. -->

**The PR fulfills these requirements:**

- [x] It's submitted to the `main` branch
- [x] When resolving a specific issue, it's referenced in the PR's description  (e.g. `fix #xxx`, where "xxx" is the issue number)

If adding a **new feature**, the PR's description includes:

- [x] A convincing reason for adding this feature <!-- to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it -->

**Other information:**
