### PR TITLE
feat(authentication, chat) set custom variable values email

### DIFF
--- a/modules/authentication/src/Authentication.ts
+++ b/modules/authentication/src/Authentication.ts
@@ -327,10 +327,13 @@ export default class Authentication extends ManagedModule<Config> {
         });
         const result = { verificationToken, hostUrl: url };
         const link = `${result.hostUrl}/hook/authentication/verify-email/${result.verificationToken.token}`;
+        const safeUser = { ...user };
+        delete safeUser.hashedPassword;
         await this.grpcSdk.emailProvider!.sendEmail('EmailVerification', {
           email: user.email,
           variables: {
             link,
+            user: safeUser,
           },
         });
       } else if (verify) {

--- a/modules/authentication/src/handlers/local.ts
+++ b/modules/authentication/src/handlers/local.ts
@@ -774,10 +774,7 @@ export class LocalHandlers implements IAuthenticationStrategy {
       },
     });
 
-    const userData = await User.getInstance().findOne(
-      { _id: user._id },
-      '-hashedPassword',
-    );
+    delete user.hashedPassword;
 
     if (config.local.verification.method === 'link') {
       const serverConfig = await this.grpcSdk.config.get('router');
@@ -788,7 +785,7 @@ export class LocalHandlers implements IAuthenticationStrategy {
         email: user.email,
         variables: {
           link,
-          user: userData,
+          user,
         },
       });
     } else {
@@ -798,7 +795,7 @@ export class LocalHandlers implements IAuthenticationStrategy {
         email: user.email,
         variables: {
           code: otp,
-          user: userData,
+          user,
         },
       });
       await this.grpcSdk.state!.setKey(emailHash, otp, 2 * 60 * 1000);

--- a/modules/authentication/src/handlers/local.ts
+++ b/modules/authentication/src/handlers/local.ts
@@ -774,6 +774,11 @@ export class LocalHandlers implements IAuthenticationStrategy {
       },
     });
 
+    const userData = await User.getInstance().findOne(
+      { _id: user._id },
+      '-hashedPassword',
+    );
+
     if (config.local.verification.method === 'link') {
       const serverConfig = await this.grpcSdk.config.get('router');
       const url = serverConfig.hostUrl;
@@ -783,6 +788,7 @@ export class LocalHandlers implements IAuthenticationStrategy {
         email: user.email,
         variables: {
           link,
+          user: userData,
         },
       });
     } else {
@@ -792,6 +798,7 @@ export class LocalHandlers implements IAuthenticationStrategy {
         email: user.email,
         variables: {
           code: otp,
+          user: userData,
         },
       });
       await this.grpcSdk.state!.setKey(emailHash, otp, 2 * 60 * 1000);

--- a/modules/authentication/src/handlers/local.ts
+++ b/modules/authentication/src/handlers/local.ts
@@ -432,7 +432,8 @@ export class LocalHandlers implements IAuthenticationStrategy {
       user: user._id,
       token: uuid(),
     });
-
+    const safeUser = { ...user };
+    delete safeUser.hashedPassword;
     const link = `${redirectUri}?reset_token=${passwordResetTokenDoc.token}`;
     if (this.grpcSdk.isAvailable('email')) {
       await this.emailModule
@@ -440,6 +441,7 @@ export class LocalHandlers implements IAuthenticationStrategy {
           email: user.email,
           variables: {
             link,
+            user: safeUser,
           },
         })
         .catch(() => {
@@ -563,11 +565,14 @@ export class LocalHandlers implements IAuthenticationStrategy {
         const link = `${result.hostUrl}/hook/authentication/verify-change-email/${
           result.verificationToken!.token
         }`;
+        const safeUser = { ...user };
+        delete safeUser.hashedPassword;
         await this.emailModule
           .sendEmail('ChangeEmailVerification', {
             email: newEmail,
             variables: {
               link,
+              user: safeUser,
             },
           })
           .catch(e => {
@@ -774,8 +779,8 @@ export class LocalHandlers implements IAuthenticationStrategy {
       },
     });
 
-    delete user.hashedPassword;
-
+    const safeUser = { ...user };
+    delete safeUser.hashedPassword;
     if (config.local.verification.method === 'link') {
       const serverConfig = await this.grpcSdk.config.get('router');
       const url = serverConfig.hostUrl;
@@ -785,7 +790,7 @@ export class LocalHandlers implements IAuthenticationStrategy {
         email: user.email,
         variables: {
           link,
-          user,
+          user: safeUser,
         },
       });
     } else {
@@ -795,7 +800,7 @@ export class LocalHandlers implements IAuthenticationStrategy {
         email: user.email,
         variables: {
           code: otp,
-          user,
+          user: safeUser,
         },
       });
       await this.grpcSdk.state!.setKey(emailHash, otp, 2 * 60 * 1000);

--- a/modules/authentication/src/handlers/team.ts
+++ b/modules/authentication/src/handlers/team.ts
@@ -585,6 +585,8 @@ export class TeamsHandler implements IAuthenticationStrategy {
       inviter: user,
       userData,
     });
+    const safeUser = { ...user };
+    delete safeUser.hashedPassword;
     if (email && config.teams.invites.sendEmail && this.grpcSdk.isAvailable('email')) {
       let link = !isEmpty(redirectUri)
         ? AuthUtils.validateRedirectUri(redirectUri)
@@ -598,6 +600,7 @@ export class TeamsHandler implements IAuthenticationStrategy {
             link,
             teamName: team.name,
             inviterName: user.name,
+            user: safeUser,
           },
         })
         .catch(e => {

--- a/modules/chat/src/utils/index.ts
+++ b/modules/chat/src/utils/index.ts
@@ -39,11 +39,6 @@ export async function sendInvitations(
 ) {
   const roomId = room._id;
 
-  const invitedUsersData = await User.getInstance().findMany(
-    { _id: { $in: users.map(user => user._id) } },
-    '-hashedPassword',
-  );
-
   for (const invitedUser of users) {
     const invitationsCount = await InvitationToken.getInstance().countDocuments({
       room: roomId,
@@ -62,6 +57,10 @@ export async function sendInvitations(
       token: uuid(),
       room: roomId,
     });
+    const safeUser = await User.getInstance().findOne(
+      { _id: invitedUser._id },
+      '-hashedPassword',
+    );
     if (sendEmail) {
       const result = { invitationToken, hostUrl: url };
       const acceptLink = `${result.hostUrl}/hook/chat/invitations/accept/${result.invitationToken.token}`;
@@ -76,7 +75,7 @@ export async function sendInvitations(
             declineLink,
             userName,
             roomName,
-            users: invitedUsersData,
+            user: safeUser,
           },
         })
         .catch((e: Error) => {

--- a/modules/chat/src/utils/index.ts
+++ b/modules/chat/src/utils/index.ts
@@ -38,6 +38,12 @@ export async function sendInvitations(
   grpcSdk: ConduitGrpcSdk,
 ) {
   const roomId = room._id;
+
+  const invitedUsersData = await User.getInstance().findMany(
+    { _id: { $in: users.map(user => user._id) } },
+    '-hashedPassword',
+  );
+
   for (const invitedUser of users) {
     const invitationsCount = await InvitationToken.getInstance().countDocuments({
       room: roomId,
@@ -70,6 +76,7 @@ export async function sendInvitations(
             declineLink,
             userName,
             roomName,
+            users: invitedUsersData,
           },
         })
         .catch((e: Error) => {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/ConduitPlatform/Conduit/blob/main/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->
Task id: 86c30zbjv
Feat: Set custom variable values in emails sent by conduit


**What kind of change does this PR introduce?** <!--(check at least one)-->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other (please describe)

**Does this PR introduce a breaking change?** <!-- (check one) -->

- [ ] Yes
- [x] No

<!-- If yes, please describe the impact and migration path for existing applications. -->

**The PR fulfills these requirements:**

- [ ] It's submitted to the `main` branch
- [x] When resolving a specific issue, it's referenced in the PR's description  (e.g. `fix #xxx`, where "xxx" is the issue number)

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature <!-- to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it -->

**Other information:**

In some cases we want to set additional variables to templates that are used in emails sent by conduit. While it is possible to update the variables array, there is no way to set the variable values when conduit is sending the email.

For example, when a user registers, they have to get a verification email. For this case the EmailVerification template is used and the only variable value set by conduit when sending the email is link

Even if you update the template's variables array, you have to also set the variable's value when sending the email, in order for the actual thing to work.
I think we should find a way to tackle this, at least for the most common emails sent by conduit.