### PR TITLE
fix(ci): pin alpine runtime image builds

### DIFF
--- a/scripts/Dockerfile.builder
+++ b/scripts/Dockerfile.builder
@@ -1,4 +1,4 @@
-FROM node:24-alpine
+FROM node:24-alpine3.22
 
 WORKDIR /app
 
@@ -6,6 +6,7 @@ RUN npm install -g pnpm@11.5.0
 
 ENV PNPM_CONFIG_TRUST_LOCKFILE=true
 ENV PNPM_CONFIG_VERIFY_DEPS_BEFORE_RUN=false
+ENV PNPM_CONFIG_UPDATE_NOTIFIER=false
 
 COPY --from=conduit-base /app/libraries/grpc-sdk /app/libraries/grpc-sdk
 COPY --from=conduit-base /app/libraries/module-tools /app/libraries/module-tools

--- a/standalone.Dockerfile
+++ b/standalone.Dockerfile
@@ -1,4 +1,4 @@
-FROM node:24-alpine
+FROM node:24-alpine3.22
 
 WORKDIR /app
 
@@ -6,6 +6,7 @@ COPY --from=conduit-base /app/ /app/
 
 ENV PNPM_CONFIG_TRUST_LOCKFILE=true
 ENV PNPM_CONFIG_VERIFY_DEPS_BEFORE_RUN=false
+ENV PNPM_CONFIG_UPDATE_NOTIFIER=false
 
 RUN apk update && \
     apk add --no-cache --virtual .gyp python3 py3-setuptools make g++ && \


### PR DESCRIPTION
The latest dev image run failed in `authorization` and `chat` with QEMU arm64 SIGILL during the Alpine runtime `pnpm install --prod` step. `communications` hit the same shape earlier, so this pins the shared runtime Alpine path instead of chasing module-specific code.

## Summary
- Pin the shared module runtime builder from floating `node:24-alpine` to `node:24-alpine3.22`
- Pin the standalone runtime image to the same Alpine 3.22 base
- Disable pnpm update notifier checks during runtime image installs

## Test plan
- [x] `nvm use 24`
- [x] `docker buildx bake --file docker-bake.hcl --print chat authorization communications`
- [x] `docker buildx bake --file docker-bake.hcl --print all`
- [x] `docker manifest inspect node:24-alpine3.22`
- [x] `git diff --check`
- [ ] Full multi-arch dev image workflow on GitHub Actions

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/ConduitPlatform/Conduit/blob/main/.github/CONTRIBUTING.md#pull-request-guidelines
-->

**What kind of change does this PR introduce?**

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [x] Build-related changes
- [ ] Other (please describe)

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

No runtime behavior changes; this only pins the Alpine base used by container image installs and suppresses pnpm's update notifier.

**The PR fulfills these requirements:**

- [x] It's submitted to the `main` branch
- [ ] When resolving a specific issue, it's referenced in the PR's description

**Other information:**

Local `docker buildx build --check` could not run because the Docker daemon socket was unavailable. CI is the real validation for the QEMU arm64 failure path.