### PR TITLE
fix(ci): avoid conduit-standalone digest collision in core manifest merge

### DIFF
--- a/.github/workflows/images.build.yml
+++ b/.github/workflows/images.build.yml
@@ -253,7 +253,9 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           path: /tmp/digests
-          pattern: digests-${{ matrix.target }}-*
+          pattern: |
+            digests-${{ matrix.target }}-amd64
+            digests-${{ matrix.target }}-arm64
           merge-multiple: true
 
       - name: Create GHCR manifest


### PR DESCRIPTION
## Summary

The `workflow_dispatch channel=all` run after #1495 built all images successfully, but **Merge Build core manifest** failed while every other manifest job passed.

Root cause: the manifest job downloaded digest artifacts with pattern `digests-conduit-*`, which also matched `digests-conduit-standalone-amd64` and `digests-conduit-standalone-arm64`. The merge step then passed those standalone digests to `imagetools create` as `ghcr.io/conduitplatform/conduit@sha256:...`, which fails because those digests live under `conduit-standalone`.

## Fix

Download only the exact per-arch artifacts for each matrix target:

- `digests-${{ matrix.target }}-amd64`
- `digests-${{ matrix.target }}-arm64`

## Test plan

- [ ] Merge and run `workflow_dispatch` with `channel=all`
- [ ] Confirm **Merge Build core manifest** succeeds
- [ ] `docker buildx imagetools inspect ghcr.io/conduitplatform/conduit:dev` shows `linux/amd64` and `linux/arm64`