### PR TITLE
fix(database,functions): custom endpoint CONTAIN op and PUT route mapping

### DIFF
--- a/modules/database/src/handlers/CustomEndpoints/utils.ts
+++ b/modules/database/src/handlers/CustomEndpoints/utils.ts
@@ -159,9 +159,8 @@ function _translateQuery(
       return { [schemaField]: { $in: comparisonField } };
     case 7:
       return { [schemaField]: { $nin: comparisonField } };
-    // maybe something else??
     case 8:
-      return { [schemaField]: { $nin: comparisonField } };
+      return { [schemaField]: comparisonField };
     default:
       return { [schemaField]: comparisonField };
   }

--- a/modules/database/src/handlers/CustomEndpoints/utils.ts
+++ b/modules/database/src/handlers/CustomEndpoints/utils.ts
@@ -159,8 +159,6 @@ function _translateQuery(
       return { [schemaField]: { $in: comparisonField } };
     case 7:
       return { [schemaField]: { $nin: comparisonField } };
-    case 8:
-      return { [schemaField]: comparisonField };
     default:
       return { [schemaField]: comparisonField };
   }

--- a/modules/functions/src/controllers/utils.ts
+++ b/modules/functions/src/controllers/utils.ts
@@ -22,6 +22,7 @@ function getOperation(op: string) {
       return ConduitRouteActions.GET;
     case 'POST':
       return ConduitRouteActions.POST;
+    case 'PUT':
     case 'UPDATE':
       return ConduitRouteActions.UPDATE;
     case 'DELETE':


### PR DESCRIPTION
## Summary

Custom endpoint comparison operation 8 was documented as array-contains but generated the same `$nin` query as operation 7, so filters never matched documents whose array fields include a value. Functions declared with `inputs.method: 'PUT'` also registered as GET routes because `getOperation` only handled the `UPDATE` alias.

- Remove the erroneous op 8 `$nin` branch so CONTAIN uses the default direct-equality query
- Treat `PUT` the same as `UPDATE` when registering function routes

**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other (please describe)

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

**The PR fulfills these requirements:**

- [x] It's submitted to the `main` branch
- [ ] When resolving a specific issue, it's referenced in the PR's description

## Test plan

- [ ] Create a custom endpoint with an array field filter using comparison op 8 and confirm matching documents are returned (op 7 with the same value should still use exclusion semantics)
- [ ] Register a request function with `inputs.method: 'PUT'` and confirm the router exposes PUT on the function path
- [ ] Send an HTTP PUT to that function path and confirm the handler runs; GET on the same path should not invoke the PUT handler