### PR TITLE
feat(authentication): add userData in userCreate grpc

### DIFF
--- a/libraries/grpc-sdk/src/modules/authentication/index.ts
+++ b/libraries/grpc-sdk/src/modules/authentication/index.ts
@@ -10,6 +10,7 @@ import {
   UserModifyStatusResponse,
   InvitationDeleteResponse,
 } from '../../protoUtils/index.js';
+import { Indexable } from '../../interfaces';
 
 export class Authentication extends ConduitModule<typeof AuthenticationDefinition> {
   constructor(
@@ -34,8 +35,15 @@ export class Authentication extends ConduitModule<typeof AuthenticationDefinitio
     verify: boolean = false,
     password?: string,
     anonymousId?: string,
+    userData?: Indexable,
   ): Promise<UserCreateResponse> {
-    return this.client!.userCreate({ email, verify, password, anonymousId });
+    return this.client!.userCreate({
+      email,
+      verify,
+      password,
+      anonymousId,
+      userData: JSON.stringify(userData),
+    });
   }
 
   userCreateByUsername(

--- a/modules/authentication/src/authentication.proto
+++ b/modules/authentication/src/authentication.proto
@@ -12,6 +12,7 @@ message UserCreateRequest {
   optional string password = 2;
   bool verify = 3;
   optional string anonymousId = 4;
+  optional string userData = 5;
 }
 
 message UserCreateByUsernameRequest {


### PR DESCRIPTION
Adding userData in userCreate grpc will allow us to set values to User extended fields (like we do in /local/new) & use them in EmailVerification template <!--
Please make sure to read the Pull Request Guidelines:
https://github.com/ConduitPlatform/Conduit/blob/main/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** <!--(check at least one)-->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other (please describe)

**Does this PR introduce a breaking change?** <!-- (check one) -->

- [ ] Yes
- [x] No

<!-- If yes, please describe the impact and migration path for existing applications. -->

**The PR fulfills these requirements:**

- [x] It's submitted to the `main` branch
- [ ] When resolving a specific issue, it's referenced in the PR's description  (e.g. `fix #xxx`, where "xxx" is the issue number)

If adding a **new feature**, the PR's description includes:

- [x] A convincing reason for adding this feature <!-- to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it -->

**Other information:**
