### PR TITLE
fix(grpc): return {} for google.protobuf.Empty responses

### DIFF
--- a/modules/authorization/src/Authorization.ts
+++ b/modules/authorization/src/Authorization.ts
@@ -331,21 +331,21 @@ export default class Authorization extends ManagedModule<Config> {
 
   async grantPermission(
     call: GrpcRequest<PermissionRequest>,
-    callback: GrpcResponse<Decision>,
+    callback: GrpcResponse<Empty>,
   ) {
     const { subject, resource, action } = call.request;
     await this.permissionsController.grantPermission(subject, action, resource);
-    callback(null);
+    callback(null, {});
   }
 
   async removePermission(
     call: GrpcRequest<PermissionRequest>,
-    callback: GrpcResponse<Decision>,
+    callback: GrpcResponse<Empty>,
   ) {
     const { subject, resource, action } = call.request;
     await this.permissionsController.removePermission(subject, action, resource);
 
-    callback(null);
+    callback(null, {});
   }
 
   async initializeMetrics() {

--- a/modules/chat/src/Chat.ts
+++ b/modules/chat/src/Chat.ts
@@ -209,7 +209,10 @@ export default class Chat extends ManagedModule<Config> {
     });
   }
 
-  async sendMessage(call: GrpcRequest<SendMessageRequest>, callback: GrpcCallback<null>) {
+  async sendMessage(
+    call: GrpcRequest<SendMessageRequest>,
+    callback: GrpcCallback<Record<string, never>>,
+  ) {
     const userId = call.request.userId;
     const { roomId, message, messageType, persist } = call.request;
 
@@ -276,7 +279,7 @@ export default class Chat extends ManagedModule<Config> {
         }),
       });
 
-      callback(null, null);
+      callback(null, {});
     } catch (e: unknown) {
       callback({
         code: status.INTERNAL,

--- a/modules/database/src/Database.ts
+++ b/modules/database/src/Database.ts
@@ -384,7 +384,7 @@ export default class DatabaseModule extends ManagedModule<Config> {
         joinedSchemas: call.request.joinedSchemas,
         query: call.request.query,
       });
-      callback(null); // @dirty-type-cast
+      callback(null, {});
     } catch (err) {
       callback({
         code: status.INTERNAL,
@@ -401,7 +401,7 @@ export default class DatabaseModule extends ManagedModule<Config> {
   async deleteView(call: GrpcRequest<DeleteViewRequest>, callback: GrpcResponse<Empty>) {
     try {
       await this._activeAdapter.deleteView(call.request.viewName);
-      callback(null);
+      callback(null, {});
     } catch (err) {
       callback({
         code: status.INTERNAL,
@@ -943,7 +943,7 @@ export default class DatabaseModule extends ManagedModule<Config> {
     callback(null, { result: exist });
   }
 
-  async migrate(call: GrpcRequest<MigrateRequest>, callback: GrpcResponse<null>) {
+  async migrate(call: GrpcRequest<MigrateRequest>, callback: GrpcResponse<Empty>) {
     if (this._activeAdapter.getDatabaseType() !== 'MongoDB') {
       const schemaName = call.request.schemaName;
       await this._activeAdapter.syncSchema(schemaName).catch(async () => {
@@ -958,7 +958,7 @@ export default class DatabaseModule extends ManagedModule<Config> {
         await this._activeAdapter.syncSchema(schemaName);
       });
     }
-    callback(null, null);
+    callback(null, {});
   }
 
   async getDatabaseType(

--- a/modules/router/src/Router.ts
+++ b/modules/router/src/Router.ts
@@ -220,7 +220,7 @@ export default class ConduitDefaultRouter extends ManagedModule<Config> {
 
   async registerGrpcRoute(
     call: GrpcRequest<RegisterConduitRouteRequest>,
-    callback: GrpcCallback<null>,
+    callback: GrpcCallback<Record<string, never>>,
   ) {
     const moduleName = call.metadata!.get('module-name')[0];
     try {
@@ -252,7 +252,7 @@ export default class ConduitDefaultRouter extends ManagedModule<Config> {
 
     //todo definitely missing an error handler here
     //perhaps wrong(?) we send an empty response
-    callback(null, undefined);
+    callback(null, {});
   }
 
   internalRegisterRoute(routes: RouteT[], url: string, moduleName?: string) {
@@ -277,7 +277,10 @@ export default class ConduitDefaultRouter extends ManagedModule<Config> {
     this.cleanupRoutes();
   }
 
-  async socketPush(call: GrpcRequest<SocketData>, callback: GrpcCallback<null>) {
+  async socketPush(
+    call: GrpcRequest<SocketData>,
+    callback: GrpcCallback<Record<string, never>>,
+  ) {
     try {
       const socketData: SocketPush = {
         event: call.request.event,
@@ -294,7 +297,7 @@ export default class ConduitDefaultRouter extends ManagedModule<Config> {
 
     //todo definitely missing an error handler here
     //perhaps wrong(?) we send an empty response
-    callback(null, undefined);
+    callback(null, {});
   }
 
   cleanupRoutes() {
@@ -387,7 +390,7 @@ export default class ConduitDefaultRouter extends ManagedModule<Config> {
 
   async patchRouteMiddlewares(
     call: GrpcRequest<PatchAppRouteMiddlewaresRequest>,
-    callback: GrpcCallback<null>,
+    callback: GrpcCallback<Record<string, never>>,
   ) {
     const { path, action, middlewares } = call.request;
     const moduleUrl = await this.grpcSdk.config.getModuleUrlByName(
@@ -407,6 +410,7 @@ export default class ConduitDefaultRouter extends ManagedModule<Config> {
         });
       },
     );
+    callback(null, {});
   }
 
   async _patchRouteMiddlewares(

--- a/packages/core/src/admin/AdminModule.ts
+++ b/packages/core/src/admin/AdminModule.ts
@@ -174,7 +174,7 @@ export default class AdminModule {
 
   async registerAdminRoute(
     call: GrpcRequest<RegisterAdminRouteRequest>,
-    callback: GrpcCallback<null>,
+    callback: GrpcCallback<Record<string, never>>,
   ) {
     const moduleName = call.metadata!.get('module-name')[0];
     try {
@@ -210,7 +210,7 @@ export default class AdminModule {
         message: 'Error when registering routes',
       });
     }
-    callback(null, null);
+    callback(null, {});
   }
 
   registerRoute(route: ConduitRoute): void {
@@ -505,7 +505,7 @@ export default class AdminModule {
 
   async patchRouteMiddlewares(
     call: GrpcRequest<PatchRouteMiddlewaresRequest>,
-    callback: GrpcCallback<null>,
+    callback: GrpcCallback<Record<string, never>>,
   ) {
     const { path, action, middlewares } = call.request;
     const moduleUrl = await this.grpcSdk.config.getModuleUrlByName(
@@ -525,7 +525,7 @@ export default class AdminModule {
         });
       },
     );
-    callback(null, null);
+    callback(null, {});
   }
 
   async _patchRouteMiddlewares(

--- a/packages/core/src/service-discovery/index.ts
+++ b/packages/core/src/service-discovery/index.ts
@@ -73,7 +73,7 @@ export class ServiceDiscovery {
    * Used by modules to notify Core regarding changes in their health state.
    * Called on module health change via grpc-sdk.
    */
-  moduleHealthProbe(call: any, callback: GrpcResponse<null>) {
+  moduleHealthProbe(call: any, callback: GrpcResponse<Record<string, never>>) {
     if (
       call.request.status < HealthCheckStatus.UNKNOWN ||
       call.request.status > HealthCheckStatus.NOT_SERVING
@@ -98,7 +98,7 @@ export class ServiceDiscovery {
       call.request.url,
       call.request.status,
     );
-    callback(null, null);
+    callback(null, {});
   }
 
   moduleList(call: GrpcRequest<null>, callback: GrpcCallback<ModuleListResponse>) {


### PR DESCRIPTION
## Summary
- Return `callback(null, {})` instead of `null`/`undefined` for all `google.protobuf.Empty` gRPC handlers.
- Fixes database startup crash on `RegisterAdminRoute` after the protobufjs 8 upgrade (`Empty: object expected`).
- Adds the missing success callback in router `patchRouteMiddlewares`.
- Aligns handler typings with Empty responses (`Record<string, never>` / `Empty`).

## Test plan
- [x] `pnpm exec turbo run build --filter=@conduitplatform/core --filter=@conduitplatform/database --filter=@conduitplatform/router --filter=@conduitplatform/chat --filter=@conduitplatform/authorization`
- [ ] Confirm database module stays up on standalone/docker startup (no `RegisterAdminRoute` crash)