### PR TITLE
fix(authorization): resource delete cascade, relations/many body, FindRelation message

### DIFF
--- a/modules/authorization/src/Authorization.ts
+++ b/modules/authorization/src/Authorization.ts
@@ -270,10 +270,10 @@ export default class Authorization extends ManagedModule<Config> {
   ) {
     const { relation, resource, subject, resourceType, subjectType, skip, limit } =
       call.request;
-    if (!subject && !relation && !resource) {
+    if (!subject && !relation && !resource && !subjectType && !resourceType) {
       return callback({
         code: status.INVALID_ARGUMENT,
-        message: 'At least 2 of subject, relation, resource must be provided',
+        message: 'At least one search filter must be provided',
       });
     }
     const [relations, count] = await this.relationsController.findRelations(

--- a/modules/authorization/src/admin/relations.ts
+++ b/modules/authorization/src/admin/relations.ts
@@ -99,7 +99,7 @@ export class RelationHandler {
   }
 
   async createRelations(call: ParsedRouterRequest): Promise<UnparsedRouterResponse> {
-    const { subject, relation, resources } = call.request.params;
+    const { subject, relation, resources } = call.request.bodyParams;
     return RelationsController.getInstance().createRelations(
       subject,
       relation,

--- a/modules/authorization/src/admin/resources.ts
+++ b/modules/authorization/src/admin/resources.ts
@@ -2,10 +2,12 @@ import {
   ConduitGrpcSdk,
   ConduitRouteActions,
   ConduitRouteReturnDefinition,
+  GrpcError,
   ParsedRouterRequest,
   Query,
   UnparsedRouterResponse,
 } from '@conduitplatform/grpc-sdk';
+import { status } from '@grpc/grpc-js';
 import {
   ConduitJson,
   ConduitNumber,
@@ -177,11 +179,11 @@ export class ResourceHandler {
 
   async deleteResource(call: ParsedRouterRequest): Promise<UnparsedRouterResponse> {
     const { id } = call.request.params;
-    const found = ResourceDefinition.getInstance().findOne({ _id: id });
+    const found = await ResourceDefinition.getInstance().findOne({ _id: id });
     if (isNil(found)) {
-      throw new Error('Resource does not exist');
+      throw new GrpcError(status.NOT_FOUND, 'Resource does not exist');
     }
-    await ResourceDefinition.getInstance().deleteOne({ _id: id });
+    await ResourceController.getInstance().deleteResource(found.name);
     return 'Resource deleted successfully';
   }
 }


### PR DESCRIPTION
**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other (please describe)

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

**The PR fulfills these requirements:**

- [x] It's submitted to the `main` branch
- [ ] When resolving a specific issue, it's referenced in the PR's description  (e.g. `fix #xxx`, where "xxx" is the issue number)

## Summary
- Bulk relation creation via `POST /authorization/relations/many` declared a JSON body but read URL params, so Conduit UI and admin clients sent valid payloads that were ignored.
- Admin `DELETE /authorization/resources/:id` removed only the resource definition document, leaving relationship tuples and index entries that the gRPC delete path already cleans up.
- gRPC `FindRelation` rejected empty queries with a misleading "At least 2" message and did not treat `subjectType` / `resourceType` as valid filters.

- Read `bodyParams` in the bulk relations handler so POST bodies are honored.
- Delegate admin resource delete to `ResourceController.deleteResource` (with `await` on the existence check and `GrpcError` 404).
- Require at least one of `subject`, `relation`, `resource`, `subjectType`, or `resourceType` and return an accurate validation message.

## Test plan
- [ ] `POST /authorization/relations/many` with `{ subject, relation, resources: [...] }` creates all tuples
- [ ] `DELETE /authorization/resources/:id` removes relations and indexes for that resource type (compare with gRPC `DeleteResource`)
- [ ] gRPC `FindRelation` with no filters → `INVALID_ARGUMENT` and message mentions at least one filter
- [ ] gRPC `FindRelation` with only `subjectType` succeeds

**Other information:**