### PR TITLE
feat(authentication): supportNative setting in providers

### DIFF
--- a/modules/authentication/src/handlers/oauth2/apple/apple.json
+++ b/modules/authentication/src/handlers/oauth2/apple/apple.json
@@ -5,5 +5,6 @@
   "tokenUrl": "https://appleid.apple.com/auth/token",
   "grantType": "authorization_code",
   "responseType": "code id_token",
-  "responseMode": "form_post"
+  "responseMode": "form_post",
+  "supportNative": true
 }

--- a/modules/authentication/src/handlers/oauth2/bitbucket/bitbucket.json
+++ b/modules/authentication/src/handlers/oauth2/bitbucket/bitbucket.json
@@ -4,5 +4,6 @@
   "providerName": "bitbucket",
   "tokenUrl": "https://bitbucket.org/site/oauth2/access_token",
   "responseType": "code",
-  "grantType": "authorization_code"
+  "grantType": "authorization_code",
+  "supportNative": false
 }

--- a/modules/authentication/src/handlers/oauth2/facebook/facebook.json
+++ b/modules/authentication/src/handlers/oauth2/facebook/facebook.json
@@ -2,5 +2,6 @@
   "accessTokenMethod": "GET",
   "authorizeUrl": "https://www.facebook.com/v11.0/dialog/oauth",
   "tokenUrl": "https://graph.facebook.com/v12.0/oauth/access_token",
-  "responseType": "code"
+  "responseType": "code",
+  "supportNative": false
 }

--- a/modules/authentication/src/handlers/oauth2/facebook/facebook.ts
+++ b/modules/authentication/src/handlers/oauth2/facebook/facebook.ts
@@ -18,6 +18,7 @@ import {
 import { OAuth2 } from '../OAuth2.js';
 import { FacebookUser } from './facebook.user.js';
 
+// todo migrate to use native method properly
 export class FacebookHandlers extends OAuth2<FacebookUser, OAuth2Settings> {
   constructor(grpcSdk: ConduitGrpcSdk, config: { facebook: ProviderConfig }) {
     super(grpcSdk, 'facebook', new OAuth2Settings(config.facebook, facebookParameters));

--- a/modules/authentication/src/handlers/oauth2/figma/figma.json
+++ b/modules/authentication/src/handlers/oauth2/figma/figma.json
@@ -3,5 +3,6 @@
   "authorizeUrl": "https://www.figma.com/oauth",
   "tokenUrl": "https://www.figma.com/api/oauth/token",
   "responseType": "code",
-  "grantType": "authorization_code"
+  "grantType": "authorization_code",
+  "supportNative": false
 }

--- a/modules/authentication/src/handlers/oauth2/github/github.json
+++ b/modules/authentication/src/handlers/oauth2/github/github.json
@@ -3,5 +3,6 @@
   "authorizeUrl": "https://github.com/login/oauth/authorize",
   "providerName": "github",
   "tokenUrl": "https://github.com/login/oauth/access_token",
-  "responseType": "code"
+  "responseType": "code",
+  "supportNative": false
 }

--- a/modules/authentication/src/handlers/oauth2/gitlab/gitlab.json
+++ b/modules/authentication/src/handlers/oauth2/gitlab/gitlab.json
@@ -4,6 +4,7 @@
   "responseType": "code",
   "authorizeUrl": "https://gitlab.com/oauth/authorize",
   "tokenUrl": "https://gitlab.com/oauth/token",
-  "grantType": "authorization_code"
+  "grantType": "authorization_code",
+  "supportNative": false
 }
 

--- a/modules/authentication/src/handlers/oauth2/google/google.json
+++ b/modules/authentication/src/handlers/oauth2/google/google.json
@@ -4,5 +4,6 @@
   "tokenUrl": "https://oauth2.googleapis.com/token",
   "responseType": "code",
   "grantType": "authorization_code",
-  "authorizeUrl": "https://accounts.google.com/o/oauth2/v2/auth"
+  "authorizeUrl": "https://accounts.google.com/o/oauth2/v2/auth",
+  "supportNative": false
 }

--- a/modules/authentication/src/handlers/oauth2/google/google.ts
+++ b/modules/authentication/src/handlers/oauth2/google/google.ts
@@ -17,6 +17,7 @@ import {
   ProviderConfig,
 } from '../interfaces/index.js';
 
+// todo migrate to use native method properly
 export class GoogleHandlers extends OAuth2<GoogleUser, OAuth2Settings> {
   constructor(grpcSdk: ConduitGrpcSdk, config: { google: ProviderConfig }) {
     super(grpcSdk, 'google', new OAuth2Settings(config.google, googleParameters));

--- a/modules/authentication/src/handlers/oauth2/interfaces/OAuth2Settings.ts
+++ b/modules/authentication/src/handlers/oauth2/interfaces/OAuth2Settings.ts
@@ -20,6 +20,7 @@ export class OAuth2Settings {
   scopeSeperator?: string;
   codeChallengeMethod?: string;
   codeVerifier?: string;
+  supportNative: boolean;
 
   constructor(
     providerConfig: ProviderConfig,
@@ -31,6 +32,7 @@ export class OAuth2Settings {
       responseType: string;
       responseMode?: string;
       codeChallengeMethod?: string;
+      supportNative?: boolean;
     },
   ) {
     this.accountLinking = providerConfig.accountLinking;
@@ -46,6 +48,7 @@ export class OAuth2Settings {
       providerParams.responseMode === 'form_post' ? 'form_post' : 'query';
     this.codeChallengeMethod = providerParams.codeChallengeMethod;
     this.codeVerifier = !isNil(this.codeChallengeMethod) ? uuid() : undefined;
+    this.supportNative = providerParams.supportNative ?? false;
   }
 
   set provider(providerName: string) {

--- a/modules/authentication/src/handlers/oauth2/linkedIn/linkedin.json
+++ b/modules/authentication/src/handlers/oauth2/linkedIn/linkedin.json
@@ -4,5 +4,6 @@
   "responseType": "code",
   "authorizeUrl": "https://www.linkedin.com/oauth/v2/authorization",
   "tokenUrl": "https://www.linkedin.com/oauth/v2/accessToken",
-  "grantType": "authorization_code"
+  "grantType": "authorization_code",
+  "supportNative": false
 }

--- a/modules/authentication/src/handlers/oauth2/microsoft/microsoft.json
+++ b/modules/authentication/src/handlers/oauth2/microsoft/microsoft.json
@@ -5,5 +5,6 @@
   "tokenUrl": "https://login.microsoftonline.com/common/oauth2/v2.0/token",
   "responseMode": "query",
   "responseType": "code",
-  "grantType": "authorization_code"
+  "grantType": "authorization_code",
+  "supportNative": false
 }

--- a/modules/authentication/src/handlers/oauth2/reddit/reddit.json
+++ b/modules/authentication/src/handlers/oauth2/reddit/reddit.json
@@ -4,5 +4,6 @@
   "providerName": "reddit",
   "tokenUrl": "https://www.reddit.com/api/v1/access_token",
   "responseType": "code",
-  "grantType": "authorization_code"
+  "grantType": "authorization_code",
+  "supportNative": false
 }

--- a/modules/authentication/src/handlers/oauth2/slack/slack.json
+++ b/modules/authentication/src/handlers/oauth2/slack/slack.json
@@ -3,5 +3,6 @@
   "authorizeUrl": "https://slack.com/oauth/authorize",
   "providerName": "slack",
   "tokenUrl": "https://slack.com/api/oauth.access",
-  "responseType": "code"
+  "responseType": "code",
+  "supportNative": false
 }

--- a/modules/authentication/src/handlers/oauth2/twitch/twitch.json
+++ b/modules/authentication/src/handlers/oauth2/twitch/twitch.json
@@ -4,5 +4,6 @@
   "providerName": "twitch",
   "tokenUrl": "https://id.twitch.tv/oauth2/token",
   "grantType": "authorization_code",
-  "responseType": "code"
+  "responseType": "code",
+  "supportNative": false
 }

--- a/modules/authentication/src/handlers/oauth2/twitter/twitter.json
+++ b/modules/authentication/src/handlers/oauth2/twitter/twitter.json
@@ -5,5 +5,6 @@
   "tokenUrl": "https://api.twitter.com/2/oauth2/token",
   "responseType": "code",
   "grantType": "authorization_code",
-  "codeChallengeMethod": "S256"
+  "codeChallengeMethod": "S256",
+  "supportNative": false
 }


### PR DESCRIPTION
This PR introduces a new setting in oAuth handlers for native options. This begun mainly for apple login, but should be implemented in other providers, mainly Facebook and Google. For now both of these providers are left in their current state.

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/ConduitPlatform/Conduit/blob/main/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** <!--(check at least one)-->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [x] Refactor
- [ ] Build-related changes
- [ ] Other (please describe)

**Does this PR introduce a breaking change?** <!-- (check one) -->

- [ ] Yes
- [x] No

<!-- If yes, please describe the impact and migration path for existing applications. -->

**The PR fulfills these requirements:**

- [ ] It's submitted to the `main` branch
- [ ] When resolving a specific issue, it's referenced in the PR's description  (e.g. `fix #xxx`, where "xxx" is the issue number)

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature <!-- to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it -->

**Other information:**
