### PR TITLE
fix(authentication, grpc-sdk): team owner deletion bug

### DIFF
--- a/libraries/grpc-sdk/src/classes/ConduitAuthorizedResource.ts
+++ b/libraries/grpc-sdk/src/classes/ConduitAuthorizedResource.ts
@@ -4,11 +4,13 @@ export class ConduitAuthorizedResource {
   readonly name: string;
   readonly relations: Resource_Relation[] = [];
   readonly permissions: Resource_Permission[] = [];
+  readonly version?: number;
 
   constructor(
     name: string,
     relations: { [field: string]: string | string[] },
     permissions: { [action: string]: string | string[] },
+    version?: number,
   ) {
     this.name = name;
     this.relations = Object.keys(relations).map(relation => {
@@ -27,5 +29,6 @@ export class ConduitAuthorizedResource {
           : ([permissions[permission]] as string[]),
       };
     });
+    this.version = version;
   }
 }

--- a/modules/authentication/src/authz/index.ts
+++ b/modules/authentication/src/authz/index.ts
@@ -9,6 +9,7 @@ export const Team = new ConduitAuthorizedResource(
     owner: ['User', 'Team'],
     readAll: ['User', 'Team'],
     editAll: ['User', 'Team'],
+    ownerRemover: ['User', 'Team'],
   },
   {
     read: ['owner', 'readAll', 'editAll', 'owner->read', 'owner->edit'],
@@ -19,5 +20,6 @@ export const Team = new ConduitAuthorizedResource(
     manageMembers: ['owner', 'owner->edit'],
     viewSubTeams: ['owner', 'readAll', 'editAll', 'owner->read', 'owner->edit'],
     manageSubTeams: ['owner', 'editAll', 'owner->edit'],
+    deleteOwners: ['owner', 'ownerRemover', 'ownerRemover->edit'],
   },
 );

--- a/modules/authentication/src/authz/index.ts
+++ b/modules/authentication/src/authz/index.ts
@@ -9,7 +9,6 @@ export const Team = new ConduitAuthorizedResource(
     owner: ['User', 'Team'],
     readAll: ['User', 'Team'],
     editAll: ['User', 'Team'],
-    ownerRemover: ['User', 'Team'],
   },
   {
     read: ['owner', 'readAll', 'editAll', 'owner->read', 'owner->edit'],
@@ -20,7 +19,7 @@ export const Team = new ConduitAuthorizedResource(
     manageMembers: ['owner', 'owner->edit'],
     viewSubTeams: ['owner', 'readAll', 'editAll', 'owner->read', 'owner->edit'],
     manageSubTeams: ['owner', 'editAll', 'owner->edit'],
-    deleteOwners: ['owner', 'ownerRemover', 'ownerRemover->edit'],
+    deleteOwners: ['owner'],
   },
   1,
 );

--- a/modules/authentication/src/authz/index.ts
+++ b/modules/authentication/src/authz/index.ts
@@ -22,4 +22,5 @@ export const Team = new ConduitAuthorizedResource(
     manageSubTeams: ['owner', 'editAll', 'owner->edit'],
     deleteOwners: ['owner', 'ownerRemover', 'ownerRemover->edit'],
   },
+  1,
 );

--- a/modules/authentication/src/authz/index.ts
+++ b/modules/authentication/src/authz/index.ts
@@ -19,7 +19,7 @@ export const Team = new ConduitAuthorizedResource(
     manageMembers: ['owner', 'owner->edit'],
     viewSubTeams: ['owner', 'readAll', 'editAll', 'owner->read', 'owner->edit'],
     manageSubTeams: ['owner', 'editAll', 'owner->edit'],
-    deleteOwners: ['owner'],
+    deleteOwners: ['owner', 'owner->deleteOwners'],
   },
   1,
 );


### PR DESCRIPTION
This PR fixes a bug mentioned in issue #1095 that allowed 'editAll' members of a team to delete team's owners

A new permission in Team resource ``deleteOwners`` now gives only the team owner (or however user is granted this permission) the right to remove the owners of the team

``Warning !``
``The addition of the new permission triggers reindexing jobs, as a new version of Team resource is applied !``

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/ConduitPlatform/Conduit/blob/main/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** <!--(check at least one)-->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other (please describe)

**Does this PR introduce a breaking change?** <!-- (check one) -->

- [ ] Yes
- [x] No

<!-- If yes, please describe the impact and migration path for existing applications. -->

**The PR fulfills these requirements:**

- [x] It's submitted to the `main` branch
- [ ] When resolving a specific issue, it's referenced in the PR's description  (e.g. `fix #xxx`, where "xxx" is the issue number)

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature <!-- to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it -->

**Other information:**
