### PR TITLE
refactor(communications): port bulk push send APIs from v0.16.x (#1476)

### DIFF
--- a/libraries/grpc-sdk/src/modules/pushNotifications/index.ts
+++ b/libraries/grpc-sdk/src/modules/pushNotifications/index.ts
@@ -76,17 +76,15 @@ export class PushNotifications extends ConduitModule<typeof CommunicationsDefini
   }
 
   sendManyNotifications(
-    notifications: [
-      {
-        sendTo: string;
-        title: string;
-        body?: string;
-        data?: string;
-        platform?: string;
-        doNotStore?: boolean;
-        isSilent?: boolean;
-      },
-    ],
+    notifications: {
+      sendTo: string;
+      title: string;
+      body?: string;
+      data?: string;
+      platform?: string;
+      doNotStore?: boolean;
+      isSilent?: boolean;
+    }[],
   ) {
     return this.client!.sendManyNotifications({
       notifications,

--- a/modules/communications/src/Communications.ts
+++ b/modules/communications/src/Communications.ts
@@ -427,6 +427,7 @@ export default class Communications extends ManagedModule<Config> {
         doNotStore: call.request.doNotStore,
         isSilent: call.request.isSilent,
       });
+      ConduitGrpcSdk.Metrics?.increment('push_notifications_sent_total', 1);
     } catch (e) {
       return callback({ code: status.INTERNAL, message: (e as Error).message });
     }
@@ -437,8 +438,14 @@ export default class Communications extends ManagedModule<Config> {
     call: GrpcRequest<SendNotificationToManyDevicesRequest>,
     callback: GrpcCallback<SendNotificationResponse>,
   ) {
+    if (call.request.sendTo.length === 0) {
+      return callback({
+        code: status.INVALID_ARGUMENT,
+        message: 'sendTo is required and must be a non-empty array',
+      });
+    }
     try {
-      await this.pushService.sendToManyDevices({
+      const result = await this.pushService.sendToManyDevices({
         sendTo: call.request.sendTo,
         title: call.request.title,
         body: call.request.body,
@@ -447,6 +454,10 @@ export default class Communications extends ManagedModule<Config> {
         doNotStore: call.request.doNotStore,
         isSilent: call.request.isSilent,
       });
+      ConduitGrpcSdk.Metrics?.increment(
+        'push_notifications_sent_total',
+        result.successCount,
+      );
     } catch (e) {
       return callback({ code: status.INTERNAL, message: (e as Error).message });
     }
@@ -457,6 +468,12 @@ export default class Communications extends ManagedModule<Config> {
     call: GrpcRequest<SendManyNotificationsRequest>,
     callback: GrpcCallback<SendNotificationResponse>,
   ) {
+    if (call.request.notifications.length === 0) {
+      return callback({
+        code: status.INVALID_ARGUMENT,
+        message: 'notifications is required and must be a non-empty array',
+      });
+    }
     try {
       const notifications = call.request.notifications.map(notification => ({
         sendTo: notification.sendTo,
@@ -467,7 +484,11 @@ export default class Communications extends ManagedModule<Config> {
         doNotStore: notification.doNotStore,
         isSilent: notification.isSilent,
       }));
-      await this.pushService.sendManyNotifications(notifications);
+      const result = await this.pushService.sendManyNotifications(notifications);
+      ConduitGrpcSdk.Metrics?.increment(
+        'push_notifications_sent_total',
+        result.successCount,
+      );
     } catch (e) {
       return callback({ code: status.INTERNAL, message: (e as Error).message });
     }

--- a/modules/communications/src/providers/push/AmazonSNS.provider.ts
+++ b/modules/communications/src/providers/push/AmazonSNS.provider.ts
@@ -7,13 +7,21 @@ import { BaseNotificationProvider } from './base.provider.js';
 import { ConduitGrpcSdk, PlatformTypesEnum } from '@conduitplatform/grpc-sdk';
 import { IAmazonSNSSettings } from '../../interfaces/index.js';
 import { NotificationToken } from '../../models/index.js';
-import { ISendNotification, ISendNotificationToManyDevices } from './interfaces/index.js';
+import {
+  IPushBatchResult,
+  IPushSendFailure,
+  IPushTokenTarget,
+  ISendNotification,
+  ISendNotificationToManyDevices,
+} from './interfaces/index.js';
 
 // Mapping between Conduit platforms and AWS SNS message types
 const CONDUIT_TO_AWS_PLATFORM: Partial<Record<PlatformTypesEnum, 'GCM' | 'APNS'>> = {
   [PlatformTypesEnum.ANDROID]: 'GCM',
   [PlatformTypesEnum.IOS]: 'APNS',
 };
+
+const SNS_SEND_CONCURRENCY = 10;
 
 export class AmazonSNSProvider extends BaseNotificationProvider<IAmazonSNSSettings> {
   private snsClient: SNSClient;
@@ -49,7 +57,6 @@ export class AmazonSNSProvider extends BaseNotificationProvider<IAmazonSNSSettin
   }
 
   async registerDeviceToken(token: string, platform: PlatformTypesEnum): Promise<string> {
-    // Get the appropriate application ARN based on platform
     const applicationArn =
       platform === PlatformTypesEnum.ANDROID
         ? this.settings.gcmApplicationArn
@@ -76,7 +83,6 @@ export class AmazonSNSProvider extends BaseNotificationProvider<IAmazonSNSSettin
       throw error;
     }
 
-    // Update the existing token entry with the new ARN
     await NotificationToken.getInstance().updateOne(
       { token: token },
       { token: endpointResponse.EndpointArn as string },
@@ -85,13 +91,57 @@ export class AmazonSNSProvider extends BaseNotificationProvider<IAmazonSNSSettin
     return endpointResponse.EndpointArn as string;
   }
 
+  private isPermanentSnsEndpointError(error: unknown): boolean {
+    if (!error || typeof error !== 'object') return false;
+    const err = error as {
+      name?: string;
+      Code?: string;
+      code?: string;
+      message?: string;
+    };
+    const name = err.name ?? '';
+    const code = String(err.Code ?? err.code ?? '');
+
+    if (
+      name === 'EndpointDisabledException' ||
+      code === 'EndpointDisabled' ||
+      name === 'EndpointDisabled'
+    ) {
+      return true;
+    }
+
+    if (name === 'NotFoundException' || code === 'NotFound' || name === 'NotFound') {
+      return true;
+    }
+
+    if (
+      name === 'InvalidParameterException' ||
+      code === 'InvalidParameter' ||
+      name === 'InvalidParameter'
+    ) {
+      const message = String(err.message ?? '').toLowerCase();
+      return (
+        message.includes('endpoint') &&
+        (message.includes('not found') ||
+          message.includes('does not exist') ||
+          message.includes('invalid') ||
+          message.includes('disabled'))
+      );
+    }
+
+    return false;
+  }
+
+  private async deleteToken(token: string): Promise<void> {
+    await NotificationToken.getInstance().deleteOne({ token });
+  }
+
   async sendMessage(
     token: string,
     params: ISendNotification | ISendNotificationToManyDevices,
   ): Promise<void | string> {
     const { title, body, data, isSilent = false, platform } = params;
 
-    // Get the AWS platform type for the message structure
     const awsPlatform = CONDUIT_TO_AWS_PLATFORM[platform as PlatformTypesEnum];
     if (!awsPlatform) {
       throw new Error(
@@ -99,7 +149,6 @@ export class AmazonSNSProvider extends BaseNotificationProvider<IAmazonSNSSettin
       );
     }
 
-    // Message payload
     const message: Record<string, string> = {
       default: JSON.stringify({ title, body, data }),
     };
@@ -133,10 +182,9 @@ export class AmazonSNSProvider extends BaseNotificationProvider<IAmazonSNSSettin
       );
     }
 
-    // Sending the message.
     try {
       const command = new PublishCommand({
-        TargetArn: token, // Using the registered token directly
+        TargetArn: token,
         Message: JSON.stringify(message),
         MessageStructure: 'json',
       });
@@ -152,5 +200,46 @@ export class AmazonSNSProvider extends BaseNotificationProvider<IAmazonSNSSettin
       ConduitGrpcSdk.Logger.error(`Failed to send SNS message: ${error}`);
       throw error;
     }
+  }
+
+  async sendMessages(
+    targets: IPushTokenTarget[],
+    params: ISendNotification | ISendNotificationToManyDevices,
+  ): Promise<IPushBatchResult> {
+    const failures: IPushSendFailure[] = [];
+    const deletePromises: Promise<void>[] = [];
+    let successCount = 0;
+
+    for (let i = 0; i < targets.length; i += SNS_SEND_CONCURRENCY) {
+      const chunk = targets.slice(i, i + SNS_SEND_CONCURRENCY);
+      await Promise.all(
+        chunk.map(async target => {
+          try {
+            await this.sendMessage(target.token, {
+              ...params,
+              platform: params.platform ?? target.platform,
+            });
+            successCount++;
+          } catch (error) {
+            failures.push({
+              token: target.token,
+              platform: target.platform,
+              error,
+            });
+            if (this.isPermanentSnsEndpointError(error)) {
+              deletePromises.push(this.deleteToken(target.token));
+            }
+          }
+        }),
+      );
+    }
+
+    await Promise.all(deletePromises);
+
+    return {
+      successCount,
+      failureCount: failures.length,
+      failures,
+    };
   }
 }

--- a/modules/communications/src/providers/push/Firebase.provider.ts
+++ b/modules/communications/src/providers/push/Firebase.provider.ts
@@ -1,10 +1,21 @@
 import { BaseNotificationProvider } from './base.provider.js';
 import { ConduitGrpcSdk } from '@conduitplatform/grpc-sdk';
-import { getMessaging, Message, Messaging } from 'firebase-admin/messaging';
+import {
+  getMessaging,
+  Message,
+  Messaging,
+  MulticastMessage,
+} from 'firebase-admin/messaging';
 import { cert, initializeApp, ServiceAccount } from 'firebase-admin/app';
 import { NotificationToken } from '../../models/index.js';
 import { IFirebaseSettings } from '../../interfaces/index.js';
-import { ISendNotification, ISendNotificationToManyDevices } from './interfaces/index.js';
+import {
+  IPushBatchResult,
+  IPushSendFailure,
+  IPushTokenTarget,
+  ISendNotification,
+  ISendNotificationToManyDevices,
+} from './interfaces/index.js';
 
 export class FirebaseProvider extends BaseNotificationProvider<IFirebaseSettings> {
   private fcm?: Messaging;
@@ -38,16 +49,12 @@ export class FirebaseProvider extends BaseNotificationProvider<IFirebaseSettings
     }
   }
 
-  async sendMessage(
-    token: string,
+  private buildFcmPayload(
     params: ISendNotification | ISendNotificationToManyDevices,
-  ) {
+  ): Omit<MulticastMessage, 'tokens'> {
     const { title, body, data } = params;
-
-    let message: Message;
     if (params.isSilent) {
-      message = {
-        token: token,
+      return {
         data: {
           ...data,
         },
@@ -62,21 +69,107 @@ export class FirebaseProvider extends BaseNotificationProvider<IFirebaseSettings
           },
         },
       };
-    } else {
-      message = {
-        token: token,
-        notification: {
-          title,
-          body,
-        },
-        data: {
-          ...data,
-        },
-      };
     }
+    return {
+      notification: {
+        title,
+        body,
+      },
+      data: {
+        ...data,
+      },
+    };
+  }
+
+  private isPermanentFcmTokenError(error: unknown): boolean {
+    const code =
+      error && typeof error === 'object' && 'code' in error
+        ? String((error as { code?: string }).code)
+        : '';
+    return (
+      code === 'messaging/registration-token-not-registered' ||
+      code === 'messaging/invalid-registration-token'
+    );
+  }
+
+  private async deleteToken(token: string): Promise<void> {
+    await NotificationToken.getInstance().deleteOne({ token });
+  }
+
+  async sendMessage(
+    token: string,
+    params: ISendNotification | ISendNotificationToManyDevices,
+  ) {
+    const message: Message = {
+      token,
+      ...this.buildFcmPayload(params),
+    };
     return this.fcm!.send(message).catch(e => {
       ConduitGrpcSdk.Logger.error('Failed to send notification: ', e);
-      NotificationToken.getInstance().deleteOne({ token });
+      if (this.isPermanentFcmTokenError(e)) {
+        void this.deleteToken(token);
+      }
     });
+  }
+
+  async sendMessages(
+    targets: IPushTokenTarget[],
+    params: ISendNotification | ISendNotificationToManyDevices,
+  ): Promise<IPushBatchResult> {
+    const multicast: MulticastMessage = {
+      tokens: targets.map(target => target.token),
+      ...this.buildFcmPayload(params),
+    };
+
+    const failures: IPushSendFailure[] = [];
+    const deletePromises: Promise<void>[] = [];
+
+    let response;
+    try {
+      response = await this.fcm!.sendEachForMulticast(multicast);
+    } catch (error) {
+      ConduitGrpcSdk.Logger.error(`Failed to send multicast notification: ${error}`);
+      return {
+        successCount: 0,
+        failureCount: targets.length,
+        failures: targets.map(target => ({
+          token: target.token,
+          platform: target.platform,
+          error,
+          reason:
+            error && typeof error === 'object' && 'code' in error
+              ? String((error as { code?: string }).code)
+              : undefined,
+        })),
+      };
+    }
+
+    response.responses.forEach((sendResponse, index) => {
+      if (sendResponse.success) return;
+      const target = targets[index];
+      const error = sendResponse.error;
+      ConduitGrpcSdk.Logger.error(
+        error instanceof Error
+          ? error
+          : `Failed to send notification: ${error?.code ?? error}`,
+      );
+      failures.push({
+        token: target.token,
+        platform: target.platform,
+        error,
+        reason: error?.code,
+      });
+      if (this.isPermanentFcmTokenError(error)) {
+        deletePromises.push(this.deleteToken(target.token));
+      }
+    });
+
+    await Promise.all(deletePromises);
+
+    return {
+      successCount: response.successCount,
+      failureCount: response.failureCount,
+      failures,
+    };
   }
 }

--- a/modules/communications/src/providers/push/OneSignal.provider.ts
+++ b/modules/communications/src/providers/push/OneSignal.provider.ts
@@ -2,7 +2,13 @@ import { BaseNotificationProvider } from './base.provider.js';
 import { createConfiguration, DefaultApi, Notification } from '@onesignal/node-onesignal';
 import { ConduitGrpcSdk } from '@conduitplatform/grpc-sdk';
 import { IOneSignalSettings } from '../../interfaces/index.js';
-import { ISendNotification, ISendNotificationToManyDevices } from './interfaces/index.js';
+import {
+  IPushBatchResult,
+  IPushSendFailure,
+  IPushTokenTarget,
+  ISendNotification,
+  ISendNotificationToManyDevices,
+} from './interfaces/index.js';
 import { NotificationToken } from '../../models/index.js';
 
 export class OneSignalProvider extends BaseNotificationProvider<IOneSignalSettings> {
@@ -17,36 +23,87 @@ export class OneSignalProvider extends BaseNotificationProvider<IOneSignalSettin
     this.appId = settings.appId;
   }
 
+  protected getSendChunkSize(): number {
+    return 2000;
+  }
+
+  private buildNotification(
+    subscriptionIds: string[],
+    params: ISendNotification | ISendNotificationToManyDevices,
+  ): Notification {
+    const { title, body, data } = params;
+    if (params.isSilent) {
+      return {
+        content_available: true,
+        app_id: this.appId,
+        data: { ...data },
+        include_subscription_ids: subscriptionIds,
+      };
+    }
+    return {
+      app_id: this.appId,
+      contents: { en: body ?? '' },
+      headings: { en: title },
+      data: { ...data },
+      include_subscription_ids: subscriptionIds,
+    };
+  }
+
+  private async cleanupInvalidSubscriptionIds(invalidIds: string[]): Promise<void> {
+    if (invalidIds.length === 0) return;
+    await NotificationToken.getInstance().deleteMany({
+      token: { $in: invalidIds },
+    });
+  }
+
   async sendMessage(
     token: string | string[],
     params: ISendNotification | ISendNotificationToManyDevices,
   ) {
-    const { title, body, data } = params;
-
-    let notification: Notification;
-    if (params.isSilent) {
-      notification = {
-        content_available: true,
-        app_id: this.appId,
-        data: { ...data },
-        include_subscription_ids: Array.isArray(token) ? token : [token],
-      };
-    } else {
-      notification = {
-        app_id: this.appId,
-        contents: { en: body ?? '' },
-        headings: { en: title },
-        data: { ...data },
-        include_subscription_ids: Array.isArray(token) ? token : [token],
-      };
-    }
-    const response = await this.client!.createNotification(notification);
-    if (response.errors?.invalid_player_ids?.length) {
-      await NotificationToken.getInstance().deleteMany({
-        token: { $in: response.errors.invalid_player_ids },
-      });
-    }
+    const subscriptionIds = Array.isArray(token) ? token : [token];
+    const response = await this.client!.createNotification(
+      this.buildNotification(subscriptionIds, params),
+    );
+    await this.cleanupInvalidSubscriptionIds(response.errors?.invalid_player_ids ?? []);
     return;
+  }
+
+  async sendMessages(
+    targets: IPushTokenTarget[],
+    params: ISendNotification | ISendNotificationToManyDevices,
+  ): Promise<IPushBatchResult> {
+    const subscriptionIds = targets.map(target => target.token);
+    try {
+      const response = await this.client!.createNotification(
+        this.buildNotification(subscriptionIds, params),
+      );
+      const invalidIds = new Set<string>(response.errors?.invalid_player_ids ?? []);
+      await this.cleanupInvalidSubscriptionIds([...invalidIds]);
+
+      const failures: IPushSendFailure[] = targets
+        .filter(target => invalidIds.has(target.token))
+        .map(target => ({
+          token: target.token,
+          platform: target.platform,
+          reason: 'invalid_player_id',
+        }));
+
+      return {
+        successCount: targets.length - failures.length,
+        failureCount: failures.length,
+        failures,
+      };
+    } catch (error) {
+      return {
+        successCount: 0,
+        failureCount: targets.length,
+        failures: targets.map(target => ({
+          token: target.token,
+          platform: target.platform,
+          error,
+        })),
+      };
+    }
   }
 
   updateProvider(settings: IOneSignalSettings) {

--- a/modules/communications/src/providers/push/base.provider.ts
+++ b/modules/communications/src/providers/push/base.provider.ts
@@ -1,8 +1,19 @@
 import { ConduitGrpcSdk, PlatformTypesEnum } from '@conduitplatform/grpc-sdk';
 import { validateNotification } from './utils/index.js';
-import { isNil, keyBy } from 'lodash-es';
+import { groupBy, isNil } from 'lodash-es';
 import { NotificationToken, Notification, User } from '../../models/index.js';
-import { ISendNotification, ISendNotificationToManyDevices } from './interfaces/index.js';
+import {
+  IPushBatchResult,
+  IPushSendAggregateResult,
+  IPushSendFailure,
+  IPushTokenTarget,
+  ISendNotification,
+  ISendNotificationToManyDevices,
+} from './interfaces/index.js';
+
+const RECIPIENT_PAGE_SIZE = 1000;
+const DEFAULT_SEND_CHUNK_SIZE = 500;
+const SEND_CONCURRENCY = 10;
 
 export class BaseNotificationProvider<T> {
   _initialized: boolean = true;
@@ -21,6 +32,211 @@ export class BaseNotificationProvider<T> {
     params: ISendNotification | ISendNotificationToManyDevices,
   ): Promise<void | string> {
     return Promise.resolve();
+  }
+
+  async sendMessages(
+    targets: IPushTokenTarget[],
+    params: ISendNotification | ISendNotificationToManyDevices,
+  ): Promise<IPushBatchResult> {
+    const outcomes = await this.mapWithConcurrency(
+      targets,
+      SEND_CONCURRENCY,
+      async target => {
+        try {
+          await this.sendMessage(target.token, {
+            ...params,
+            platform: params.platform ?? target.platform,
+          });
+          return { ok: true as const };
+        } catch (error) {
+          return {
+            ok: false as const,
+            failure: {
+              token: target.token,
+              platform: target.platform,
+              error,
+            },
+          };
+        }
+      },
+    );
+
+    const failures: IPushSendFailure[] = [];
+    let successCount = 0;
+    for (const outcome of outcomes) {
+      if (outcome.ok) successCount++;
+      else failures.push(outcome.failure);
+    }
+
+    return {
+      successCount,
+      failureCount: failures.length,
+      failures,
+    };
+  }
+
+  protected getSendChunkSize(): number {
+    return DEFAULT_SEND_CHUNK_SIZE;
+  }
+
+  protected chunkItems<V>(items: V[], chunkSize: number = RECIPIENT_PAGE_SIZE): V[][] {
+    if (items.length === 0) return [];
+    const chunks: V[][] = [];
+    for (let i = 0; i < items.length; i += chunkSize) {
+      chunks.push(items.slice(i, i + chunkSize));
+    }
+    return chunks;
+  }
+
+  protected toTokenTargets(tokens: NotificationToken[]): IPushTokenTarget[] {
+    return tokens.map(token => ({
+      token: token.token,
+      platform: token.platform,
+    }));
+  }
+
+  protected groupTargetsByPlatform(
+    targets: IPushTokenTarget[],
+    platform?: string,
+  ): IPushTokenTarget[][] {
+    const groups = new Map<string, IPushTokenTarget[]>();
+    for (const target of targets) {
+      const effectivePlatform = platform ?? target.platform;
+      const bucket = groups.get(effectivePlatform) ?? [];
+      bucket.push(target);
+      groups.set(effectivePlatform, bucket);
+    }
+    return [...groups.values()];
+  }
+
+  protected chunkTargets(
+    targets: IPushTokenTarget[],
+    chunkSize: number = this.getSendChunkSize(),
+  ): IPushTokenTarget[][] {
+    return this.chunkItems(targets, chunkSize);
+  }
+
+  protected mergeBatchResults(results: IPushBatchResult[]): IPushBatchResult {
+    return results.reduce(
+      (acc, result) => ({
+        successCount: acc.successCount + result.successCount,
+        failureCount: acc.failureCount + result.failureCount,
+        failures: acc.failures.concat(result.failures),
+      }),
+      { successCount: 0, failureCount: 0, failures: [] as IPushSendFailure[] },
+    );
+  }
+
+  protected async mapWithConcurrency<V, R>(
+    items: V[],
+    concurrency: number,
+    fn: (item: V, index: number) => Promise<R>,
+  ): Promise<R[]> {
+    if (items.length === 0) return [];
+    const results = new Array<R>(items.length);
+    let nextIndex = 0;
+    const workerCount = Math.min(concurrency, items.length);
+    await Promise.all(
+      Array.from({ length: workerCount }, async () => {
+        while (nextIndex < items.length) {
+          const index = nextIndex++;
+          results[index] = await fn(items[index], index);
+        }
+      }),
+    );
+    return results;
+  }
+
+  protected async dispatchSendMessages(
+    targets: IPushTokenTarget[],
+    params: ISendNotification | ISendNotificationToManyDevices,
+  ): Promise<IPushBatchResult[]> {
+    const results: IPushBatchResult[] = [];
+    for (const platformGroup of this.groupTargetsByPlatform(targets, params.platform)) {
+      for (const chunk of this.chunkTargets(platformGroup)) {
+        results.push(await this.sendMessages(chunk, params));
+      }
+    }
+    return results;
+  }
+
+  protected mergeTokensIntoCache(
+    cache: Map<string, NotificationToken[]>,
+    tokens: NotificationToken[],
+  ): void {
+    for (const token of tokens) {
+      const userId = token.userId.toString();
+      const bucket = cache.get(userId);
+      if (bucket) bucket.push(token);
+      else cache.set(userId, [token]);
+    }
+  }
+
+  protected logBatchFailures(results: IPushBatchResult[]): void {
+    for (const failure of results.flatMap(result => result.failures)) {
+      ConduitGrpcSdk.Logger.error(
+        failure.error instanceof Error
+          ? failure.error
+          : String(failure.reason ?? failure.error ?? 'Push notification send failed'),
+      );
+    }
+  }
+
+  protected aggregateUserSendResults(
+    tokens: NotificationToken[],
+    results: IPushBatchResult[],
+    requestedCount: number,
+  ): IPushSendAggregateResult {
+    const failedTokens = new Set(
+      this.mergeBatchResults(results).failures.map(failure => failure.token),
+    );
+    const usersById = groupBy(tokens, token => token.userId.toString());
+    let successCount = 0;
+    for (const userTokens of Object.values(usersById)) {
+      if (userTokens.some(token => !failedTokens.has(token.token))) {
+        successCount++;
+      }
+    }
+    const usersWithTokens = Object.keys(usersById).length;
+    return {
+      requestedCount,
+      successCount,
+      failureCount: usersWithTokens - successCount,
+      skippedCount: requestedCount - usersWithTokens,
+    };
+  }
+
+  protected aggregateNotificationSendResults(
+    outcomes: { success: boolean; skipped: boolean }[],
+  ): IPushSendAggregateResult {
+    let successCount = 0;
+    let failureCount = 0;
+    let skippedCount = 0;
+    for (const outcome of outcomes) {
+      if (outcome.skipped) skippedCount++;
+      else if (outcome.success) successCount++;
+      else failureCount++;
+    }
+    return {
+      requestedCount: outcomes.length,
+      successCount,
+      failureCount,
+      skippedCount,
+    };
+  }
+
+  protected async storeNotifications(
+    notifications: {
+      user: string | User;
+      title?: string;
+      body?: string;
+      data?: any;
+      platform?: string | PlatformTypesEnum;
+    }[],
+  ): Promise<void> {
+    for (const batch of this.chunkItems(notifications)) {
+      await Notification.getInstance().createMany(batch);
+    }
   }
 
   async sendToDevice(params: ISendNotification): Promise<any> {
@@ -42,24 +258,16 @@ export class BaseNotificationProvider<T> {
     if (notificationTokens.length === 0) {
       throw new Error('No notification token found');
     }
-    const promises = notificationTokens.map(async notToken => {
-      await this.sendMessage(notToken.token, {
-        ...params,
-        platform: params.platform ?? notToken.platform,
-      });
-    });
-    return Promise.all(promises);
+    const results = await this.dispatchSendMessages(
+      this.toTokenTargets(notificationTokens),
+      params,
+    );
+    this.logBatchFailures(results);
   }
 
   fetchTokens(users: string | string[], platform?: string): Promise<NotificationToken[]> {
     if (Array.isArray(users)) {
-      return NotificationToken.getInstance().findMany(
-        {
-          userId: { $in: users },
-          ...(platform ? { platform } : {}),
-        },
-        { readPreference: 'primary' },
-      );
+      return this.fetchTokensForUsers(users, platform);
     }
     return NotificationToken.getInstance().findMany(
       {
@@ -70,7 +278,26 @@ export class BaseNotificationProvider<T> {
     );
   }
 
-  async sendMany(params: ISendNotification[]): Promise<any> {
+  protected async fetchTokensForUsers(
+    users: string[],
+    platform?: string,
+  ): Promise<NotificationToken[]> {
+    if (users.length === 0) return [];
+    const tokens: NotificationToken[] = [];
+    for (const userBatch of this.chunkItems(users)) {
+      const batch = await NotificationToken.getInstance().findMany(
+        {
+          userId: { $in: userBatch },
+          ...(platform ? { platform } : {}),
+        },
+        { readPreference: 'primary' },
+      );
+      tokens.push(...batch);
+    }
+    return tokens;
+  }
+
+  async sendMany(params: ISendNotification[]): Promise<IPushSendAggregateResult> {
     if (!this._initialized) throw new Error('Provider not initialized');
     const notifications: {
       user: string | User;
@@ -91,35 +318,62 @@ export class BaseNotificationProvider<T> {
       });
     });
     if (notifications.length !== 0) {
-      await Notification.getInstance().createMany(notifications);
+      await this.storeNotifications(notifications);
     }
-    if (this.isBaseProvider) return;
-    const userIds = params.map(param => param.sendTo);
-    const notificationsObj = keyBy(params, param => param.sendTo);
+    if (this.isBaseProvider) {
+      return {
+        requestedCount: params.length,
+        successCount: notifications.length,
+        failureCount: 0,
+        skippedCount: params.length - notifications.length,
+      };
+    }
 
-    const notificationTokens = (await this.fetchTokens(userIds)) as NotificationToken[];
-    if (!notificationTokens || notificationTokens.length === 0)
-      throw new Error('Could not find tokens');
-    const promises = notificationTokens.map(async token => {
-      const id = token.userId.toString();
-      const data = notificationsObj[id];
-      if (data.platform && data.platform !== token.platform) return;
-      await this.sendMessage(token.token, {
-        ...data,
-        platform: data.platform ?? token.platform,
-      }).catch(e => {
-        ConduitGrpcSdk.Logger.error(e);
-      });
-    });
-    return Promise.all(promises);
+    const tokenCache = new Map<string, NotificationToken[]>();
+    const uniqueUserIds = [...new Set(params.map(param => param.sendTo))];
+    for (const userBatch of this.chunkItems(uniqueUserIds)) {
+      this.mergeTokensIntoCache(tokenCache, await this.fetchTokensForUsers(userBatch));
+    }
+    if (tokenCache.size === 0) throw new Error('Could not find tokens');
+
+    const outcomes: { success: boolean; skipped: boolean }[] = [];
+    for (const paramBatch of this.chunkItems(params)) {
+      const batchOutcomes = await this.mapWithConcurrency(
+        paramBatch,
+        SEND_CONCURRENCY,
+        async param => {
+          const userTokens = tokenCache.get(param.sendTo) ?? [];
+          const applicable = userTokens.filter(
+            (token: NotificationToken) =>
+              !param.platform || param.platform === token.platform,
+          );
+          if (applicable.length === 0) {
+            return { success: false, skipped: true };
+          }
+
+          const results = await this.dispatchSendMessages(
+            this.toTokenTargets(applicable),
+            param,
+          );
+          this.logBatchFailures(results);
+          const merged = this.mergeBatchResults(results);
+          return { success: merged.successCount > 0, skipped: false };
+        },
+      );
+      outcomes.push(...batchOutcomes);
+    }
+
+    return this.aggregateNotificationSendResults(outcomes);
   }
 
-  async sendToManyDevices(params: ISendNotificationToManyDevices): Promise<any> {
+  async sendToManyDevices(
+    params: ISendNotificationToManyDevices,
+  ): Promise<IPushSendAggregateResult> {
     if (!this._initialized) throw new Error('Provider not initialized');
 
     validateNotification(params);
     if (!params.doNotStore && !params.isSilent) {
-      await Notification.getInstance().createMany(
+      await this.storeNotifications(
         params.sendTo.map(userId => ({
           user: userId,
           title: params.title,
@@ -129,19 +383,31 @@ export class BaseNotificationProvider<T> {
         })),
       );
     }
-    if (this.isBaseProvider) return;
-    const notificationTokens = (await this.fetchTokens(
+    if (this.isBaseProvider) {
+      const storedCount = params.doNotStore || params.isSilent ? 0 : params.sendTo.length;
+      return {
+        requestedCount: params.sendTo.length,
+        successCount: storedCount,
+        failureCount: 0,
+        skippedCount: params.sendTo.length - storedCount,
+      };
+    }
+
+    const notificationTokens = await this.fetchTokensForUsers(
       params.sendTo,
       params.platform,
-    )) as NotificationToken[];
-
+    );
     if (notificationTokens.length === 0) throw new Error('Could not find tokens');
-    const promises = notificationTokens.map(async notToken => {
-      await this.sendMessage(notToken.token, {
-        ...params,
-        platform: params.platform ?? notToken.platform,
-      });
-    });
-    return Promise.all(promises);
+
+    const results = await this.dispatchSendMessages(
+      this.toTokenTargets(notificationTokens),
+      params,
+    );
+    this.logBatchFailures(results);
+    return this.aggregateUserSendResults(
+      notificationTokens,
+      results,
+      params.sendTo.length,
+    );
   }
 }

--- a/modules/communications/src/providers/push/interfaces/index.ts
+++ b/modules/communications/src/providers/push/interfaces/index.ts
@@ -17,3 +17,28 @@ export interface ISendNotificationToManyDevices {
   doNotStore?: boolean;
   isSilent?: boolean;
 }
+
+export interface IPushTokenTarget {
+  token: string;
+  platform: string;
+}
+
+export interface IPushSendFailure {
+  token: string;
+  platform?: string;
+  error?: unknown;
+  reason?: string;
+}
+
+export interface IPushBatchResult {
+  successCount: number;
+  failureCount: number;
+  failures: IPushSendFailure[];
+}
+
+export interface IPushSendAggregateResult {
+  requestedCount: number;
+  successCount: number;
+  failureCount: number;
+  skippedCount: number;
+}

--- a/modules/communications/src/services/push.service.ts
+++ b/modules/communications/src/services/push.service.ts
@@ -1,5 +1,5 @@
 import { isNil } from 'lodash-es';
-import { Notification, NotificationToken } from '../models/index.js';
+import { NotificationToken } from '../models/index.js';
 import { ConduitGrpcSdk } from '@conduitplatform/grpc-sdk';
 import {
   ChannelResult,
@@ -8,8 +8,8 @@ import {
   IChannelSendParams,
 } from '../interfaces/index.js';
 import { BaseNotificationProvider } from '../providers/push/base.provider.js';
-import { validateNotification } from '../providers/push/utils/index.js';
 import {
+  IPushSendAggregateResult,
   ISendNotification,
   ISendNotificationToManyDevices,
 } from '../providers/push/interfaces/index.js';
@@ -105,7 +105,6 @@ export class PushService implements IChannel {
   }
 
   async getStatus(messageId: string): Promise<ChannelStatus> {
-    // Push notifications don't typically have status tracking like email
     return {
       status: 'sent' as const,
       messageId,
@@ -134,137 +133,31 @@ export class PushService implements IChannel {
     return tokenDocuments || [];
   }
 
-  async sendNotification(params: ISendNotification) {
+  async sendNotification(params: ISendNotification): Promise<void> {
     if (!this.isAvailable()) {
       throw new Error('Provider not initialized');
     }
-
-    validateNotification(params);
-    if (!params.doNotStore && !params.isSilent) {
-      await Notification.getInstance().create({
-        user: params.sendTo,
-        title: params.title,
-        body: params.body,
-        data: params.data,
-        platform: params.platform,
-      });
-    }
-
-    if (this.provider!.isBaseProvider) return;
-
-    const notificationTokens = await this.provider!.fetchTokens(
-      params.sendTo,
-      params.platform,
-    );
-    if (notificationTokens.length === 0) {
-      throw new Error('No notification token found');
-    }
-
-    const promises = notificationTokens.map(async notToken => {
-      await this.provider!.sendMessage(notToken.token, {
-        ...params,
-        platform: params.platform ?? notToken.platform,
-      });
-    });
-
-    return Promise.all(promises);
+    await this.provider!.sendToDevice(params);
   }
 
-  async sendToManyDevices(params: ISendNotificationToManyDevices) {
+  async sendToManyDevices(
+    params: ISendNotificationToManyDevices,
+  ): Promise<IPushSendAggregateResult> {
     if (!this.isAvailable()) {
       throw new Error('Provider not initialized');
     }
-
-    validateNotification(params);
-    if (!params.doNotStore && !params.isSilent) {
-      await Notification.getInstance().createMany(
-        params.sendTo.map(userId => ({
-          user: userId,
-          title: params.title,
-          body: params.body,
-          data: params.data,
-          platform: params.platform,
-        })),
-      );
-    }
-
-    if (this.provider!.isBaseProvider) return;
-
-    const notificationTokens = await this.provider!.fetchTokens(
-      params.sendTo,
-      params.platform,
-    );
-    if (notificationTokens.length === 0) {
-      throw new Error('Could not find tokens');
-    }
-
-    const promises = notificationTokens.map(async notToken => {
-      await this.provider!.sendMessage(notToken.token, {
-        ...params,
-        platform: params.platform ?? notToken.platform,
-      });
-    });
-
-    return Promise.all(promises);
+    return this.provider!.sendToManyDevices(params);
   }
 
-  async sendManyNotifications(notifications: ISendNotification[]) {
+  async sendManyNotifications(
+    notifications: ISendNotification[],
+  ): Promise<IPushSendAggregateResult> {
     if (!this.isAvailable()) {
       throw new Error('Provider not initialized');
     }
-
-    const notificationsToStore: {
-      user: string;
-      title?: string;
-      body?: string;
-      data?: any;
-      platform?: string;
-    }[] = [];
-
-    notifications.forEach(param => {
-      validateNotification(param);
-      if (param.doNotStore || param.isSilent) return;
-      notificationsToStore.push({
-        user: param.sendTo,
-        title: param.title,
-        body: param.body,
-        data: param.data,
-        platform: param.platform,
-      });
-    });
-
-    if (notificationsToStore.length !== 0) {
-      await Notification.getInstance().createMany(notificationsToStore);
+    if (notifications.length === 0) {
+      throw new Error('notifications is required and must be a non-empty array');
     }
-
-    if (this.provider!.isBaseProvider) return;
-
-    const userIds = notifications.map(param => param.sendTo);
-    const notificationsObj = notifications.reduce(
-      (acc, param) => {
-        acc[param.sendTo] = param;
-        return acc;
-      },
-      {} as Record<string, ISendNotification>,
-    );
-
-    const notificationTokens = await this.provider!.fetchTokens(userIds);
-    if (!notificationTokens || notificationTokens.length === 0) {
-      throw new Error('Could not find tokens');
-    }
-
-    const promises = notificationTokens.map(async token => {
-      const id = token.userId.toString();
-      const data = notificationsObj[id];
-      if (data.platform && data.platform !== token.platform) return;
-      await this.provider!.sendMessage(token.token, {
-        ...data,
-        platform: data.platform ?? token.platform,
-      }).catch(e => {
-        ConduitGrpcSdk.Logger.error(e);
-      });
-    });
-
-    return Promise.all(promises);
+    return this.provider!.sendMany(notifications);
   }
 }


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/ConduitPlatform/Conduit/blob/main/.github/CONTRIBUTING.md#pull-request-guidelines
-->

Ports #1476 to the v0.17 communications module. The comms split (#1471) copied push providers from the pre-#1476 snapshot on `v0.16.x`, so bulk send improvements never landed on `main`.

This PR brings over:
- Chunked/concurrent batch dispatch in the push base provider
- Firebase `sendEachForMulticast` with permanent-token-only cleanup and corrected logging
- Amazon SNS concurrent batch sends with endpoint error handling
- OneSignal bulk `sendMessages` via a single API call
- Success-based `push_notifications_sent_total` metrics on gRPC bulk routes
- grpc-sdk `sendManyNotifications` array type fix (`{...}[]` instead of tuple)

Tasks:
- [x] Port batch interfaces and base provider dispatch
- [x] Port Firebase, Amazon SNS, and OneSignal provider implementations
- [x] Delegate push service to provider aggregate methods
- [x] Align gRPC handlers (validation + metrics)
- [x] Fix grpc-sdk `sendManyNotifications` typing

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** <!--(check at least one)-->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [x] Refactor
- [ ] Build-related changes
- [ ] Other (please describe)

**Does this PR introduce a breaking change?** <!-- (check one) -->

- [ ] Yes
- [x] No

<!-- If yes, please describe the impact and migration path for existing applications. -->

**The PR fulfills these requirements:**

- [x] It's submitted to the `main` branch
- [x] When resolving a specific issue, it's referenced in the PR's description  (e.g. `fix #xxx`, where "xxx" is the issue number)

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature <!-- to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it -->

**Other information:**

Follow-up to #1476 (merged on `v0.16.x` as v0.16.27). No grpc-sdk module target changes — communications client wiring stays on `CommunicationsDefinition`.