### PR TITLE
fix(communications,storage): SMS provider field, email status job, Azure folder metric

### DIFF
--- a/modules/communications/src/controllers/queue.controller.ts
+++ b/modules/communications/src/controllers/queue.controller.ts
@@ -4,6 +4,7 @@ import { randomUUID } from 'crypto';
 import { ConduitGrpcSdk } from '@conduitplatform/grpc-sdk';
 import { Cluster, Redis } from 'ioredis';
 import { fileURLToPath } from 'node:url';
+import { Provider } from '../utils/getEmailStatus.js';
 
 export class QueueController {
   private static _instance: QueueController;
@@ -90,6 +91,7 @@ export class QueueController {
     messageId: string,
     emailRecId: string,
     retries = 0,
+    provider: Provider,
   ): Promise<Job> {
     return this.emailStatusQueue.add(
       `email-status-${randomUUID()}`,
@@ -97,6 +99,7 @@ export class QueueController {
         messageId,
         emailRecId,
         retries,
+        provider,
       },
       { delay: 5000 * (retries + 1) },
     );

--- a/modules/communications/src/interfaces/IJobData.ts
+++ b/modules/communications/src/interfaces/IJobData.ts
@@ -1,5 +1,8 @@
+import { Provider } from '../utils/getEmailStatus.js';
+
 export interface IJobData {
   messageId: string;
   emailRecId: string;
   retries: number;
+  provider: Provider;
 }

--- a/modules/communications/src/jobs/getEmailStatus.ts
+++ b/modules/communications/src/jobs/getEmailStatus.ts
@@ -1,31 +1,29 @@
 import { SandboxedJob } from 'bullmq';
-import { ConduitGrpcSdk } from '@conduitplatform/grpc-sdk';
+import { Communications, ConduitGrpcSdk } from '@conduitplatform/grpc-sdk';
 import { EmailRecord } from '../models/index.js';
 import { QueueController } from '../controllers/queue.controller.js';
 import { EmailStatusEnum } from '../models/EmailStatusEnum.js';
 import { IJobData } from '../interfaces/index.js';
-import { Config } from '../config/index.js';
-import { mapProviderStatus, Provider } from '../utils/index.js';
+import { mapProviderStatus } from '../utils/index.js';
 
 let grpcSdk: ConduitGrpcSdk | undefined = undefined;
 
 export default async (job: SandboxedJob<IJobData>) => {
   if (!grpcSdk) {
     if (!process.env.CONDUIT_SERVER) throw new Error('No serverUrl provided!');
-    grpcSdk = new ConduitGrpcSdk(process.env.CONDUIT_SERVER, 'email', false);
+    grpcSdk = new ConduitGrpcSdk(process.env.CONDUIT_SERVER, 'communications', false);
     await grpcSdk.initialize();
     await grpcSdk.initializeEventBus();
-    await grpcSdk.waitForExistence('email');
+    await grpcSdk.waitForExistence('communications');
     await grpcSdk.waitForExistence('database');
     QueueController.getInstance(grpcSdk);
     EmailRecord.getInstance(grpcSdk.database!);
   }
 
-  const { messageId, emailRecId, retries = 0 } = job.data;
+  const { messageId, emailRecId, retries = 0, provider } = job.data;
 
-  // For now, return a basic status since we don't have direct provider access in jobs
-  const rawProviderResponse = { status: 'sent' };
-  const provider = 'sendgrid' as Provider;
+  const communications = grpcSdk.getModule('communications') as Communications;
+  const rawProviderResponse = await communications.getEmailStatus(messageId);
   const status = mapProviderStatus(provider, rawProviderResponse);
 
   const query = {
@@ -42,6 +40,7 @@ export default async (job: SandboxedJob<IJobData>) => {
         messageId,
         emailRecId,
         retries + 1,
+        provider,
       );
     } else {
       await EmailRecord.getInstance().findByIdAndUpdate(emailRecId, {

--- a/modules/communications/src/services/email.service.ts
+++ b/modules/communications/src/services/email.service.ts
@@ -18,6 +18,9 @@ import { getHandleBarsValues } from '../providers/email/utils/index.js';
 import { QueueController } from '../controllers/queue.controller.js';
 import { storeEmail } from '../utils/storeEmail.js';
 import { Config } from '../config/index.js';
+import { Provider } from '../utils/index.js';
+
+const STATUS_UNSUPPORTED_TRANSPORTS = new Set(['amazonSes', 'smtp']);
 
 export interface IRegisterTemplateParams {
   name: string;
@@ -329,7 +332,15 @@ export class EmailService implements IChannel {
       );
 
       if (messageId) {
-        await QueueController.getInstance().addEmailStatusJob(messageId, emailRecId, 0);
+        const transport = config.email?.transport;
+        if (transport && !STATUS_UNSUPPORTED_TRANSPORTS.has(transport)) {
+          await QueueController.getInstance().addEmailStatusJob(
+            messageId,
+            emailRecId,
+            0,
+            transport as Provider,
+          );
+        }
       }
     }
     return { messageId, ...sentMessageInfo };

--- a/modules/communications/src/services/sms.service.ts
+++ b/modules/communications/src/services/sms.service.ts
@@ -14,6 +14,7 @@ import { TwilioProvider } from '../providers/sms/twilio.js';
 
 export class SmsService implements IChannel {
   private provider?: ISmsProvider;
+  private providerName?: string;
 
   constructor(private readonly grpcSdk: ConduitGrpcSdk) {}
 
@@ -26,6 +27,7 @@ export class SmsService implements IChannel {
     }
     if (!smsConfig.active) {
       this.provider = undefined;
+      this.providerName = undefined;
       return;
     }
 
@@ -46,8 +48,12 @@ export class SmsService implements IChannel {
         default:
           ConduitGrpcSdk.Logger.error(`Unknown SMS provider: ${name}`);
       }
+      if (this.provider) {
+        this.providerName = name;
+      }
     } catch (e) {
       this.provider = undefined;
+      this.providerName = undefined;
       ConduitGrpcSdk.Logger.error('Failed to initialize SMS provider:', e);
     }
   }
@@ -69,7 +75,7 @@ export class SmsService implements IChannel {
       const smsRecord = await SmsRecord.getInstance().create({
         recipient,
         message: body || '',
-        provider: 'unknown', // This should be determined from the provider
+        provider: this.providerName ?? 'unknown',
         status: 'sent',
         providerResponse: result,
       });
@@ -142,7 +148,7 @@ export class SmsService implements IChannel {
     const smsRecord = await SmsRecord.getInstance().create({
       recipient: to,
       message,
-      provider: 'unknown', // This should be determined from the provider
+      provider: this.providerName ?? 'unknown',
       status: 'sent',
       providerResponse: result,
     });

--- a/modules/storage/src/providers/azure/index.ts
+++ b/modules/storage/src/providers/azure/index.ts
@@ -45,7 +45,7 @@ export class AzureStorage implements IStorageProvider {
       }
     }
     ConduitGrpcSdk.Logger.log(`${i} blobs deleted.`);
-    ConduitGrpcSdk.Metrics?.increment('folders_total');
+    ConduitGrpcSdk.Metrics?.decrement('folders_total');
     return true;
   }
 


### PR DESCRIPTION
**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other (please describe)

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

**The PR fulfills these requirements:**

- [x] It's submitted to the `main` branch
- [ ] When resolving a specific issue, it's referenced in the PR's description  (e.g. `fix #xxx`, where "xxx" is the issue number)

## Summary

- SMS message records always stored `provider: 'unknown'` even when Twilio, AWS SNS, or MessageBird was configured.
- The BullMQ email status worker still returned a hardcoded SendGrid stub after the communications module migration, so delivery status never reflected the configured ESP.
- Azure storage `deleteFolder` incremented `folders_total` instead of decrementing it, unlike every other provider.

- Track the configured SMS provider name on `SmsService` and persist it on new `SmsRecord` documents.
- Point the sandboxed status worker at the communications gRPC `getEmailStatus` path, map responses with the configured transport, and skip status polling for SMTP and Amazon SES.
- Use `decrement('folders_total')` in Azure `deleteFolder`.

## Test plan

- [ ] Configure Twilio SMS, send a message, confirm `GET /sms/messages` shows `provider: twilio`
- [ ] Configure Mailgun (or SendGrid) email with stored emails enabled, send mail, confirm `EmailRecord.status` updates after the status job runs
- [ ] Confirm SMTP/SES sends do not enqueue an email status job
- [ ] On Azure storage, create then delete a folder and confirm `folders_total` returns to the prior value

**Other information:**