### PR TITLE
feat(chat): add populate param in getMessages function

### DIFF
--- a/modules/chat/src/routes/index.ts
+++ b/modules/chat/src/routes/index.ts
@@ -264,7 +264,7 @@ export class ChatRoutes {
   }
 
   async getMessages(call: ParsedRouterRequest): Promise<UnparsedRouterResponse> {
-    const { roomId, skip, limit } = call.request.params;
+    const { roomId, skip, limit, populate } = call.request.params;
     const { user } = call.request.context;
     let messagesPromise;
     let countPromise;
@@ -284,6 +284,7 @@ export class ChatRoutes {
         skip,
         limit,
         { createdAt: -1 },
+        populate,
       );
       countPromise = ChatMessage.getInstance().countDocuments(query);
     } else {
@@ -305,6 +306,7 @@ export class ChatRoutes {
           skip,
           limit,
           { createdAt: -1 },
+          populate,
         )
         .catch((e: Error) => {
           throw new GrpcError(status.INTERNAL, e.message);
@@ -602,6 +604,7 @@ export class ChatRoutes {
           roomId: ConduitString.Optional,
           skip: ConduitNumber.Optional,
           limit: ConduitNumber.Optional,
+          populate: [ConduitString.Optional],
         },
         middlewares: ['authMiddleware'],
       },


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/ConduitPlatform/Conduit/blob/main/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** <!--(check at least one)-->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other (please describe)

**Does this PR introduce a breaking change?** <!-- (check one) -->

- [ ] Yes
- [x] No

<!-- If yes, please describe the impact and migration path for existing applications. -->

**The PR fulfills these requirements:**

- [ ] It's submitted to the `main` branch
- [ ] When resolving a specific issue, it's referenced in the PR's description  (e.g. `fix #xxx`, where "xxx" is the issue number)

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature <!-- to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it -->

**Other information:**

https://app.clickup.com/t/86c3q10vy

In our projects, until now, when we wanted to get the messages of a chatRoom with populated messages, we had to make a custom endpoint and use findMany<> with populate option. 
With this small fix, we can just use Conduit's GET chat/messages with the new populate option.
