### PR TITLE
feat(core): deep readiness probe with dependency checks

### DIFF
--- a/packages/core/src/GrpcServer.ts
+++ b/packages/core/src/GrpcServer.ts
@@ -74,6 +74,10 @@ export class GrpcServer {
     return this._initialized;
   }
 
+  isGrpcServing(): boolean {
+    return this._serviceHealthState === HealthCheckStatus.SERVING;
+  }
+
   get internalGrpc() {
     return this.server;
   }
@@ -101,7 +105,7 @@ export class GrpcServer {
   }
 
   private async bootstrapSdkComponents() {
-    this.adminModule = new AdminModule(this._grpcSdk, this.configManager);
+    this.adminModule = new AdminModule(this._grpcSdk, this.configManager, this);
     this.configManager.setAdminModule(this.adminModule);
     this.initializeMetrics();
 

--- a/packages/core/src/admin/AdminModule.ts
+++ b/packages/core/src/admin/AdminModule.ts
@@ -42,33 +42,17 @@ import metricsSchema from './metrics/index.js';
 import cors from 'cors';
 import { ConfigController, GrpcServer, merge } from '@conduitplatform/module-tools';
 import { fileURLToPath } from 'node:url';
+import { loadReadinessConfig } from '../health/config.js';
+import { getReadinessMiddleware } from '../health/readinessMiddleware.js';
+import { ReadinessService } from '../health/ReadinessService.js';
+import type { CoreHealthProvider } from '../health/types.js';
 
 export default class AdminModule {
   grpcSdk: ConduitGrpcSdk;
   readonly config: convict.Config<ConfigSchema> = convict(AppConfigSchema);
   private _router!: ConduitRoutingController;
-  private _sdkRoutes: ConduitRoute[] = [
-    adminRoutes.getLoginRoute(),
-    adminRoutes.getCreateAdminRoute(),
-    adminRoutes.getAdminRoute(),
-    adminRoutes.getAdminsRoute(),
-    adminRoutes.deleteAdminUserRoute(),
-    adminRoutes.changePasswordRoute(),
-    adminRoutes.getReadyRoute(),
-    adminRoutes.toggleTwoFaRoute(),
-    adminRoutes.verifyQrCodeRoute(),
-    adminRoutes.verifyTwoFaRoute(),
-    adminRoutes.changeUsersPasswordRoute(),
-    adminRoutes.patchRouteMiddlewares(this),
-    adminRoutes.getRouteMiddlewares(this),
-    adminRoutes.createApiTokenRoute(),
-    adminRoutes.getApiTokensRoute(),
-    adminRoutes.deleteApiTokenRoute(),
-    configRoutes.getModulesRoute(),
-    adminRoutes.getStateExportRoute(this),
-    adminRoutes.getStateImportRoute(this),
-    adminRoutes.getConfigImportRoute(this),
-  ];
+  private readonly _readinessService: ReadinessService;
+  private _sdkRoutes: ConduitRoute[];
   private readonly _grpcRoutes: {
     [field: string]: RegisterAdminRouteRequest_PathDefinition[];
   } = {};
@@ -77,9 +61,41 @@ export default class AdminModule {
   private _refreshTimeout: NodeJS.Timeout | null = null;
   readonly configManager: any;
 
-  constructor(grpcSdk: ConduitGrpcSdk, configManager: any) {
+  constructor(
+    grpcSdk: ConduitGrpcSdk,
+    configManager: any,
+    coreHealth?: CoreHealthProvider,
+  ) {
     this.grpcSdk = grpcSdk;
     this.configManager = configManager;
+    this._readinessService = new ReadinessService(
+      grpcSdk,
+      coreHealth ?? { initialized: false, isGrpcServing: () => false },
+      loadReadinessConfig(),
+    );
+    this._sdkRoutes = [
+      adminRoutes.getLoginRoute(),
+      adminRoutes.getCreateAdminRoute(),
+      adminRoutes.getAdminRoute(),
+      adminRoutes.getAdminsRoute(),
+      adminRoutes.deleteAdminUserRoute(),
+      adminRoutes.changePasswordRoute(),
+      adminRoutes.getReadyRoute(this._readinessService),
+      adminRoutes.getLiveRoute(),
+      adminRoutes.toggleTwoFaRoute(),
+      adminRoutes.verifyQrCodeRoute(),
+      adminRoutes.verifyTwoFaRoute(),
+      adminRoutes.changeUsersPasswordRoute(),
+      adminRoutes.patchRouteMiddlewares(this),
+      adminRoutes.getRouteMiddlewares(this),
+      adminRoutes.createApiTokenRoute(),
+      adminRoutes.getApiTokensRoute(),
+      adminRoutes.deleteApiTokenRoute(),
+      configRoutes.getModulesRoute(),
+      adminRoutes.getStateExportRoute(this),
+      adminRoutes.getStateImportRoute(this),
+      adminRoutes.getConfigImportRoute(this),
+    ];
     this._router = new ConduitRoutingController(
       this.getHttpPort()!,
       this.getSocketPort()!,
@@ -151,6 +167,10 @@ export default class AdminModule {
     this._router.registerMiddleware(
       middleware.getAuthMiddleware(this.grpcSdk, this.configManager),
       true,
+    );
+    this._router.registerMiddleware(
+      getReadinessMiddleware(() => this._readinessService),
+      false,
     );
     this._router.registerMiddleware(helmet(), false);
     this._router.registerMiddleware((req: Request, res: Response, next: NextFunction) => {

--- a/packages/core/src/admin/middleware/Admin.middleware.ts
+++ b/packages/core/src/admin/middleware/Admin.middleware.ts
@@ -22,7 +22,10 @@ export function getAdminMiddleware(configManager: any) {
     ) {
       return next();
     }
-    if (req.originalUrl.indexOf('/ready') === 0) {
+    if (
+      req.originalUrl.indexOf('/ready') === 0 ||
+      req.originalUrl.indexOf('/live') === 0
+    ) {
       return next();
     }
     // Allow API tokens (cdt_*) to bypass masterkey; Auth.middleware will validate the token

--- a/packages/core/src/admin/middleware/Auth.middleware.ts
+++ b/packages/core/src/admin/middleware/Auth.middleware.ts
@@ -8,11 +8,12 @@ import { ConduitRequest } from '@conduitplatform/hermes';
 import { gql } from 'graphql-tag';
 import { ConfigController } from '@conduitplatform/module-tools';
 
-const excludedRestRoutes = ['/ready', '/login', '/config/modules'];
+const excludedRestRoutes = ['/ready', '/live', '/login', '/config/modules'];
 const excludedGqlOperations = [
   '__schema',
   'IntrospectionQuery',
   'getReady',
+  'getLive',
   'postLogin',
   'getConfigModules',
 ];

--- a/packages/core/src/admin/routes/GetModules.route.ts
+++ b/packages/core/src/admin/routes/GetModules.route.ts
@@ -1,5 +1,4 @@
 import {
-  ConduitError,
   ConduitRouteActions,
   ConduitRouteParameters,
   ConduitRouteReturnDefinition,
@@ -31,9 +30,6 @@ export function getModulesRoute() {
     async (call: ConduitRouteParameters) => {
       const sortByName = call.params!.sortByName;
       const modules = ServiceRegistry.getInstance().getModuleDetailsList();
-      if (modules.length === 0) {
-        throw new ConduitError('INTERNAL', 500, 'Modules not available yet');
-      }
       if (!isNil(sortByName)) {
         if (sortByName) modules!.sort((a, b) => a.moduleName.localeCompare(b.moduleName));
         else modules!.sort((a, b) => b.moduleName.localeCompare(a.moduleName));

--- a/packages/core/src/admin/routes/Live.ts
+++ b/packages/core/src/admin/routes/Live.ts
@@ -1,0 +1,27 @@
+import {
+  ConduitRouteActions,
+  ConduitRouteReturnDefinition,
+} from '@conduitplatform/grpc-sdk';
+import { ConduitRoute } from '@conduitplatform/hermes';
+import { ConduitBoolean, ConduitString } from '@conduitplatform/module-tools';
+
+export function getLiveRoute() {
+  return new ConduitRoute(
+    {
+      path: '/live',
+      action: ConduitRouteActions.GET,
+      description: 'Shallow liveness probe — process alive, Admin HTTP responding.',
+      queryParams: {
+        legacy: ConduitBoolean.Optional,
+      },
+    },
+    new ConduitRouteReturnDefinition('Live', {
+      status: ConduitString.Required,
+      message: ConduitString.Required,
+    }),
+    async () => ({
+      status: 'alive',
+      message: 'Conduit Core is alive',
+    }),
+  );
+}

--- a/packages/core/src/admin/routes/Ready.ts
+++ b/packages/core/src/admin/routes/Ready.ts
@@ -1,18 +1,45 @@
 import {
+  ConduitError,
   ConduitRouteActions,
   ConduitRouteReturnDefinition,
 } from '@conduitplatform/grpc-sdk';
 import { ConduitRoute } from '@conduitplatform/hermes';
+import {
+  ConduitBoolean,
+  ConduitNumber,
+  ConduitString,
+} from '@conduitplatform/module-tools';
+import type { ReadinessService } from '../../health/ReadinessService.js';
 
-export function getReadyRoute() {
+export function getReadyRoute(readinessService: ReadinessService) {
   return new ConduitRoute(
     {
       path: '/ready',
       action: ConduitRouteActions.GET,
+      description: 'Deep readiness probe for Core coordination health.',
+      queryParams: {
+        legacy: ConduitBoolean.Optional,
+      },
     },
-    new ConduitRouteReturnDefinition('Ready', 'String'),
+    new ConduitRouteReturnDefinition('Ready', {
+      status: ConduitString.Required,
+      message: ConduitString.Required,
+      checks: [
+        {
+          name: ConduitString.Required,
+          status: ConduitString.Required,
+          message: ConduitString.Optional,
+          latencyMs: ConduitNumber.Optional,
+        },
+      ],
+      timestamp: ConduitString.Required,
+    }),
     async () => {
-      return 'Conduit Core is online!';
+      const report = await readinessService.evaluate();
+      if (report.status === 'not_ready') {
+        throw new ConduitError('SERVICE_UNAVAILABLE', 503, report.message);
+      }
+      return report;
     },
   );
 }

--- a/packages/core/src/admin/routes/index.ts
+++ b/packages/core/src/admin/routes/index.ts
@@ -10,6 +10,7 @@ export * from './GetMonoConfig.route.js';
 export * from './GetRouteMiddlewares.route.js';
 export * from './Login.route.js';
 export * from './PatchRouteMiddlewares.route.js';
+export * from './Live.js';
 export * from './Ready.js';
 export * from './SetModuleConfig.route.js';
 export * from './StateExport.route.js';

--- a/packages/core/src/health/ReadinessService.ts
+++ b/packages/core/src/health/ReadinessService.ts
@@ -1,0 +1,249 @@
+import {
+  ConduitGrpcSdk,
+  HealthCheckResponse,
+  HealthCheckStatus,
+} from '@conduitplatform/grpc-sdk';
+import { ServiceRegistry } from '../service-discovery/ServiceRegistry.js';
+import type {
+  CoreHealthProvider,
+  ReadinessCheck,
+  ReadinessConfig,
+  ReadinessReport,
+} from './types.js';
+
+function withTimeout<T>(
+  promise: Promise<T>,
+  timeoutMs: number,
+  label: string,
+): Promise<T> {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      reject(new Error(`${label} timed out after ${timeoutMs}ms`));
+    }, timeoutMs);
+    promise
+      .then(value => {
+        clearTimeout(timer);
+        resolve(value);
+      })
+      .catch(err => {
+        clearTimeout(timer);
+        reject(err);
+      });
+  });
+}
+
+export class ReadinessService {
+  constructor(
+    private readonly grpcSdk: ConduitGrpcSdk,
+    private readonly coreHealth: CoreHealthProvider,
+    private readonly config: ReadinessConfig,
+  ) {}
+
+  async evaluate(): Promise<ReadinessReport> {
+    const deadline = Date.now() + this.config.totalTimeoutMs;
+    const checks: ReadinessCheck[] = [];
+
+    const remainingMs = () => Math.max(1, deadline - Date.now());
+
+    checks.push(this.checkCoreInitialized());
+    checks.push(this.checkCoreGrpc());
+
+    if (this.config.checkRedis) {
+      checks.push(
+        await this.checkRedis(Math.min(this.config.redisTimeoutMs, remainingMs())),
+      );
+    }
+
+    const moduleChecks = await this.checkModules(remainingMs);
+    checks.push(...moduleChecks);
+
+    const hasFailure = checks.some(check => check.status === 'fail');
+    const status = hasFailure ? 'not_ready' : 'ready';
+
+    return {
+      status,
+      message: status === 'ready' ? 'Conduit Core is ready' : 'Conduit Core is not ready',
+      checks,
+      timestamp: new Date().toISOString(),
+    };
+  }
+
+  private checkCoreInitialized(): ReadinessCheck {
+    const start = Date.now();
+    const pass = this.coreHealth.initialized;
+    return {
+      name: 'core.initialized',
+      status: pass ? 'pass' : 'fail',
+      message: pass ? undefined : 'Core bootstrap incomplete',
+      latencyMs: Date.now() - start,
+    };
+  }
+
+  private checkCoreGrpc(): ReadinessCheck {
+    const start = Date.now();
+    const pass = this.coreHealth.isGrpcServing();
+    return {
+      name: 'core.grpc',
+      status: pass ? 'pass' : 'fail',
+      message: pass ? undefined : 'gRPC health is not SERVING',
+      latencyMs: Date.now() - start,
+    };
+  }
+
+  private async checkRedis(timeoutMs: number): Promise<ReadinessCheck> {
+    const start = Date.now();
+    try {
+      const client = this.grpcSdk.redisManager.getClient();
+      const pong = await withTimeout(client.ping(), timeoutMs, 'Redis PING');
+      if (pong !== 'PONG') {
+        return {
+          name: 'redis',
+          status: 'fail',
+          message: `Unexpected PING response: ${String(pong)}`,
+          latencyMs: Date.now() - start,
+        };
+      }
+      return {
+        name: 'redis',
+        status: 'pass',
+        latencyMs: Date.now() - start,
+      };
+    } catch (err) {
+      return {
+        name: 'redis',
+        status: 'fail',
+        message: err instanceof Error ? err.message : 'Redis check failed',
+        latencyMs: Date.now() - start,
+      };
+    }
+  }
+
+  private async checkModules(remainingMs: () => number): Promise<ReadinessCheck[]> {
+    const registry = ServiceRegistry.getInstance();
+    const registered = new Map(
+      registry.getModuleDetailsList().map(module => [module.moduleName, module]),
+    );
+    const required = new Set(this.config.requiredModules);
+    const checks: ReadinessCheck[] = [];
+
+    for (const moduleName of required) {
+      checks.push(
+        await this.checkRequiredModule(
+          moduleName,
+          registered.get(moduleName),
+          remainingMs,
+        ),
+      );
+    }
+
+    for (const module of registered.values()) {
+      if (required.has(module.moduleName)) continue;
+      checks.push(await this.checkOptionalModule(module.moduleName, module, remainingMs));
+    }
+
+    return checks;
+  }
+
+  private async checkRequiredModule(
+    moduleName: string,
+    module:
+      | {
+          moduleName: string;
+          url: string;
+          serving: boolean;
+        }
+      | undefined,
+    remainingMs: () => number,
+  ): Promise<ReadinessCheck> {
+    const start = Date.now();
+    if (!module) {
+      return {
+        name: `modules.${moduleName}`,
+        status: 'fail',
+        message: 'not registered',
+        latencyMs: Date.now() - start,
+      };
+    }
+
+    if (this.config.probeModulesActive) {
+      const active = await this.probeModuleHealth(
+        moduleName,
+        Math.min(this.config.moduleTimeoutMs, remainingMs()),
+      );
+      if (!active) {
+        return {
+          name: `modules.${moduleName}`,
+          status: 'fail',
+          message: 'health check failed',
+          latencyMs: Date.now() - start,
+        };
+      }
+    } else if (!module.serving) {
+      return {
+        name: `modules.${moduleName}`,
+        status: 'fail',
+        message: 'not serving',
+        latencyMs: Date.now() - start,
+      };
+    }
+
+    return {
+      name: `modules.${moduleName}`,
+      status: 'pass',
+      latencyMs: Date.now() - start,
+    };
+  }
+
+  private async checkOptionalModule(
+    moduleName: string,
+    module: { moduleName: string; url: string; serving: boolean },
+    remainingMs: () => number,
+  ): Promise<ReadinessCheck> {
+    const start = Date.now();
+    let serving = module.serving;
+
+    if (this.config.probeModulesActive) {
+      serving = await this.probeModuleHealth(
+        moduleName,
+        Math.min(this.config.moduleTimeoutMs, remainingMs()),
+      );
+    }
+
+    if (!serving) {
+      const status = this.config.strict ? 'fail' : 'warn';
+      return {
+        name: `modules.${moduleName}`,
+        status,
+        message: 'not serving',
+        latencyMs: Date.now() - start,
+      };
+    }
+
+    return {
+      name: `modules.${moduleName}`,
+      status: 'pass',
+      latencyMs: Date.now() - start,
+    };
+  }
+
+  private async probeModuleHealth(
+    moduleName: string,
+    timeoutMs: number,
+  ): Promise<boolean> {
+    const healthClient = this.grpcSdk.getHealthClient(moduleName);
+    if (!healthClient) return true;
+
+    try {
+      const response = await withTimeout(
+        healthClient.check({}) as Promise<HealthCheckResponse>,
+        timeoutMs,
+        `Module ${moduleName} health`,
+      );
+      return (
+        (response.status as unknown as HealthCheckStatus) === HealthCheckStatus.SERVING
+      );
+    } catch {
+      return false;
+    }
+  }
+}

--- a/packages/core/src/health/config.ts
+++ b/packages/core/src/health/config.ts
@@ -1,0 +1,29 @@
+import type { ReadinessConfig } from './types.js';
+
+function parseBoolean(value: string | undefined, defaultValue: boolean): boolean {
+  if (value === undefined || value === '') return defaultValue;
+  return value.toLowerCase() === 'true' || value === '1';
+}
+
+function parsePositiveInt(value: string | undefined, defaultValue: number): number {
+  if (value === undefined || value === '') return defaultValue;
+  const parsed = parseInt(value, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : defaultValue;
+}
+
+export function loadReadinessConfig(): ReadinessConfig {
+  const requiredModules = (process.env.READY_REQUIRED_MODULES ?? '')
+    .split(',')
+    .map(name => name.trim())
+    .filter(Boolean);
+
+  return {
+    requiredModules,
+    checkRedis: parseBoolean(process.env.READY_CHECK_REDIS, true),
+    strict: parseBoolean(process.env.READY_STRICT, false),
+    probeModulesActive: parseBoolean(process.env.READY_PROBE_MODULES_ACTIVE, false),
+    totalTimeoutMs: parsePositiveInt(process.env.READY_TOTAL_TIMEOUT_MS, 3000),
+    redisTimeoutMs: parsePositiveInt(process.env.READY_REDIS_TIMEOUT_MS, 500),
+    moduleTimeoutMs: parsePositiveInt(process.env.READY_MODULE_TIMEOUT_MS, 1000),
+  };
+}

--- a/packages/core/src/health/readinessMiddleware.ts
+++ b/packages/core/src/health/readinessMiddleware.ts
@@ -1,0 +1,27 @@
+import { NextFunction, Response } from 'express';
+import { ConduitRequest } from '@conduitplatform/hermes';
+import { ReadinessService } from './ReadinessService.js';
+import { sendLiveResponse, sendReadyResponse } from './response.js';
+
+export function getReadinessMiddleware(getService: () => ReadinessService) {
+  return async function readinessMiddleware(
+    req: ConduitRequest,
+    res: Response,
+    next: NextFunction,
+  ) {
+    if (req.method !== 'GET') return next();
+
+    if (req.path === '/live') {
+      sendLiveResponse(req, res);
+      return;
+    }
+
+    if (req.path === '/ready') {
+      const report = await getService().evaluate();
+      sendReadyResponse(req, res, report);
+      return;
+    }
+
+    next();
+  };
+}

--- a/packages/core/src/health/response.ts
+++ b/packages/core/src/health/response.ts
@@ -1,0 +1,37 @@
+import type { Request, Response } from 'express';
+import type { ReadinessReport } from './types.js';
+
+export const LEGACY_READY_MESSAGE = 'Conduit Core is online!';
+export const LEGACY_NOT_READY_MESSAGE = 'Conduit Core is not ready';
+
+export function wantsLegacyResponse(req: Request): boolean {
+  if (req.query.legacy === 'true') return true;
+  const accept = req.headers.accept;
+  if (!accept || typeof accept !== 'string') return false;
+  if (accept.includes('application/json')) return false;
+  return accept.includes('text/plain') || accept.includes('*/*');
+}
+
+export function sendReadyResponse(
+  req: Request,
+  res: Response,
+  report: ReadinessReport,
+): void {
+  const httpStatus = report.status === 'ready' ? 200 : 503;
+  if (wantsLegacyResponse(req)) {
+    const body =
+      report.status === 'ready' ? LEGACY_READY_MESSAGE : LEGACY_NOT_READY_MESSAGE;
+    res.status(httpStatus).type('text/plain').send(body);
+    return;
+  }
+  res.status(httpStatus).json(report);
+}
+
+export function sendLiveResponse(req: Request, res: Response): void {
+  const payload = { status: 'alive', message: 'Conduit Core is alive' };
+  if (wantsLegacyResponse(req)) {
+    res.status(200).type('text/plain').send(LEGACY_READY_MESSAGE);
+    return;
+  }
+  res.status(200).json(payload);
+}

--- a/packages/core/src/health/types.ts
+++ b/packages/core/src/health/types.ts
@@ -1,0 +1,30 @@
+export type ReadinessCheckStatus = 'pass' | 'fail' | 'warn';
+
+export type ReadinessCheck = {
+  name: string;
+  status: ReadinessCheckStatus;
+  message?: string;
+  latencyMs?: number;
+};
+
+export type ReadinessReport = {
+  status: 'ready' | 'not_ready';
+  message: string;
+  checks: ReadinessCheck[];
+  timestamp: string;
+};
+
+export interface CoreHealthProvider {
+  readonly initialized: boolean;
+  isGrpcServing(): boolean;
+}
+
+export type ReadinessConfig = {
+  requiredModules: string[];
+  checkRedis: boolean;
+  strict: boolean;
+  probeModulesActive: boolean;
+  totalTimeoutMs: number;
+  redisTimeoutMs: number;
+  moduleTimeoutMs: number;
+};


### PR DESCRIPTION
**What kind of change does this PR introduce?**

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other (please describe)

**Does this PR introduce a breaking change?**

- [x] Yes
- [ ] No

`GET /ready` now returns structured JSON and HTTP 503 when Core cannot coordinate the platform. Scripts that expected a plain `"Conduit Core is online!"` body on every 200 should use `?legacy=true` or `Accept: text/plain`.

**The PR fulfills these requirements:**

- [x] It's submitted to the `main` branch
- [ ] When resolving a specific issue, it's referenced in the PR's description

**Other information:**

## Problem

Core `GET /ready` always returned 200 with a static string, so Kubernetes and external monitors could mark the pod ready while Redis or required modules were unavailable.

## Solution

- Add `ReadinessService` aggregating checks for Core bootstrap, gRPC health, Redis PING, and required modules from `ServiceRegistry`.
- Upgrade `GET /ready` to return JSON with per-check status; HTTP 503 when not ready.
- Add shallow `GET /live` for optional HTTP liveness.
- Support `?legacy=true` and `Accept: text/plain` for the previous string responses on success.
- Return `{ modules: [] }` from `GET /config/modules` during startup instead of HTTP 500.

### Config (`READY_*` env)

| Variable | Default | Purpose |
|----------|---------|---------|
| `READY_REQUIRED_MODULES` | `""` | Comma-separated module names that must be serving |
| `READY_CHECK_REDIS` | `true` | Enable Redis PING |
| `READY_STRICT` | `false` | Treat non-serving optional modules as failures |
| `READY_PROBE_MODULES_ACTIVE` | `false` | Active gRPC health per request |
| `READY_TOTAL_TIMEOUT_MS` | `3000` | Overall deadline |
| `READY_REDIS_TIMEOUT_MS` | `500` | Redis timeout |
| `READY_MODULE_TIMEOUT_MS` | `1000` | Active module probe timeout |

## Test plan

- [ ] `curl localhost:3030/ready` returns 503 before required modules register, then 200 when healthy
- [ ] Stop Redis: `/ready` returns 503 while `/live` stays 200
- [ ] `curl '?legacy=true' localhost:3030/ready` returns legacy string on success
- [ ] `GET /config/modules` returns `{ modules: [] }` when no modules are registered yet

## Follow-up

Router module `GET /ready` remains shallow; deep readiness there is a separate change.