### PR TITLE
refactor(authentication,communications,database): remove ts-ignore suppressions

### DIFF
--- a/modules/authentication/src/Authentication.ts
+++ b/modules/authentication/src/Authentication.ts
@@ -676,11 +676,12 @@ export default class Authentication extends ManagedModule<Config> {
     const { email, teamId } = call.request;
 
     try {
-      const deletedToken = await Token.getInstance().deleteOne({
-        // @ts-expect-error Unsafe nested property access
+      const invitationQuery: Indexable = {
         'data.teamId': teamId,
         'data.email': email,
-      });
+      };
+
+      const deletedToken = await Token.getInstance().deleteOne(invitationQuery);
 
       if (deletedToken.deletedCount === 0) {
         return callback({

--- a/modules/authentication/src/handlers/metamask.ts
+++ b/modules/authentication/src/handlers/metamask.ts
@@ -5,6 +5,7 @@ import {
   ConduitRouteActions,
   ConduitRouteReturnDefinition,
   GrpcError,
+  Indexable,
   ParsedRouterRequest,
   UnparsedRouterResponse,
 } from '@conduitplatform/grpc-sdk';
@@ -70,10 +71,11 @@ export class MetamaskHandlers implements IAuthenticationStrategy {
     const { ethPublicAddress } = call.request.params;
     const normalizedEthPublicAddress = ethPublicAddress.toLowerCase();
 
-    const existingUser: User | null = await User.getInstance().findOne({
-      // @ts-expect-error Unsafe nested property access
+    const metamaskQuery: Indexable = {
       'metamask.ethPublicAddress': normalizedEthPublicAddress,
-    });
+    };
+
+    const existingUser: User | null = await User.getInstance().findOne(metamaskQuery);
 
     if (existingUser) {
       return { nonce: existingUser.metamask!.nonce };
@@ -100,10 +102,11 @@ export class MetamaskHandlers implements IAuthenticationStrategy {
       throw new GrpcError(status.UNAUTHENTICATED, 'No headers provided');
     }
 
-    const user = await User.getInstance().findOne({
-      // @ts-expect-error Unsafe nested property access
+    const metamaskQuery: Indexable = {
       'metamask.ethPublicAddress': normalizedEthPublicAddress,
-    });
+    };
+
+    const user = await User.getInstance().findOne(metamaskQuery);
 
     if (isNil(user)) {
       throw new GrpcError(
@@ -145,10 +148,11 @@ export class MetamaskHandlers implements IAuthenticationStrategy {
       );
     }
 
-    await User.getInstance().findByIdAndUpdate(user._id, {
-      // @ts-expect-error Unsafe nested property access
+    const nonceUpdate: Indexable = {
       'metamask.nonce': uuid(),
-    });
+    };
+
+    await User.getInstance().findByIdAndUpdate(user._id, nonceUpdate);
 
     ConduitGrpcSdk.Metrics?.increment('logged_in_users_total');
     const config = ConfigController.getInstance().config;

--- a/modules/authentication/src/handlers/team.ts
+++ b/modules/authentication/src/handlers/team.ts
@@ -134,11 +134,12 @@ export class TeamsHandler implements IAuthenticationStrategy {
   }
 
   async getUserInvites(call: ParsedRouterRequest): Promise<UnparsedRouterResponse> {
-    const invites = await Token.getInstance().findMany({
+    const userInvitesQuery: Indexable = {
       tokenType: TokenType.TEAM_INVITE_TOKEN,
-      // @ts-ignore
       'data.email': call.request.context.user.email,
-    });
+    };
+
+    const invites = await Token.getInstance().findMany(userInvitesQuery);
     return {
       invites: invites.map(invite => ({
         teamId: invite.data.teamId,
@@ -579,12 +580,13 @@ export class TeamsHandler implements IAuthenticationStrategy {
     }
 
     // Delete any existing invite for the same email and team
-    await Token.getInstance().deleteOne({
+    const existingInviteQuery: Indexable = {
       tokenType: TokenType.TEAM_INVITE_TOKEN,
-      // @ts-expect-error Unsafe nested property access
       'data.teamId': teamId,
       'data.email': email,
-    });
+    };
+
+    await Token.getInstance().deleteOne(existingInviteQuery);
 
     const invitation = await this.createUserInvitation({
       teamId,
@@ -645,12 +647,13 @@ export class TeamsHandler implements IAuthenticationStrategy {
     }
 
     // Delete any existing invite for the same email and team
-    await Token.getInstance().deleteOne({
+    const invitationQuery: Indexable = {
       tokenType: TokenType.TEAM_INVITE_TOKEN,
-      // @ts-expect-error Unsafe nested property access
       'data.teamId': teamId,
       'data.email': email,
-    });
+    };
+
+    await Token.getInstance().deleteOne(invitationQuery);
 
     return 'OK';
   }
@@ -682,17 +685,14 @@ export class TeamsHandler implements IAuthenticationStrategy {
       );
     }
 
-    const invites = await Token.getInstance().findMany({
+    const teamInvitesQuery: Indexable = {
       tokenType: TokenType.TEAM_INVITE_TOKEN,
-      // @ts-expect-error Unsafe nested property access
       'data.teamId': teamId,
-    });
+    };
 
-    const count = await Token.getInstance().countDocuments({
-      tokenType: TokenType.TEAM_INVITE_TOKEN,
-      // @ts-expect-error Unsafe nested property access
-      'data.teamId': teamId,
-    });
+    const invites = await Token.getInstance().findMany(teamInvitesQuery);
+
+    const count = await Token.getInstance().countDocuments(teamInvitesQuery);
 
     return {
       invites,

--- a/modules/database/src/adapters/DatabaseAdapter.ts
+++ b/modules/database/src/adapters/DatabaseAdapter.ts
@@ -472,16 +472,29 @@ export abstract class DatabaseAdapter<T extends Schema> {
       canModify: 'Everything',
       canDelete: true,
     } as const;
+
+    const setDefaultPermission = <K extends keyof typeof defaultPermissions>(
+      permissions: NonNullable<
+        NonNullable<ConduitSchema['modelOptions']['conduit']>['permissions']
+      >,
+      key: K,
+    ) => {
+      if (!Object.prototype.hasOwnProperty.call(permissions, key)) {
+        permissions[key] = defaultPermissions[key];
+      }
+    };
+
     if (isNil(schema.modelOptions.conduit)) schema.modelOptions.conduit = {};
+
     if (isNil(schema.modelOptions.conduit.permissions)) {
-      schema.modelOptions.conduit!.permissions = defaultPermissions;
+      schema.modelOptions.conduit.permissions = { ...defaultPermissions };
     } else {
-      Object.keys(defaultPermissions).forEach(perm => {
-        if (!schema.modelOptions.conduit!.permissions!.hasOwnProperty(perm)) {
-          // @ts-ignore
-          schema.modelOptions.conduit!.permissions![perm] =
-            defaultPermissions[perm as keyof typeof defaultPermissions];
-        }
+      const permissions = schema.modelOptions.conduit.permissions;
+      const defaultPermissionKeys = Object.keys(defaultPermissions) as Array<
+        keyof typeof defaultPermissions
+      >;
+      defaultPermissionKeys.forEach(perm => {
+        setDefaultPermission(permissions, perm);
       });
     }
     return schema;

--- a/modules/database/src/adapters/utils/database-transform-utils.ts
+++ b/modules/database/src/adapters/utils/database-transform-utils.ts
@@ -120,9 +120,8 @@ export function extractFieldProperties(
   } else if (objectField.hasOwnProperty('unique') && objectField.unique) {
     res.unique = objectField.unique ?? false;
     res.allowNull = false;
-  } else if (objectField.hasOwnProperty('required') && objectField.required) {
-    // @ts-expect-error
-    res.allowNull = !objectField.required ?? true;
+  } else if (objectField.hasOwnProperty('required') && isBoolean(objectField.required)) {
+    res.allowNull = !objectField.required;
   }
 
   return res;

--- a/modules/database/src/utils/utilities.ts
+++ b/modules/database/src/utils/utilities.ts
@@ -199,22 +199,28 @@ function validateCrudOperations(crudOperations: CrudOperations) {
     throw new Error(`CMS field 'crudOperations' must be of type Object`);
 
   Object.keys(crudOperations).forEach(op => {
-    if (!allowedCrudOperations.includes(op as keyof CrudOperations)) {
+    const crudOperation = op as keyof CrudOperations;
+
+    if (!allowedCrudOperations.includes(crudOperation)) {
       throw new Error(`Unrecognized CRUD operation '${op}' provided`);
     }
-    // @ts-ignore
-    if (!isObject(crudOperations[op])) {
+
+    const operationConfig = crudOperations[crudOperation];
+
+    if (!isObject(operationConfig)) {
       throw new Error(`Crud operation field '${op}' must be of type Object`);
     }
-    // @ts-ignore
-    Object.keys(crudOperations[op]).forEach(opField => {
-      if (!['enabled', 'authenticated'].includes(opField)) {
+
+    Object.keys(operationConfig).forEach(opField => {
+      const crudOperationField = opField as keyof typeof operationConfig;
+
+      if (!['enabled', 'authenticated'].includes(crudOperationField)) {
         throw new Error(
           `Unrecognized crud operation field '${opField}' for operation '${op}' provided`,
         );
       }
-      // @ts-ignore
-      if (!isBoolean(crudOperations[op][opField])) {
+
+      if (!isBoolean(operationConfig[crudOperationField])) {
         throw new Error(
           `Crud operation field '${opField}' for operation '${op}' must be of type Boolean`,
         );

--- a/modules/email/src/email-provider/transports/mandrill/MandrilProvider.ts
+++ b/modules/email/src/email-provider/transports/mandrill/MandrilProvider.ts
@@ -9,8 +9,6 @@ import { getHandleBarsValues } from '../../utils/index.js';
 import { UpdateEmailTemplate } from '../../interfaces/UpdateEmailTemplate.js';
 import { MandrillTemplate } from '../../interfaces/mandrill/MandrillTemplate.js';
 
-// @ts-expect-error
-// missing typings for nodemailer-mandrill-transport
 import mandrillTransport from 'nodemailer-mandrill-transport';
 import { Indexable } from '@conduitplatform/grpc-sdk';
 

--- a/modules/email/src/types/nodemailer-mandrill-transport.d.ts
+++ b/modules/email/src/types/nodemailer-mandrill-transport.d.ts
@@ -1,0 +1,13 @@
+declare module 'nodemailer-mandrill-transport' {
+  import type { Transport } from 'nodemailer';
+
+  interface MandrillTransportOptions {
+    auth: {
+      apiKey: string;
+    };
+  }
+
+  function mandrillTransport(options: MandrillTransportOptions): Transport;
+
+  export default mandrillTransport;
+}

--- a/modules/storage/src/utils/index.ts
+++ b/modules/storage/src/utils/index.ts
@@ -13,17 +13,25 @@ import { randomUUID } from 'node:crypto';
 import { ConfigController } from '@conduitplatform/module-tools';
 import { status } from '@grpc/grpc-js';
 
-export async function streamToBuffer(readableStream: any): Promise<Buffer> {
-  return new Promise((resolve, reject) => {
+export async function streamToBuffer(
+  readableStream?: NodeJS.ReadableStream,
+): Promise<Buffer> {
+  return new Promise<Buffer>((resolve, reject) => {
+    if (!readableStream) {
+      reject(new Error('Readable stream is undefined'));
+      return;
+    }
+
     const chunks: Buffer[] = [];
-    readableStream.on('data', (data: any) => {
-      chunks.push(data instanceof Buffer ? data : Buffer.from(data));
+
+    readableStream.on('data', (data: string | Buffer | Uint8Array) => {
+      chunks.push(Buffer.isBuffer(data) ? data : Buffer.from(data));
     });
+
     readableStream.on('end', () => {
-      // shouldn't really provide an error
-      // @ts-expect-error
-      resolve(Buffer.concat(chunks));
+      resolve(Buffer.concat(chunks as unknown as readonly Uint8Array[]));
     });
+
     readableStream.on('error', reject);
   });
 }


### PR DESCRIPTION

**What kind of change does this PR introduce?** <!--(check at least one)-->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [x] Refactor
- [ ] Build-related changes
- [ ] Other (please describe)

**Does this PR introduce a breaking change?** <!-- (check one) -->

- [ ] Yes
- [x] No



**The PR fulfills these requirements:**

- [x] It's submitted to the `main` branch
- [ ] When resolving a specific issue, it's referenced in the PR's description  (e.g. `fix #xxx`, where "xxx" is the issue number)

If adding a **new feature**, the PR's description includes:


**Other information:**
## Summary

This PR removes the assigned `@ts-ignore` / `@ts-expect-error` suppressions and replaces them with explicit TypeScript-safe handling.

## Changes

### Task A — CRUD validation helpers

**File:** `modules/database/src/utils/utilities.ts`  
**Lines:** 199–224

`Object.keys()` returns `string[]`, so TypeScript could not safely index `crudOperations[op]` or nested fields. I narrowed the dynamic keys to `keyof CrudOperations` / `keyof typeof operationConfig`, stored the operation config in a typed local variable, and removed the three `@ts-ignore` comments.

### Task B — DB transform / `allowNull`

**File:** `modules/database/src/adapters/utils/database-transform-utils.ts`  
**Lines:** 123–124

`objectField` is typed as `Indexable`, so TypeScript could not assume `objectField.required` was a boolean. I added an explicit `isBoolean(objectField.required)` guard and simplified the assignment to `res.allowNull = !objectField.required`, removing the `@ts-expect-error`.

### Task C — Default schema permissions

**File:** `modules/database/src/adapters/DatabaseAdapter.ts`  
**Lines:** ~472–496

`Object.keys(defaultPermissions)` returns `string[]`, and `permissions` is optional in the schema type. I added a typed helper for assigning default permissions, typed the keys as `Array<keyof typeof defaultPermissions>`, and removed the `@ts-ignore`.

### Task D — Mandrill mail transport

**File:** `modules/email/src/email-provider/transports/mandrill/MandrilProvider.ts`  
**New file:** `modules/email/src/types/nodemailer-mandrill-transport.d.ts`

`nodemailer-mandrill-transport` does not provide TypeScript declarations. I removed the `@ts-expect-error` from the import and added a local module declaration file for the package.

### Task E — Stream → buffer

**File:** `modules/storage/src/utils/index.ts`  
**Lines:** 16–35

The original implementation used `Buffer.concat(chunks)`, but this project’s typings report `Buffer` as incompatible with `Uint8Array`. I typed the stream and chunk input, normalized chunks to `Buffer`, and used a narrow local cast at the `Buffer.concat` call instead of suppressing the error.

### Task F — Invitation delete

**File:** `modules/authentication/src/Authentication.ts`  
**Lines:** 679–684

The delete query uses Mongo-style dotted keys (`data.teamId`, `data.email`), which TypeScript cannot treat as normal Token model properties. I extracted the query into an `Indexable` object and passed it to `deleteOne`.

### Task G — Authentication handlers

**Files:**  
`modules/authentication/src/handlers/metamask.ts`  
`modules/authentication/src/handlers/team.ts`

**Lines:**  
`metamask.ts`: 74, 105, 151  
`team.ts`: 137, 583, 650, 688–695

Several queries and updates used Mongo-style dotted keys such as `metamask.ethPublicAddress`, `metamask.nonce`, `data.email`, and `data.teamId`. I extracted these into explicit `Indexable` query/update objects and removed the suppressions.

