### PR TITLE
fix(database): rawQuery throwing error on mongoose update methods

### DIFF
--- a/libraries/grpc-sdk/src/interfaces/RawQuery.ts
+++ b/libraries/grpc-sdk/src/interfaces/RawQuery.ts
@@ -13,7 +13,7 @@ export type RawMongoQuery = {
   find?: object;
   insertOne?: object;
   insertMany?: object | object[];
-  updateOne?: object;
+  updateOne?: object | object[];
   updateMany?: object | object[];
   options?: object;
 };

--- a/modules/database/src/adapters/mongoose-adapter/index.ts
+++ b/modules/database/src/adapters/mongoose-adapter/index.ts
@@ -20,7 +20,7 @@ import {
   ConduitDatabaseSchema,
   introspectedSchemaCmsOptionsDefaults,
 } from '../../interfaces/index.js';
-import { isNil, isEqual } from 'lodash-es';
+import { isNil, isEqual, isArray } from 'lodash-es';
 
 // @ts-ignore
 import * as parseSchema from 'mongodb-schema';
@@ -337,9 +337,10 @@ export class MongooseAdapter extends DatabaseAdapter<MongooseSchema> {
       const queryOperation = Object.keys(rawQuery).filter(v => {
         if (v !== 'options') return v;
       })[0];
+      const queryObjects = rawQuery[queryOperation as keyof RawMongoQuery];
       // @ts-ignore
       result = await collection[queryOperation](
-        rawQuery[queryOperation as keyof RawMongoQuery],
+        ...(isArray(queryObjects) ? queryObjects : [queryObjects]), // spread if array
         rawQuery.options,
       );
       if (queryOperation === 'aggregate') {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/ConduitPlatform/Conduit/blob/main/.github/CONTRIBUTING.md#pull-request-guidelines
-->

This PR fixes a bug found when I wanted to use updateOne or updateMany through rawQuery(). 
The only way to set both the ``filter`` and the ``update`` query objects, was to put them together as an array (probably that's why we had defined the type as object[]) and the mongoose updateOne/Many method was not expecting an array.

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** <!--(check at least one)-->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other (please describe)

**Does this PR introduce a breaking change?** <!-- (check one) -->

- [ ] Yes
- [x] No

<!-- If yes, please describe the impact and migration path for existing applications. -->

**The PR fulfills these requirements:**

- [x] It's submitted to the `main` branch
- [x] When resolving a specific issue, it's referenced in the PR's description  (e.g. `fix #xxx`, where "xxx" is the issue number)

If adding a **new feature**, the PR's description includes:

- [x] A convincing reason for adding this feature <!-- to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it -->

**Other information:**
