### PR TITLE
docs(authorization): MCP bulk relations and indexer guardrails

### DIFF
--- a/modules/authorization/src/admin/index.ts
+++ b/modules/authorization/src/admin/index.ts
@@ -98,7 +98,7 @@ export class AdminHandlers {
         bodyParams: {
           soft: ConduitBoolean.Optional,
         },
-        description: `Wipes and re-constructs the relation indexes.`,
+        description: `Rebuilds relation indexes. Body: soft (optional boolean, default false). soft=true skips wipe and only enqueues missing index jobs; soft=false deletes all ActorIndex and ObjectIndex documents first, then re-enqueues jobs for every relation. Returns "ok" immediately; work runs in background. Use only after index corruption or bulk imports — try soft=true first; require explicit user confirmation before soft=false.`,
       },
       new ConduitRouteReturnDefinition('IndexReconstruct', 'String'),
       this.reconstructIndices.bind(this),

--- a/modules/authorization/src/admin/relations.ts
+++ b/modules/authorization/src/admin/relations.ts
@@ -37,7 +37,7 @@ export class RelationHandler {
       {
         path: '/relations/many',
         action: ConduitRouteActions.POST,
-        description: `Creates many relations.`,
+        description: `Creates many relations in one request. Body: subject, relation, resources[] (required). Enqueues async index jobs per tuple. Prefer post_authorization_relations for a single tuple. Validate subject/relation against the ResourceDefinition; batch ≤100 resources when possible. Admin-only.`,
         bodyParams: {
           subject: ConduitString.Required,
           relation: ConduitString.Required,


### PR DESCRIPTION
## Summary

Agents provisioning ReBAC need bulk relation grants and index recovery via MCP, but the existing admin routes lacked safety-oriented descriptions in tool metadata. This PR enriches route `description` fields for `POST /authorization/relations/many` and `POST /authorization/indexer/reconstruct` so Hermes MCP tools (`post_authorization_relations_many`, `post_authorization_indexer_reconstruct`) surface batching guidance and destructive-rebuild warnings to agents.

- **`POST /authorization/relations/many`** — documents body shape (`subject`, `relation`, `resources[]`), async indexing, preference for single-create, ResourceDefinition validation, and batch size guidance
- **`POST /authorization/indexer/reconstruct`** — documents `soft` semantics (default hard wipe), async behavior, and requirement to try `soft: true` first with explicit user confirmation before `soft: false`

No route handler or `mcp` flag changes. Database `schemas/import` and `introspection/*` routes remain excluded from MCP.

## Test plan

- [ ] Connect MCP with `?modules=authorization` and call `tools/list`
- [ ] Confirm `post_authorization_relations_many` and `post_authorization_indexer_reconstruct` are listed
- [ ] Invoke `post_authorization_relations_many` with JSON body `{ subject, relation, resources: [...] }` → relations created
- [ ] Invoke `post_authorization_indexer_reconstruct` with `{ "soft": true }` → returns `"ok"`
- [ ] Confirm database import/introspection tools are absent from tools/list