### PR TITLE
refactor(sms): remove requirement for phone number in twilio

### DIFF
--- a/modules/sms/src/config/config.ts
+++ b/modules/sms/src/config/config.ts
@@ -12,6 +12,7 @@ export default {
     phoneNumber: {
       format: 'String',
       default: '',
+      optional: true,
     },
     accountSID: {
       format: 'String',

--- a/modules/sms/src/providers/twilio.ts
+++ b/modules/sms/src/providers/twilio.ts
@@ -3,14 +3,14 @@ import { ConduitGrpcSdk } from '@conduitplatform/grpc-sdk';
 import twilio from 'twilio';
 
 export class TwilioProvider implements ISmsProvider {
-  private readonly phoneNumber: string;
+  private readonly phoneNumber?: string;
   private readonly accountSID: string;
   private readonly authToken: string;
   private readonly serviceSid: string | undefined;
   private client: twilio.Twilio;
 
   constructor(settings: {
-    phoneNumber: string;
+    phoneNumber?: string;
     accountSID: string;
     authToken: string;
     verify: { active: boolean; serviceSid: string | undefined };
@@ -26,6 +26,8 @@ export class TwilioProvider implements ISmsProvider {
   }
 
   sendSms(to: string, message: string) {
+    if (!this.phoneNumber)
+      return Promise.reject(Error('Phone number missing from settings'));
     return this.client.messages.create({
       body: message,
       to,


### PR DESCRIPTION
Since support was added for Twilio, the prime use case is the "Verify" service. In  accordance to that, there is no requirement for phone number and it's actually part of the value proposition.

Us requiring users to add phone numbers in their config goes against it. So this PR goes ahead and removes it.

In reality when you just want to use verify you can just add a random phone number, it will never be checked.

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/ConduitPlatform/Conduit/blob/main/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** <!--(check at least one)-->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [x] Refactor
- [ ] Build-related changes
- [ ] Other (please describe)

**Does this PR introduce a breaking change?** <!-- (check one) -->

- [ ] Yes
- [x] No

<!-- If yes, please describe the impact and migration path for existing applications. -->

**The PR fulfills these requirements:**

- [ ] It's submitted to the `main` branch
- [ ] When resolving a specific issue, it's referenced in the PR's description  (e.g. `fix #xxx`, where "xxx" is the issue number)

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature <!-- to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it -->

**Other information:**
