### PR TITLE
feat(authorization,grpc-sdk): CreateResourceAccessList viewName

### DIFF
--- a/libraries/grpc-sdk/src/modules/authorization/index.ts
+++ b/libraries/grpc-sdk/src/modules/authorization/index.ts
@@ -12,6 +12,7 @@ import {
   Relation,
   Resource,
   ResourceAccessListRequest,
+  ResourceAccessListResponse,
 } from '../../protoUtils/index.js';
 import { Empty } from '../../protoUtils/google/protobuf/empty.js';
 
@@ -77,7 +78,9 @@ export class Authorization extends ConduitModule<typeof AuthorizationDefinition>
     return this.client!.getAllowedResources(data);
   }
 
-  createResourceAccessList(data: ResourceAccessListRequest): Promise<unknown> {
+  createResourceAccessList(
+    data: ResourceAccessListRequest,
+  ): Promise<ResourceAccessListResponse> {
     return this.client!.createResourceAccessList(data);
   }
 }

--- a/modules/authorization/src/Authorization.ts
+++ b/modules/authorization/src/Authorization.ts
@@ -230,11 +230,12 @@ export default class Authorization extends ManagedModule<Config> {
     call: GrpcRequest<ResourceAccessListRequest>,
     callback: GrpcResponse<Empty>,
   ) {
-    const { subject, action, resourceType } = call.request;
+    const { subject, action, resourceType, viewName: requestedViewName } = call.request;
     const viewName = await this.permissionsController.createAccessList(
       subject,
       action,
       resourceType,
+      requestedViewName,
     );
     callback(null, { viewName });
   }

--- a/modules/authorization/src/Authorization.ts
+++ b/modules/authorization/src/Authorization.ts
@@ -231,8 +231,12 @@ export default class Authorization extends ManagedModule<Config> {
     callback: GrpcResponse<Empty>,
   ) {
     const { subject, action, resourceType } = call.request;
-    await this.permissionsController.createAccessList(subject, action, resourceType);
-    callback(null);
+    const viewName = await this.permissionsController.createAccessList(
+      subject,
+      action,
+      resourceType,
+    );
+    callback(null, { viewName });
   }
 
   async can(call: GrpcRequest<PermissionCheck>, callback: GrpcResponse<Decision>) {

--- a/modules/authorization/src/authorization.proto
+++ b/modules/authorization/src/authorization.proto
@@ -81,6 +81,10 @@ message ResourceAccessListRequest {
   string resourceType = 5;
 }
 
+message ResourceAccessListResponse {
+  string viewName = 1;
+}
+
 message PermissionCheck {
   string subject = 1;
   repeated string actions = 2;
@@ -110,5 +114,5 @@ service Authorization {
   rpc FindRelation(FindRelationRequest) returns (FindRelationResponse);
   rpc Can(PermissionCheck) returns (Decision);
   rpc GetAllowedResources(AllowedResourcesRequest) returns (AllowedResourcesResponse);
-  rpc CreateResourceAccessList(ResourceAccessListRequest) returns (google.protobuf.Empty);
+  rpc CreateResourceAccessList(ResourceAccessListRequest) returns (ResourceAccessListResponse);
 }

--- a/modules/authorization/src/authorization.proto
+++ b/modules/authorization/src/authorization.proto
@@ -78,7 +78,8 @@ message AllowedResourcesResponse {
 message ResourceAccessListRequest {
   string subject = 1;
   string action = 2;
-  string resourceType = 5;
+  string resourceType = 3;
+  optional string viewName = 4;
 }
 
 message ResourceAccessListResponse {

--- a/modules/authorization/src/controllers/permissions.controller.ts
+++ b/modules/authorization/src/controllers/permissions.controller.ts
@@ -127,14 +127,19 @@ export class PermissionsController {
     return { resources: allowedIds.concat(index), count };
   }
 
-  async createAccessList(subject: string, action: string, objectType: string) {
+  async createAccessList(
+    subject: string,
+    action: string,
+    objectType: string,
+    requestedViewName?: string,
+  ) {
     const computedTuple = `${subject}#${action}@${objectType}`;
     const objectTypeCollection = await this.grpcSdk
       .database!.getSchema(objectType)
       .then(r => r.collectionName);
-    const viewName = createHash('sha256')
-      .update(`${objectType}_${subject}_${action}`)
-      .digest('hex');
+    const viewName =
+      requestedViewName ??
+      createHash('sha256').update(`${objectType}_${subject}_${action}`).digest('hex');
     const dbType = await this.grpcSdk.database!.getDatabaseType().then(r => r.result);
     await this.grpcSdk.database?.createView(
       objectType,

--- a/modules/authorization/src/controllers/permissions.controller.ts
+++ b/modules/authorization/src/controllers/permissions.controller.ts
@@ -132,10 +132,13 @@ export class PermissionsController {
     const objectTypeCollection = await this.grpcSdk
       .database!.getSchema(objectType)
       .then(r => r.collectionName);
+    const viewName = createHash('sha256')
+      .update(`${objectType}_${subject}_${action}`)
+      .digest('hex');
     const dbType = await this.grpcSdk.database!.getDatabaseType().then(r => r.result);
     await this.grpcSdk.database?.createView(
       objectType,
-      createHash('sha256').update(`${objectType}_${subject}_${action}`).digest('hex'),
+      viewName,
       ['Permission', 'ActorIndex', 'ObjectIndex'],
       {
         mongoQuery: [
@@ -246,6 +249,6 @@ export class PermissionsController {
               ),
       },
     );
-    return;
+    return viewName;
   }
 }


### PR DESCRIPTION
This PR updates `Authorization`'s `CreateResourceAccessList` RPC so that it:
-returns the newly created view's name in its response (`viewName`)
-optionally accepts an explicit view name via its request (`viewName`)

**What kind of change does this PR introduce?** <!--(check at least one)-->

- [ ] Bugfix
- [X] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other (please describe)

**Does this PR introduce a breaking change?** <!-- (check one) -->

- [ ] Yes
- [X] No

<!-- If yes, please describe the impact and migration path for existing applications. -->

**The PR fulfills these requirements:**

- [X] It's submitted to the `main` branch
- [ ] When resolving a specific issue, it's referenced in the PR's description  (e.g. `fix #xxx`, where "xxx" is the issue number)

If adding a **new feature**, the PR's description includes:

- [X] A convincing reason for adding this feature <!-- to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it -->

**Other information:**
