### PR TITLE
fix(authentication): UserLogin, GetTeam RPCs

### DIFF
--- a/modules/authentication/src/Authentication.ts
+++ b/modules/authentication/src/Authentication.ts
@@ -116,14 +116,14 @@ export default class Authentication extends ManagedModule<Config> {
     if (
       (
         config.accessTokens
-          .cookieOptions as typeof config.accessTokens['cookieOptions'] & {
+          .cookieOptions as (typeof config.accessTokens)['cookieOptions'] & {
           maxAge?: number;
         }
       ).maxAge
     ) {
       delete (
         config.accessTokens
-          .cookieOptions as typeof config.accessTokens['cookieOptions'] & {
+          .cookieOptions as (typeof config.accessTokens)['cookieOptions'] & {
           maxAge?: number;
         }
       )['maxAge'];
@@ -131,14 +131,14 @@ export default class Authentication extends ManagedModule<Config> {
     if (
       (
         config.refreshTokens
-          .cookieOptions as typeof config.accessTokens['cookieOptions'] & {
+          .cookieOptions as (typeof config.accessTokens)['cookieOptions'] & {
           maxAge?: number;
         }
       ).maxAge
     ) {
       delete (
         config.refreshTokens
-          .cookieOptions as typeof config.refreshTokens['cookieOptions'] & {
+          .cookieOptions as (typeof config.refreshTokens)['cookieOptions'] & {
           maxAge?: number;
         }
       )['maxAge'];
@@ -430,7 +430,12 @@ export default class Authentication extends ManagedModule<Config> {
   async getTeam(call: GrpcRequest<GetTeamRequest>, callback: GrpcCallback<GrpcTeam>) {
     const request = createParsedRouterRequest(call.request);
     try {
-      const team = (await new TeamsAdmin(this.grpcSdk).getTeam(request)) as models.Team;
+      const team = (await new TeamsAdmin(this.grpcSdk).getTeam(request)) as
+        | models.Team
+        | undefined;
+      if (!team) {
+        return callback({ code: status.NOT_FOUND, message: 'Team not found' });
+      }
       return callback(null, {
         id: team._id,
         name: team.name,

--- a/modules/authentication/src/handlers/tokenProvider.ts
+++ b/modules/authentication/src/handlers/tokenProvider.ts
@@ -144,6 +144,9 @@ export class TokenProvider {
   private async createUserTokens(
     tokenOptions: TokenOptions,
   ): Promise<[AccessToken, RefreshToken?]> {
+    if (!tokenOptions.user.active) {
+      throw new Error('User is blocked or deleted');
+    }
     const signTokenOptions: SignOptions = {
       expiresIn: (tokenOptions.config.accessTokens.expiryPeriod as number) / 1000,
     };


### PR DESCRIPTION
This PR includes the following fixes:
1) `TokenProvider.createUserTokens` not throwing for inactive (blocked) users.
2) `UserLogin` RPC not throwing for inactive (blocked) users
3) `GetTeam` RPC not throwing for not-found

I'd much rather return a specific exception type in (1), but it's not technically in a `GrpcError` layer.

Failing early in `UserLogin` both to avoid unnecessary operations and to enforce proper error type (regardless of whatever else `TokenProvider.createUserTokens()` ends up throwing for in the future.

I'd also much rather have `GetTeam` return an optional Team field instead of throwing, but that would constitute a breaking change in the gRPC API contract.

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** <!--(check at least one)-->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other (please describe)

**Does this PR introduce a breaking change?** <!-- (check one) -->

- [ ] Yes
- [X] No

These RPC changes do not constitute a gRPC API breaking change.

**The PR fulfills these requirements:**

- [X] It's submitted to the `main` branch
- [ ] When resolving a specific issue, it's referenced in the PR's description  (e.g. `fix #xxx`, where "xxx" is the issue number)
