### PR TITLE
fix(storage): integration with non-aws providers issues

### DIFF
--- a/modules/storage/src/Storage.ts
+++ b/modules/storage/src/Storage.ts
@@ -94,6 +94,9 @@ export default class Storage extends ManagedModule<Config> {
       if (isNil(config.aws.accountId)) {
         config.aws.accountId = await getAwsAccountId(config);
       }
+      if (isNil(config.aws.usePathStyle)) {
+        config.aws.usePathStyle = false;
+      }
     }
     return config;
   }

--- a/modules/storage/src/config/config.ts
+++ b/modules/storage/src/config/config.ts
@@ -51,6 +51,12 @@ export default {
       format: 'String',
       default: '',
     },
+    usePathStyle: {
+      description:
+        'Use path style addressing for S3 buckets (only for non-AWS S3 compatible providers)',
+      format: 'Boolean',
+      default: true,
+    },
   },
   aliyun: {
     region: {

--- a/modules/storage/src/interfaces/StorageConfig.ts
+++ b/modules/storage/src/interfaces/StorageConfig.ts
@@ -12,6 +12,7 @@ export interface StorageConfig {
     region: string;
     accountId: string;
     endpoint: string;
+    usePathStyle?: boolean;
   };
   azure: {
     connectionString: string;

--- a/modules/storage/src/utils/index.ts
+++ b/modules/storage/src/utils/index.ts
@@ -24,6 +24,10 @@ export async function streamToBuffer(readableStream: any): Promise<Buffer> {
 }
 
 export async function getAwsAccountId(config: StorageConfig) {
+  // when using non AWS S3 storage provider
+  if (config.aws.endpoint) {
+    return randomUUID();
+  }
   const iamClient = new IAMClient({
     region: config.aws.region,
     credentials: {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/ConduitPlatform/Conduit/blob/main/.github/CONTRIBUTING.md#pull-request-guidelines
-->
This PR fixes some issues when integrating with non-AWS S3 providers.
- The Storage provider assumed that domain-based routing would always be used for file access since AWS deprecated the functionality. A new config parameter usePathStyle has been added to accommodate path-based routing.
- Public URL construction assumed an AWS deployment, this has been modified to construct the URL based on the provided endpoint if not on AWS
- Public URL construction did not apply region on AWS URLs, which typically won't create an issue, but has been added for clarity
<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** <!--(check at least one)-->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other (please describe)

**Does this PR introduce a breaking change?** <!-- (check one) -->

- [ ] Yes
- [x] No

<!-- If yes, please describe the impact and migration path for existing applications. -->

**The PR fulfills these requirements:**

- [x] It's submitted to the `main` branch
- [x] When resolving a specific issue, it's referenced in the PR's description  (e.g. `fix #xxx`, where "xxx" is the issue number)

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature <!-- to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it -->

**Other information:**
