### PR TITLE
feat(communications): unified CommunicationTemplate CRUD and orchestration

### DIFF
--- a/libraries/grpc-sdk/src/modules/communications/index.ts
+++ b/libraries/grpc-sdk/src/modules/communications/index.ts
@@ -201,11 +201,12 @@ export class Communications extends ConduitModule<typeof CommunicationsDefinitio
       platform?: string;
       doNotStore?: boolean;
       isSilent?: boolean;
+      templateName?: string;
     },
   ) {
     return this.client!.sendCommunication({
       channel,
-      templateName: '', // Not used for direct sending
+      templateName: params.templateName ?? '',
       params: {
         recipient: params.recipient,
         subject: params.subject,
@@ -244,12 +245,13 @@ export class Communications extends ConduitModule<typeof CommunicationsDefinitio
       platform?: string;
       doNotStore?: boolean;
       isSilent?: boolean;
+      templateName?: string;
     },
   ) {
     return this.client!.sendToMultipleChannels({
       channels,
       strategy,
-      templateName: '', // Not used for direct sending
+      templateName: params.templateName ?? '',
       params: {
         recipient: params.recipient,
         subject: params.subject,
@@ -287,11 +289,12 @@ export class Communications extends ConduitModule<typeof CommunicationsDefinitio
       platform?: string;
       doNotStore?: boolean;
       isSilent?: boolean;
+      templateName?: string;
     },
   ) {
     return this.client!.sendWithFallback({
       fallbackChain,
-      templateName: '', // Not used for direct sending
+      templateName: params.templateName ?? '',
       params: {
         recipient: params.recipient,
         subject: params.subject,
@@ -322,5 +325,74 @@ export class Communications extends ConduitModule<typeof CommunicationsDefinitio
     }).then(res => {
       return JSON.parse(res.statusInfo);
     });
+  }
+
+  registerCommunicationTemplate(template: {
+    name: string;
+    channels: ('email' | 'push' | 'sms')[];
+    description?: string;
+    variables?: string[];
+    email?: { subject: string; body: string; sender?: string };
+    push?: { title: string; body: string };
+    sms?: { message: string };
+  }) {
+    return this.client!.registerCommunicationTemplate({
+      name: template.name,
+      channels: template.channels,
+      description: template.description,
+      variables: template.variables ?? [],
+      template: {
+        email: template.email,
+        push: template.push,
+        sms: template.sms,
+      },
+    }).then(res => JSON.parse(res.template));
+  }
+
+  updateCommunicationTemplate(
+    id: string,
+    params: {
+      name?: string;
+      channels?: ('email' | 'push' | 'sms')[];
+      description?: string;
+      variables?: string[];
+      email?: { subject: string; body: string; sender?: string };
+      push?: { title: string; body: string };
+      sms?: { message: string };
+    },
+  ) {
+    return this.client!.updateCommunicationTemplate({
+      id,
+      name: params.name,
+      channels: params.channels ?? [],
+      description: params.description,
+      variables: params.variables ?? [],
+      template: {
+        email: params.email,
+        push: params.push,
+        sms: params.sms,
+      },
+    }).then(res => JSON.parse(res.template));
+  }
+
+  deleteCommunicationTemplate(id: string) {
+    return this.client!.deleteCommunicationTemplate({ id });
+  }
+
+  getCommunicationTemplate(params: { id?: string; name?: string }) {
+    return this.client!.getCommunicationTemplate(params).then(res => {
+      return JSON.parse(res.template);
+    });
+  }
+
+  listCommunicationTemplates(params: { skip?: number; limit?: number; search?: string }) {
+    return this.client!.listCommunicationTemplates({
+      skip: params.skip ?? 0,
+      limit: params.limit ?? 25,
+      search: params.search,
+    }).then(res => ({
+      templates: res.templates.map(t => JSON.parse(t)),
+      count: res.count,
+    }));
   }
 }

--- a/modules/communications/src/Communications.ts
+++ b/modules/communications/src/Communications.ts
@@ -24,8 +24,10 @@ import { EmailService } from './services/email.service.js';
 import { PushService } from './services/push.service.js';
 import { SmsService } from './services/sms.service.js';
 import { OrchestratorService } from './services/orchestrator.service.js';
+import { CommunicationTemplateService } from './services/communication-template.service.js';
 import { QueueController } from './controllers/queue.controller.js';
 import * as models from './models/index.js';
+import type { CommunicationTemplate } from './models/CommunicationTemplate.schema.js';
 import { runMigrations } from './migrations/index.js';
 import metricsSchema from './metrics/index.js';
 import {
@@ -52,6 +54,13 @@ import {
   GetNotificationTokensResponse,
   RegisterCommunicationTemplateRequest,
   RegisterCommunicationTemplateResponse,
+  UpdateCommunicationTemplateRequest,
+  DeleteCommunicationTemplateRequest,
+  DeleteCommunicationTemplateResponse,
+  GetCommunicationTemplateRequest,
+  GetCommunicationTemplateResponse,
+  ListCommunicationTemplatesRequest,
+  ListCommunicationTemplatesResponse,
   RegisterTemplateRequest,
   RegisterTemplateResponse,
   ResendEmailRequest,
@@ -109,6 +118,10 @@ export default class Communications extends ManagedModule<Config> {
       sendToMultipleChannels: this.sendToMultipleChannels.bind(this),
       sendWithFallback: this.sendWithFallback.bind(this),
       registerCommunicationTemplate: this.registerCommunicationTemplate.bind(this),
+      updateCommunicationTemplate: this.updateCommunicationTemplate.bind(this),
+      deleteCommunicationTemplate: this.deleteCommunicationTemplate.bind(this),
+      getCommunicationTemplate: this.getCommunicationTemplate.bind(this),
+      listCommunicationTemplates: this.listCommunicationTemplates.bind(this),
       getMessageStatus: this.getMessageStatus.bind(this),
     },
   };
@@ -121,6 +134,7 @@ export default class Communications extends ManagedModule<Config> {
   private pushService: PushService;
   private smsService: SmsService;
   private orchestratorService: OrchestratorService;
+  private templateService: CommunicationTemplateService;
   private legacyModulesPendingCleanup: string[] = [];
 
   // Provider instances
@@ -211,6 +225,7 @@ export default class Communications extends ManagedModule<Config> {
         this.pushService,
         this.smsService,
         this.orchestratorService,
+        this.templateService,
       );
 
       // Initialize user routes for push notifications
@@ -237,8 +252,15 @@ export default class Communications extends ManagedModule<Config> {
   }
 
   async initializeMetrics() {
-    const templatesTotal = await models.EmailTemplate.getInstance().countDocuments({});
-    ConduitGrpcSdk.Metrics?.set('email_templates_total', templatesTotal);
+    const [emailTemplatesTotal, communicationTemplatesTotal] = await Promise.all([
+      models.EmailTemplate.getInstance().countDocuments({}),
+      models.CommunicationTemplate.getInstance().countDocuments({}),
+    ]);
+    ConduitGrpcSdk.Metrics?.set('email_templates_total', emailTemplatesTotal);
+    ConduitGrpcSdk.Metrics?.set(
+      'communication_templates_total',
+      communicationTemplatesTotal,
+    );
   }
 
   // Framework export/import (GitOps)
@@ -314,6 +336,17 @@ export default class Communications extends ManagedModule<Config> {
         continue;
       }
       try {
+        const emailCollision = await emailModel.findOne({ name });
+        if (emailCollision) {
+          result.communicationTemplates.failed += 1;
+          result.communicationTemplates.errors.push(
+            `${String(name)}: name conflicts with existing email template`,
+          );
+          continue;
+        }
+
+        this.templateService.validateForImport(r);
+
         const existing = await commModel.findOne({ name });
         if (existing) {
           await commModel.updateOne({ name }, r);
@@ -329,6 +362,10 @@ export default class Communications extends ManagedModule<Config> {
         );
       }
     }
+
+    const commTemplateCount = await commModel.countDocuments({});
+    ConduitGrpcSdk.Metrics?.set('communication_templates_total', commTemplateCount);
+
     return result;
   }
 
@@ -654,6 +691,7 @@ export default class Communications extends ManagedModule<Config> {
       platform: params!.platform,
       doNotStore: params!.doNotStore,
       isSilent: params!.isSilent,
+      templateName: templateName || undefined,
     };
 
     let errorMessage: string | null = null;
@@ -700,6 +738,7 @@ export default class Communications extends ManagedModule<Config> {
       platform: params!.platform,
       doNotStore: params!.doNotStore,
       isSilent: params!.isSilent,
+      templateName: templateName || undefined,
     };
 
     let errorMessage: string | null = null;
@@ -752,6 +791,7 @@ export default class Communications extends ManagedModule<Config> {
       platform: params!.platform,
       doNotStore: params!.doNotStore,
       isSilent: params!.isSilent,
+      templateName: templateName || undefined,
     };
 
     let errorMessage: string | null = null;
@@ -781,9 +821,166 @@ export default class Communications extends ManagedModule<Config> {
     call: GrpcRequest<RegisterCommunicationTemplateRequest>,
     callback: GrpcCallback<RegisterCommunicationTemplateResponse>,
   ) {
-    // This would implement the unified template registration
-    // For now, return a placeholder
-    return callback(null, { template: JSON.stringify({ name: call.request.name }) });
+    try {
+      const template = await this.templateService.create(
+        this.mapProtoToCreateParams(call.request),
+      );
+      return callback(null, { template: JSON.stringify(template) });
+    } catch (e) {
+      const message = (e as Error).message;
+      const code = message.includes('already exists')
+        ? status.ALREADY_EXISTS
+        : status.INTERNAL;
+      return callback({ code, message });
+    }
+  }
+
+  async updateCommunicationTemplate(
+    call: GrpcRequest<UpdateCommunicationTemplateRequest>,
+    callback: GrpcCallback<RegisterCommunicationTemplateResponse>,
+  ) {
+    try {
+      const template = await this.templateService.update(
+        call.request.id,
+        this.mapProtoToUpdateParams(call.request),
+      );
+      return callback(null, { template: JSON.stringify(template) });
+    } catch (e) {
+      const message = (e as Error).message;
+      const code = message.includes('not found')
+        ? status.NOT_FOUND
+        : message.includes('already exists')
+          ? status.ALREADY_EXISTS
+          : status.INTERNAL;
+      return callback({ code, message });
+    }
+  }
+
+  async deleteCommunicationTemplate(
+    call: GrpcRequest<DeleteCommunicationTemplateRequest>,
+    callback: GrpcCallback<DeleteCommunicationTemplateResponse>,
+  ) {
+    try {
+      const result = await this.templateService.delete(call.request.id);
+      return callback(null, { deleted: result.deleted });
+    } catch (e) {
+      const message = (e as Error).message;
+      const code = message.includes('not found') ? status.NOT_FOUND : status.INTERNAL;
+      return callback({ code, message });
+    }
+  }
+
+  async getCommunicationTemplate(
+    call: GrpcRequest<GetCommunicationTemplateRequest>,
+    callback: GrpcCallback<GetCommunicationTemplateResponse>,
+  ) {
+    try {
+      let template;
+      if (call.request.id) {
+        template = await this.templateService.getById(call.request.id);
+      } else if (call.request.name) {
+        template = await this.templateService.getByName(call.request.name);
+        if (!template) {
+          return callback({ code: status.NOT_FOUND, message: 'Template does not exist' });
+        }
+      } else {
+        return callback({
+          code: status.INVALID_ARGUMENT,
+          message: 'Either id or name must be provided',
+        });
+      }
+      return callback(null, { template: JSON.stringify(template) });
+    } catch (e) {
+      const message = (e as Error).message;
+      const code = message.includes('not found') ? status.NOT_FOUND : status.INTERNAL;
+      return callback({ code, message });
+    }
+  }
+
+  async listCommunicationTemplates(
+    call: GrpcRequest<ListCommunicationTemplatesRequest>,
+    callback: GrpcCallback<ListCommunicationTemplatesResponse>,
+  ) {
+    const { skip, limit, search } = call.request;
+    let query: Record<string, unknown> = {};
+    if (search) {
+      if (search.match(/^[a-fA-F\d]{24}$/)) {
+        query = { _id: search };
+      } else {
+        query = { name: { $regex: `.*${search}.*`, $options: 'i' } };
+      }
+    }
+
+    try {
+      const { documents, count } = await this.templateService.list(query as never, {
+        skip,
+        limit,
+      });
+      return callback(null, {
+        templates: documents.map((doc: CommunicationTemplate) => JSON.stringify(doc)),
+        count,
+      });
+    } catch (e) {
+      return callback({ code: status.INTERNAL, message: (e as Error).message });
+    }
+  }
+
+  private mapProtoToCreateParams(request: RegisterCommunicationTemplateRequest) {
+    const nested = request.template;
+    return {
+      name: request.name,
+      channels: (request.channels ?? []) as ('email' | 'push' | 'sms')[],
+      summary: request.description,
+      variables: request.variables?.length ? request.variables : undefined,
+      email: nested?.email
+        ? {
+            subject: nested.email.subject,
+            body: nested.email.body,
+            sender: nested.email.sender,
+          }
+        : undefined,
+      push: nested?.push
+        ? {
+            title: nested.push.title,
+            body: nested.push.body,
+          }
+        : undefined,
+      sms: nested?.sms
+        ? {
+            message: nested.sms.message,
+          }
+        : undefined,
+    };
+  }
+
+  private mapProtoToUpdateParams(request: UpdateCommunicationTemplateRequest) {
+    const nested = request.template;
+    return {
+      name: request.name,
+      channels: request.channels?.length
+        ? (request.channels as ('email' | 'push' | 'sms')[])
+        : undefined,
+      summary: request.description,
+      variables: request.variables?.length ? request.variables : undefined,
+      email: nested?.email
+        ? {
+            subject: nested.email.subject,
+            body: nested.email.body,
+            sender: nested.email.sender,
+          }
+        : undefined,
+      push: nested?.push
+        ? {
+            title: nested.push.title,
+            body: nested.push.body,
+          }
+        : undefined,
+      sms: nested?.sms
+        ? {
+            message: nested.sms.message,
+          }
+        : undefined,
+    };
   }
 
   async getMessageStatus(
@@ -815,13 +1012,14 @@ export default class Communications extends ManagedModule<Config> {
     this.emailService = new EmailService(this.grpcSdk);
     this.pushService = new PushService(this.grpcSdk);
     this.smsService = new SmsService(this.grpcSdk);
+    this.templateService = new CommunicationTemplateService(this.grpcSdk);
 
-    // Initialize orchestrator service
     this.orchestratorService = new OrchestratorService(
       this.grpcSdk,
       this.emailService,
       this.pushService,
       this.smsService,
+      this.templateService,
     );
   }
 }

--- a/modules/communications/src/admin/index.ts
+++ b/modules/communications/src/admin/index.ts
@@ -26,11 +26,13 @@ import { EmailService } from '../services/email.service.js';
 import { PushService } from '../services/push.service.js';
 import { SmsService } from '../services/sms.service.js';
 import { OrchestratorService } from '../services/orchestrator.service.js';
+import { CommunicationTemplateService } from '../services/communication-template.service.js';
 import {
   EmailTemplate,
   EmailRecord,
   NotificationToken,
   SmsRecord,
+  CommunicationTemplate,
 } from '../models/index.js';
 import { getHandleBarsValues } from '../providers/email/utils/index.js';
 import { Template } from '../providers/email/interfaces/Template.js';
@@ -41,6 +43,7 @@ export class AdminHandlers {
   private pushService: PushService;
   private smsService: SmsService;
   private orchestratorService: OrchestratorService;
+  private templateService: CommunicationTemplateService;
   private readonly routingManager: RoutingManager;
 
   constructor(
@@ -56,11 +59,13 @@ export class AdminHandlers {
     pushService: PushService,
     smsService: SmsService,
     orchestratorService: OrchestratorService,
+    templateService: CommunicationTemplateService,
   ) {
     this.emailService = emailService;
     this.pushService = pushService;
     this.smsService = smsService;
     this.orchestratorService = orchestratorService;
+    this.templateService = templateService;
   }
 
   // Email admin routes
@@ -127,7 +132,7 @@ export class AdminHandlers {
   async sendToMultipleChannels(
     call: ParsedRouterRequest,
   ): Promise<UnparsedRouterResponse> {
-    const { channels, strategy, recipient, subject, body, variables } =
+    const { channels, strategy, recipient, subject, body, variables, templateName } =
       call.request.params;
 
     const sendParams = {
@@ -137,6 +142,7 @@ export class AdminHandlers {
       subject,
       body,
       variables,
+      templateName,
     };
 
     const result = await this.orchestratorService
@@ -153,7 +159,8 @@ export class AdminHandlers {
   }
 
   async sendWithFallback(call: ParsedRouterRequest): Promise<UnparsedRouterResponse> {
-    const { fallbackChain, recipient, subject, body, variables } = call.request.params;
+    const { fallbackChain, recipient, subject, body, variables, templateName } =
+      call.request.params;
 
     const sendParams = {
       fallbackChain: fallbackChain.map((step: { channel: string; timeout?: number }) => ({
@@ -164,6 +171,7 @@ export class AdminHandlers {
       subject,
       body,
       variables,
+      templateName,
     };
 
     const result = await this.orchestratorService
@@ -177,6 +185,145 @@ export class AdminHandlers {
       messageId: result.messageId,
       attempts: result.attempts,
     };
+  }
+
+  // Unified communication template management
+  async sendCommunication(call: ParsedRouterRequest): Promise<UnparsedRouterResponse> {
+    const { channel, templateName, recipient, subject, body, variables, sender } =
+      call.request.params;
+
+    const result = await this.orchestratorService
+      .sendToChannel(channel as 'email' | 'push' | 'sms', {
+        recipient,
+        subject,
+        body,
+        variables,
+        sender,
+        templateName,
+      })
+      .catch(e => {
+        throw new GrpcError(status.INTERNAL, e.message);
+      });
+
+    return result;
+  }
+
+  async getCommunicationTemplates(
+    call: ParsedRouterRequest,
+  ): Promise<UnparsedRouterResponse> {
+    const { sort } = call.request.params;
+    const { skip } = call.request.params ?? 0;
+    const { limit } = call.request.params ?? 25;
+    let query: Query<CommunicationTemplate> = {};
+    let identifier;
+    if (!isNil(call.request.params.search)) {
+      if (call.request.params.search.match(/^[a-fA-F\d]{24}$/)) {
+        query = { _id: call.request.params.search };
+      } else {
+        identifier = escapeStringRegexp(call.request.params.search);
+        query = { name: { $regex: `.*${identifier}.*`, $options: 'i' } };
+      }
+    }
+
+    const { documents, count } = await this.templateService
+      .list(query, { skip, limit, sort })
+      .catch((e: Error) => {
+        throw new GrpcError(status.INTERNAL, e.message);
+      });
+
+    return { templateDocuments: documents, count };
+  }
+
+  async getCommunicationTemplate(
+    call: ParsedRouterRequest,
+  ): Promise<UnparsedRouterResponse> {
+    const template = await this.templateService
+      .getById(call.request.urlParams.id)
+      .catch((e: Error) => {
+        if (e.message.includes('not exist')) {
+          throw new GrpcError(status.NOT_FOUND, e.message);
+        }
+        throw new GrpcError(status.INTERNAL, e.message);
+      });
+    return { template };
+  }
+
+  async createCommunicationTemplate(
+    call: ParsedRouterRequest,
+  ): Promise<UnparsedRouterResponse> {
+    const { name, channels, email, push, sms, variables, templateDescription } =
+      call.request.params;
+    const template = await this.templateService
+      .create({
+        name,
+        channels,
+        email,
+        push,
+        sms,
+        variables,
+        summary: templateDescription,
+      })
+      .catch((e: Error) => {
+        if (e.message.includes('already exists')) {
+          throw new GrpcError(status.ALREADY_EXISTS, e.message);
+        }
+        throw new GrpcError(status.INTERNAL, e.message);
+      });
+    return { template };
+  }
+
+  async patchCommunicationTemplate(
+    call: ParsedRouterRequest,
+  ): Promise<UnparsedRouterResponse> {
+    const bodyParams = { ...call.request.bodyParams };
+    if (bodyParams.templateDescription !== undefined) {
+      bodyParams.summary = bodyParams.templateDescription;
+      delete bodyParams.templateDescription;
+    }
+    const template = await this.templateService
+      .update(call.request.urlParams.id, bodyParams)
+      .catch((e: Error) => {
+        if (e.message.includes('not exist')) {
+          throw new GrpcError(status.NOT_FOUND, e.message);
+        }
+        if (e.message.includes('already exists')) {
+          throw new GrpcError(status.ALREADY_EXISTS, e.message);
+        }
+        throw new GrpcError(status.INTERNAL, e.message);
+      });
+    return { template };
+  }
+
+  async deleteCommunicationTemplate(
+    call: ParsedRouterRequest,
+  ): Promise<UnparsedRouterResponse> {
+    return await this.templateService
+      .delete(call.request.urlParams.id)
+      .catch((e: Error) => {
+        if (e.message.includes('not exist')) {
+          throw new GrpcError(status.NOT_FOUND, e.message);
+        }
+        throw new GrpcError(status.INTERNAL, e.message);
+      });
+  }
+
+  async migrateFromEmailTemplate(
+    call: ParsedRouterRequest,
+  ): Promise<UnparsedRouterResponse> {
+    const { emailTemplateId, dryRun, skipExisting, deleteSource } = call.request.params;
+    return await this.templateService
+      .migrateFromEmailTemplate({
+        emailTemplateId,
+        dryRun,
+        skipExisting,
+        deleteSource,
+      })
+      .catch((e: Error) => {
+        if (e.message.includes('already exists')) {
+          throw new GrpcError(status.ALREADY_EXISTS, e.message);
+        }
+        throw new GrpcError(status.INTERNAL, e.message);
+      });
   }
 
   // Email template management methods
@@ -224,7 +371,6 @@ export class AdminHandlers {
 
     if (externalManaged) {
       if (isNil(_id)) {
-        //that means that we want to create an external managed template
         const [err, template] = await to(
           this.emailService.createExternalTemplate({
             name,
@@ -240,6 +386,15 @@ export class AdminHandlers {
         externalId = _id;
       }
     }
+
+    const unifiedCollision = await CommunicationTemplate.getInstance().findOne({ name });
+    if (!isNil(unifiedCollision)) {
+      throw new GrpcError(
+        status.ALREADY_EXISTS,
+        `A unified template named '${name}' already exists`,
+      );
+    }
+
     const newTemplate = await EmailTemplate.getInstance()
       .create({
         name,
@@ -594,6 +749,7 @@ export class AdminHandlers {
           subject: ConduitString.Optional,
           body: ConduitString.Optional,
           variables: ConduitJson.Optional,
+          templateName: ConduitString.Optional,
         },
       },
       new ConduitRouteReturnDefinition('SendToMultipleChannels', 'Object'),
@@ -611,10 +767,140 @@ export class AdminHandlers {
           subject: ConduitString.Optional,
           body: ConduitString.Optional,
           variables: ConduitJson.Optional,
+          templateName: ConduitString.Optional,
         },
       },
       new ConduitRouteReturnDefinition('SendWithFallback', 'Object'),
       this.sendWithFallback.bind(this),
+    );
+
+    this.routingManager.route(
+      {
+        path: '/communications/send',
+        action: ConduitRouteActions.POST,
+        description: 'Sends a message on a single channel.',
+        bodyParams: {
+          channel: ConduitString.Required,
+          recipient: ConduitString.Required,
+          templateName: ConduitString.Optional,
+          subject: ConduitString.Optional,
+          body: ConduitString.Optional,
+          variables: ConduitJson.Optional,
+          sender: ConduitString.Optional,
+        },
+      },
+      new ConduitRouteReturnDefinition('SendCommunication', 'Object'),
+      this.sendCommunication.bind(this),
+    );
+
+    this.routingManager.route(
+      {
+        path: '/communications/templates',
+        action: ConduitRouteActions.GET,
+        description: 'Get unified communication templates',
+        queryParams: {
+          skip: ConduitNumber.Optional,
+          limit: ConduitNumber.Optional,
+          sort: ConduitString.Optional,
+          search: ConduitString.Optional,
+        },
+      },
+      new ConduitRouteReturnDefinition('GetCommunicationTemplates', {
+        templateDocuments: ['CommunicationTemplate'],
+        count: ConduitNumber.Required,
+      }),
+      this.getCommunicationTemplates.bind(this),
+    );
+
+    this.routingManager.route(
+      {
+        path: '/communications/templates',
+        action: ConduitRouteActions.POST,
+        description: 'Create unified communication template',
+        bodyParams: {
+          name: ConduitString.Required,
+          channels: { type: [TYPE.String], required: true },
+          email: ConduitJson.Optional,
+          push: ConduitJson.Optional,
+          sms: ConduitJson.Optional,
+          variables: { type: [TYPE.String], required: false },
+          templateDescription: ConduitString.Optional,
+        },
+      },
+      new ConduitRouteReturnDefinition('CreateCommunicationTemplate', {
+        template: 'CommunicationTemplate',
+      }),
+      this.createCommunicationTemplate.bind(this),
+    );
+
+    this.routingManager.route(
+      {
+        path: '/communications/templates/migrate-from-email',
+        action: ConduitRouteActions.POST,
+        description: 'Migrate email templates to unified communication templates',
+        bodyParams: {
+          emailTemplateId: ConduitString.Optional,
+          dryRun: ConduitBoolean.Optional,
+          skipExisting: ConduitBoolean.Optional,
+          deleteSource: ConduitBoolean.Optional,
+        },
+      },
+      new ConduitRouteReturnDefinition('MigrateFromEmailTemplate', 'Object'),
+      this.migrateFromEmailTemplate.bind(this),
+    );
+
+    this.routingManager.route(
+      {
+        path: '/communications/templates/:id',
+        action: ConduitRouteActions.GET,
+        description: 'Get unified communication template by id',
+        urlParams: {
+          id: ConduitString.Required,
+        },
+      },
+      new ConduitRouteReturnDefinition('GetCommunicationTemplate', {
+        template: 'CommunicationTemplate',
+      }),
+      this.getCommunicationTemplate.bind(this),
+    );
+
+    this.routingManager.route(
+      {
+        path: '/communications/templates/:id',
+        action: ConduitRouteActions.PATCH,
+        description: 'Update unified communication template',
+        urlParams: {
+          id: ConduitString.Required,
+        },
+        bodyParams: {
+          name: ConduitString.Optional,
+          channels: { type: [TYPE.String], required: false },
+          email: ConduitJson.Optional,
+          push: ConduitJson.Optional,
+          sms: ConduitJson.Optional,
+          variables: { type: [TYPE.String], required: false },
+          templateDescription: ConduitString.Optional,
+        },
+      },
+      new ConduitRouteReturnDefinition('PatchCommunicationTemplate', {
+        template: 'CommunicationTemplate',
+      }),
+      this.patchCommunicationTemplate.bind(this),
+    );
+
+    this.routingManager.route(
+      {
+        path: '/communications/templates/:id',
+        action: ConduitRouteActions.DELETE,
+        description: 'Delete unified communication template',
+        urlParams: {
+          id: ConduitString.Required,
+        },
+      },
+      new ConduitRouteReturnDefinition('DeleteCommunicationTemplate', {
+        deleted: ConduitBoolean.Required,
+      }),
+      this.deleteCommunicationTemplate.bind(this),
     );
 
     // Additional Email routes

--- a/modules/communications/src/communications.proto
+++ b/modules/communications/src/communications.proto
@@ -236,7 +236,9 @@ message SendWithFallbackResponse {
 
 message RegisterCommunicationTemplateRequest {
   string name = 1;
-  CommunicationTemplate template = 2;
+  repeated string channels = 2;
+  optional string description = 3;
+  CommunicationTemplate template = 4;
   message CommunicationTemplate {
     optional EmailTemplate email = 1;
     optional PushTemplate push = 2;
@@ -257,10 +259,48 @@ message RegisterCommunicationTemplateRequest {
       repeated string variables = 2;
     }
   }
+  repeated string variables = 5;
 }
 
 message RegisterCommunicationTemplateResponse {
   string template = 1;
+}
+
+message UpdateCommunicationTemplateRequest {
+  string id = 1;
+  optional string name = 2;
+  repeated string channels = 3;
+  optional string description = 4;
+  optional RegisterCommunicationTemplateRequest.CommunicationTemplate template = 5;
+  repeated string variables = 6;
+}
+
+message DeleteCommunicationTemplateRequest {
+  string id = 1;
+}
+
+message DeleteCommunicationTemplateResponse {
+  bool deleted = 1;
+}
+
+message GetCommunicationTemplateRequest {
+  optional string id = 1;
+  optional string name = 2;
+}
+
+message GetCommunicationTemplateResponse {
+  string template = 1;
+}
+
+message ListCommunicationTemplatesRequest {
+  int32 skip = 1;
+  int32 limit = 2;
+  optional string search = 3;
+}
+
+message ListCommunicationTemplatesResponse {
+  repeated string templates = 1;
+  int32 count = 2;
 }
 
 message GetMessageStatusRequest {
@@ -298,5 +338,9 @@ service Communications {
   rpc SendToMultipleChannels(SendToMultipleChannelsRequest) returns (SendToMultipleChannelsResponse);
   rpc SendWithFallback(SendWithFallbackRequest) returns (SendWithFallbackResponse);
   rpc RegisterCommunicationTemplate(RegisterCommunicationTemplateRequest) returns (RegisterCommunicationTemplateResponse);
+  rpc UpdateCommunicationTemplate(UpdateCommunicationTemplateRequest) returns (RegisterCommunicationTemplateResponse);
+  rpc DeleteCommunicationTemplate(DeleteCommunicationTemplateRequest) returns (DeleteCommunicationTemplateResponse);
+  rpc GetCommunicationTemplate(GetCommunicationTemplateRequest) returns (GetCommunicationTemplateResponse);
+  rpc ListCommunicationTemplates(ListCommunicationTemplatesRequest) returns (ListCommunicationTemplatesResponse);
   rpc GetMessageStatus(GetMessageStatusRequest) returns (GetMessageStatusResponse);
 }

--- a/modules/communications/src/metrics/index.ts
+++ b/modules/communications/src/metrics/index.ts
@@ -50,6 +50,13 @@ export default {
       help: 'Total number of failed communications',
     },
   },
+  communication_templates_total: {
+    type: MetricType.Gauge,
+    config: {
+      name: 'communication_templates_total',
+      help: 'Total number of unified communication templates',
+    },
+  },
   fallback_chain_used_total: {
     type: MetricType.Counter,
     config: {

--- a/modules/communications/src/models/CommunicationTemplate.schema.ts
+++ b/modules/communications/src/models/CommunicationTemplate.schema.ts
@@ -13,6 +13,9 @@ const schema: ConduitModel = {
     unique: true,
     required: true,
   },
+  summary: {
+    type: TYPE.String,
+  },
   channels: {
     type: [TYPE.String],
     enum: ['email', 'push', 'sms'],
@@ -68,6 +71,7 @@ export class CommunicationTemplate extends ConduitActiveSchema<CommunicationTemp
   private static _instance: CommunicationTemplate;
   _id: string;
   declare name: string;
+  summary?: string;
   channels: ('email' | 'push' | 'sms')[];
   email?: {
     subject?: string;

--- a/modules/communications/src/services/communication-template.service.ts
+++ b/modules/communications/src/services/communication-template.service.ts
@@ -327,7 +327,7 @@ export class CommunicationTemplateService {
     const created = [];
     for (const item of planned) {
       if (item.skipped) continue;
-      const doc = await this.create(item.target);
+      const doc = await this.createMigratedTemplate(item.target);
       created.push(doc);
       if (deleteSource) {
         await EmailTemplate.getInstance().deleteOne({ _id: item.sourceId });
@@ -336,6 +336,28 @@ export class CommunicationTemplateService {
     }
 
     return { dryRun: false, planned, created, count: created.length };
+  }
+
+  private async createMigratedTemplate(params: ICreateCommunicationTemplateParams) {
+    const validated = this.validateTemplatePayload(params);
+    await this.assertUnifiedNameAvailable(validated.name);
+
+    const variables =
+      params.variables && params.variables.length > 0
+        ? params.variables
+        : this.extractVariables(validated);
+
+    const doc = await CommunicationTemplate.getInstance()
+      .create({
+        ...validated,
+        variables,
+      })
+      .catch((e: Error) => {
+        throw new GrpcError(status.INTERNAL, e.message);
+      });
+
+    ConduitGrpcSdk.Metrics?.increment('communication_templates_total');
+    return doc;
   }
 
   private renderUnifiedChannel(
@@ -477,11 +499,8 @@ export class CommunicationTemplateService {
     return [...vars];
   }
 
-  private async assertNameAvailable(name: string, excludeId?: string) {
-    const [unified, email] = await Promise.all([
-      CommunicationTemplate.getInstance().findOne({ name }),
-      EmailTemplate.getInstance().findOne({ name }),
-    ]);
+  private async assertUnifiedNameAvailable(name: string, excludeId?: string) {
+    const unified = await CommunicationTemplate.getInstance().findOne({ name });
 
     if (unified && unified._id !== excludeId) {
       throw new GrpcError(
@@ -489,7 +508,12 @@ export class CommunicationTemplateService {
         `A unified template named '${name}' already exists`,
       );
     }
+  }
 
+  private async assertNameAvailable(name: string, excludeId?: string) {
+    await this.assertUnifiedNameAvailable(name, excludeId);
+
+    const email = await EmailTemplate.getInstance().findOne({ name });
     if (email) {
       throw new GrpcError(
         status.ALREADY_EXISTS,

--- a/modules/communications/src/services/communication-template.service.ts
+++ b/modules/communications/src/services/communication-template.service.ts
@@ -1,0 +1,500 @@
+import handlebars from 'handlebars';
+import { isEmpty, isNil } from 'lodash-es';
+import { ConduitGrpcSdk, GrpcError, Query } from '@conduitplatform/grpc-sdk';
+import { status } from '@grpc/grpc-js';
+import { CommunicationTemplate, EmailTemplate } from '../models/index.js';
+import { getHandleBarsValues } from '../providers/email/utils/index.js';
+import { IChannelSendParams } from '../interfaces/index.js';
+
+export type CommunicationChannel = 'email' | 'push' | 'sms';
+
+export interface ICreateCommunicationTemplateParams {
+  name: string;
+  channels: CommunicationChannel[];
+  email?: {
+    subject?: string;
+    body?: string;
+    sender?: string;
+  };
+  push?: {
+    title?: string;
+    body?: string;
+  };
+  sms?: {
+    message?: string;
+  };
+  variables?: string[];
+  summary?: string;
+}
+
+export interface IUpdateCommunicationTemplateParams {
+  name?: string;
+  channels?: CommunicationChannel[];
+  email?: {
+    subject?: string;
+    body?: string;
+    sender?: string;
+  };
+  push?: {
+    title?: string;
+    body?: string;
+  };
+  sms?: {
+    message?: string;
+  };
+  variables?: string[];
+  summary?: string;
+}
+
+export interface IResolvedTemplateParams {
+  subject?: string;
+  body?: string;
+  sender?: string;
+  /** When set, email send should use EmailService.sendEmail for external-managed templates */
+  emailTemplateName?: string;
+}
+
+const CHANNELS: CommunicationChannel[] = ['email', 'push', 'sms'];
+
+export class CommunicationTemplateService {
+  constructor(private readonly grpcSdk: ConduitGrpcSdk) {}
+
+  async create(params: ICreateCommunicationTemplateParams) {
+    const validated = this.validateTemplatePayload(params);
+    await this.assertNameAvailable(validated.name);
+
+    const variables =
+      params.variables && params.variables.length > 0
+        ? params.variables
+        : this.extractVariables(validated);
+
+    const doc = await CommunicationTemplate.getInstance()
+      .create({
+        ...validated,
+        variables,
+      })
+      .catch((e: Error) => {
+        throw new GrpcError(status.INTERNAL, e.message);
+      });
+
+    ConduitGrpcSdk.Metrics?.increment('communication_templates_total');
+    return doc;
+  }
+
+  async update(id: string, params: IUpdateCommunicationTemplateParams) {
+    const existing = await CommunicationTemplate.getInstance().findOne({ _id: id });
+    if (isNil(existing)) {
+      throw new GrpcError(status.NOT_FOUND, 'Template does not exist');
+    }
+
+    const merged: ICreateCommunicationTemplateParams = {
+      name: params.name ?? existing.name,
+      channels: params.channels ?? existing.channels,
+      email: params.email ?? existing.email,
+      push: params.push ?? existing.push,
+      sms: params.sms ?? existing.sms,
+      summary: params.summary ?? (existing as { summary?: string }).summary,
+      variables: params.variables,
+    };
+
+    if (params.name && params.name !== existing.name) {
+      await this.assertNameAvailable(params.name, id);
+    }
+
+    const validated = this.validateTemplatePayload(merged);
+    const variables =
+      params.variables && params.variables.length > 0
+        ? params.variables
+        : this.extractVariables(validated);
+
+    const updated = await CommunicationTemplate.getInstance()
+      .findByIdAndUpdate(id, { ...validated, variables })
+      .catch((e: Error) => {
+        throw new GrpcError(status.INTERNAL, e.message);
+      });
+
+    return updated;
+  }
+
+  async delete(id: string) {
+    const existing = await CommunicationTemplate.getInstance().findOne({ _id: id });
+    if (isNil(existing)) {
+      throw new GrpcError(status.NOT_FOUND, 'Template does not exist');
+    }
+
+    await CommunicationTemplate.getInstance()
+      .deleteOne({ _id: id })
+      .catch((e: Error) => {
+        throw new GrpcError(status.INTERNAL, e.message);
+      });
+
+    ConduitGrpcSdk.Metrics?.decrement('communication_templates_total');
+    return { deleted: true };
+  }
+
+  async getById(id: string) {
+    const doc = await CommunicationTemplate.getInstance().findOne({ _id: id });
+    if (isNil(doc)) {
+      throw new GrpcError(status.NOT_FOUND, 'Template does not exist');
+    }
+    return doc;
+  }
+
+  async getByName(name: string) {
+    return CommunicationTemplate.getInstance().findOne({ name });
+  }
+
+  async list(
+    query: Query<CommunicationTemplate>,
+    pagination: { skip?: number; limit?: number; sort?: string },
+  ) {
+    const [documents, count] = await Promise.all([
+      CommunicationTemplate.getInstance().findMany(query, pagination),
+      CommunicationTemplate.getInstance().countDocuments(query),
+    ]);
+    return { documents, count };
+  }
+
+  async resolve(
+    templateName: string,
+    channel: CommunicationChannel,
+    variables: Record<string, unknown> = {},
+  ): Promise<IResolvedTemplateParams> {
+    const unified = await this.getByName(templateName);
+    if (unified) {
+      if (!unified.channels.includes(channel)) {
+        throw new GrpcError(
+          status.INVALID_ARGUMENT,
+          `Template '${templateName}' does not include channel '${channel}'`,
+        );
+      }
+      return this.renderUnifiedChannel(unified, channel, variables);
+    }
+
+    if (channel === 'email') {
+      const emailTemplate = await EmailTemplate.getInstance().findOne({
+        name: templateName,
+      });
+      if (emailTemplate) {
+        if (emailTemplate.externalManaged) {
+          return { emailTemplateName: templateName };
+        }
+        return {
+          subject: emailTemplate.subject
+            ? handlebars.compile(emailTemplate.subject)(variables)
+            : undefined,
+          body: emailTemplate.body
+            ? handlebars.compile(emailTemplate.body)(variables)
+            : undefined,
+          sender: emailTemplate.sender,
+        };
+      }
+    }
+
+    throw new GrpcError(status.NOT_FOUND, `Template '${templateName}' not found`);
+  }
+
+  async resolveAll(
+    templateName: string,
+    variables: Record<string, unknown> = {},
+  ): Promise<Partial<Record<CommunicationChannel, IResolvedTemplateParams>>> {
+    const unified = await this.getByName(templateName);
+    if (unified) {
+      const result: Partial<Record<CommunicationChannel, IResolvedTemplateParams>> = {};
+      for (const channel of unified.channels) {
+        result[channel] = this.renderUnifiedChannel(unified, channel, variables);
+      }
+      return result;
+    }
+
+    const emailTemplate = await EmailTemplate.getInstance().findOne({
+      name: templateName,
+    });
+    if (emailTemplate) {
+      if (emailTemplate.externalManaged) {
+        return { email: { emailTemplateName: templateName } };
+      }
+      return {
+        email: {
+          subject: emailTemplate.subject
+            ? handlebars.compile(emailTemplate.subject)(variables)
+            : undefined,
+          body: emailTemplate.body
+            ? handlebars.compile(emailTemplate.body)(variables)
+            : undefined,
+          sender: emailTemplate.sender,
+        },
+      };
+    }
+
+    throw new GrpcError(status.NOT_FOUND, `Template '${templateName}' not found`);
+  }
+
+  mergeWithRequest(
+    baseParams: IChannelSendParams,
+    resolved: IResolvedTemplateParams,
+  ): IChannelSendParams & { emailTemplateName?: string } {
+    if (resolved.emailTemplateName) {
+      return { ...baseParams, emailTemplateName: resolved.emailTemplateName };
+    }
+
+    return {
+      ...baseParams,
+      subject: !isEmpty(baseParams.subject) ? baseParams.subject : resolved.subject,
+      body: !isEmpty(baseParams.body) ? baseParams.body : resolved.body,
+      sender: !isEmpty(baseParams.sender) ? baseParams.sender : resolved.sender,
+    };
+  }
+
+  validateForImport(record: Record<string, unknown>): ICreateCommunicationTemplateParams {
+    return this.validateTemplatePayload(
+      record as unknown as ICreateCommunicationTemplateParams,
+    );
+  }
+
+  async migrateFromEmailTemplate(options: {
+    emailTemplateId?: string;
+    dryRun?: boolean;
+    skipExisting?: boolean;
+    deleteSource?: boolean;
+  }) {
+    const { emailTemplateId, dryRun, skipExisting, deleteSource } = options;
+    const query = emailTemplateId ? { _id: emailTemplateId } : {};
+    const emailTemplates = await EmailTemplate.getInstance().findMany(query);
+
+    const planned: Array<{
+      sourceId: string;
+      sourceName: string;
+      target: ICreateCommunicationTemplateParams;
+      skipped?: boolean;
+      warning?: string;
+    }> = [];
+
+    for (const emailTemplate of emailTemplates) {
+      const existing = await this.getByName(emailTemplate.name);
+      if (existing) {
+        if (skipExisting) {
+          planned.push({
+            sourceId: emailTemplate._id,
+            sourceName: emailTemplate.name,
+            target: {
+              name: emailTemplate.name,
+              channels: ['email'],
+              email: {
+                subject: emailTemplate.subject,
+                body: emailTemplate.body,
+                sender: emailTemplate.sender,
+              },
+              variables: emailTemplate.variables,
+            },
+            skipped: true,
+          });
+          continue;
+        }
+        throw new GrpcError(
+          status.ALREADY_EXISTS,
+          `Unified template '${emailTemplate.name}' already exists`,
+        );
+      }
+
+      const warning = emailTemplate.externalManaged
+        ? 'Source template is external-managed; unified template will be Conduit-managed only'
+        : undefined;
+
+      const target: ICreateCommunicationTemplateParams = {
+        name: emailTemplate.name,
+        channels: ['email'],
+        email: {
+          subject: emailTemplate.subject,
+          body: emailTemplate.body,
+          sender: emailTemplate.sender,
+        },
+        variables: emailTemplate.variables,
+      };
+
+      planned.push({
+        sourceId: emailTemplate._id,
+        sourceName: emailTemplate.name,
+        target,
+        warning,
+      });
+    }
+
+    if (dryRun) {
+      return { dryRun: true, planned, created: 0 };
+    }
+
+    const created = [];
+    for (const item of planned) {
+      if (item.skipped) continue;
+      const doc = await this.create(item.target);
+      created.push(doc);
+      if (deleteSource) {
+        await EmailTemplate.getInstance().deleteOne({ _id: item.sourceId });
+        ConduitGrpcSdk.Metrics?.decrement('email_templates_total');
+      }
+    }
+
+    return { dryRun: false, planned, created, count: created.length };
+  }
+
+  private renderUnifiedChannel(
+    template: CommunicationTemplate,
+    channel: CommunicationChannel,
+    variables: Record<string, unknown>,
+  ): IResolvedTemplateParams {
+    switch (channel) {
+      case 'email': {
+        const email = template.email;
+        if (!email?.subject || !email?.body) {
+          throw new GrpcError(
+            status.INVALID_ARGUMENT,
+            `Template '${template.name}' email channel is incomplete`,
+          );
+        }
+        return {
+          subject: handlebars.compile(email.subject)(variables),
+          body: handlebars.compile(email.body)(variables),
+          sender: email.sender,
+        };
+      }
+      case 'push': {
+        const push = template.push;
+        if (!push?.title || !push?.body) {
+          throw new GrpcError(
+            status.INVALID_ARGUMENT,
+            `Template '${template.name}' push channel is incomplete`,
+          );
+        }
+        return {
+          subject: handlebars.compile(push.title)(variables),
+          body: handlebars.compile(push.body)(variables),
+        };
+      }
+      case 'sms': {
+        const sms = template.sms;
+        if (!sms?.message) {
+          throw new GrpcError(
+            status.INVALID_ARGUMENT,
+            `Template '${template.name}' sms channel is incomplete`,
+          );
+        }
+        return {
+          body: handlebars.compile(sms.message)(variables),
+        };
+      }
+      default: {
+        const _exhaustive: never = channel;
+        throw new GrpcError(status.INVALID_ARGUMENT, `Unknown channel: ${_exhaustive}`);
+      }
+    }
+  }
+
+  private validateTemplatePayload(
+    params: ICreateCommunicationTemplateParams,
+  ): ICreateCommunicationTemplateParams {
+    if (!params.name || isEmpty(params.name.trim())) {
+      throw new GrpcError(status.INVALID_ARGUMENT, 'Template name is required');
+    }
+
+    if (!params.channels || params.channels.length === 0) {
+      throw new GrpcError(status.INVALID_ARGUMENT, 'At least one channel is required');
+    }
+
+    const uniqueChannels = [...new Set(params.channels)];
+    if (uniqueChannels.length !== params.channels.length) {
+      throw new GrpcError(status.INVALID_ARGUMENT, 'Duplicate channels are not allowed');
+    }
+
+    for (const ch of params.channels) {
+      if (!CHANNELS.includes(ch)) {
+        throw new GrpcError(status.INVALID_ARGUMENT, `Invalid channel: ${ch}`);
+      }
+    }
+
+    const result: ICreateCommunicationTemplateParams = {
+      name: params.name.trim(),
+      channels: params.channels,
+      summary: params.summary,
+    };
+
+    if (params.channels.includes('email')) {
+      if (!params.email?.subject || !params.email?.body) {
+        throw new GrpcError(
+          status.INVALID_ARGUMENT,
+          'Email channel requires subject and body',
+        );
+      }
+      result.email = {
+        subject: params.email.subject,
+        body: params.email.body,
+        sender: params.email.sender,
+      };
+    }
+
+    if (params.channels.includes('push')) {
+      if (!params.push?.title || !params.push?.body) {
+        throw new GrpcError(
+          status.INVALID_ARGUMENT,
+          'Push channel requires title and body',
+        );
+      }
+      result.push = {
+        title: params.push.title,
+        body: params.push.body,
+      };
+    }
+
+    if (params.channels.includes('sms')) {
+      if (!params.sms?.message) {
+        throw new GrpcError(status.INVALID_ARGUMENT, 'SMS channel requires message');
+      }
+      result.sms = { message: params.sms.message };
+    }
+
+    return result;
+  }
+
+  private extractVariables(params: ICreateCommunicationTemplateParams): string[] {
+    const vars = new Set<string>();
+
+    if (params.email?.subject) {
+      Object.keys(getHandleBarsValues(params.email.subject)).forEach(v => vars.add(v));
+    }
+    if (params.email?.body) {
+      Object.keys(getHandleBarsValues(params.email.body)).forEach(v => vars.add(v));
+    }
+    if (params.push?.title) {
+      Object.keys(getHandleBarsValues(params.push.title)).forEach(v => vars.add(v));
+    }
+    if (params.push?.body) {
+      Object.keys(getHandleBarsValues(params.push.body)).forEach(v => vars.add(v));
+    }
+    if (params.sms?.message) {
+      Object.keys(getHandleBarsValues(params.sms.message)).forEach(v => vars.add(v));
+    }
+
+    return [...vars];
+  }
+
+  private async assertNameAvailable(name: string, excludeId?: string) {
+    const [unified, email] = await Promise.all([
+      CommunicationTemplate.getInstance().findOne({ name }),
+      EmailTemplate.getInstance().findOne({ name }),
+    ]);
+
+    if (unified && unified._id !== excludeId) {
+      throw new GrpcError(
+        status.ALREADY_EXISTS,
+        `A unified template named '${name}' already exists`,
+      );
+    }
+
+    if (email) {
+      throw new GrpcError(
+        status.ALREADY_EXISTS,
+        `An email template named '${name}' already exists. Migrate or rename before creating a unified template.`,
+      );
+    }
+  }
+}

--- a/modules/communications/src/services/orchestrator.service.ts
+++ b/modules/communications/src/services/orchestrator.service.ts
@@ -3,10 +3,12 @@ import { IChannel, IChannelSendParams, ChannelResult } from '../interfaces/index
 import { EmailService } from './email.service.js';
 import { PushService } from './push.service.js';
 import { SmsService } from './sms.service.js';
+import { CommunicationTemplateService } from './communication-template.service.js';
 
 export interface IMultiChannelSendParams extends IChannelSendParams {
   channels: ('email' | 'push' | 'sms')[];
   strategy: 'BEST_EFFORT' | 'ALL_OR_NOTHING';
+  templateName?: string;
 }
 
 export interface IFallbackSendParams extends IChannelSendParams {
@@ -14,7 +16,12 @@ export interface IFallbackSendParams extends IChannelSendParams {
     channel: 'email' | 'push' | 'sms';
     timeout: number;
   }>;
+  templateName?: string;
 }
+
+export type OrchestratorSendParams = IChannelSendParams & {
+  templateName?: string;
+};
 
 export class OrchestratorService {
   constructor(
@@ -22,7 +29,12 @@ export class OrchestratorService {
     private emailService: EmailService,
     private pushService: PushService,
     private smsService: SmsService,
+    private templateService?: CommunicationTemplateService,
   ) {}
+
+  setTemplateService(templateService: CommunicationTemplateService) {
+    this.templateService = templateService;
+  }
 
   updateServices(
     emailService: EmailService,
@@ -47,12 +59,72 @@ export class OrchestratorService {
     }
   }
 
+  private async resolveParamsForChannel(
+    channel: 'email' | 'push' | 'sms',
+    params: OrchestratorSendParams,
+  ): Promise<IChannelSendParams & { emailTemplateName?: string }> {
+    if (!params.templateName || !this.templateService) {
+      return params;
+    }
+
+    const resolved = await this.templateService.resolve(
+      params.templateName,
+      channel,
+      params.variables ?? {},
+    );
+    return this.templateService.mergeWithRequest(params, resolved);
+  }
+
+  private async sendOnChannel(
+    channel: 'email' | 'push' | 'sms',
+    params: IChannelSendParams & { emailTemplateName?: string },
+  ): Promise<ChannelResult> {
+    if (channel === 'email' && params.emailTemplateName) {
+      try {
+        const result = await this.emailService.sendEmail(params.emailTemplateName, {
+          email: params.recipient,
+          subject: params.subject,
+          body: params.body,
+          variables: params.variables,
+          sender: params.sender,
+          cc: params.cc,
+          replyTo: params.replyTo,
+        });
+        return {
+          success: true,
+          messageId: result.messageId,
+          channel: 'email',
+        };
+      } catch (error) {
+        return {
+          success: false,
+          error: (error as Error).message,
+          channel: 'email',
+        };
+      }
+    }
+
+    const service = this.getChannelService(channel);
+    return service.send(params);
+  }
+
+  private trackSendMetrics(results: ChannelResult[]) {
+    ConduitGrpcSdk.Metrics?.increment('communications_sent_total', results.length);
+    for (const result of results) {
+      if (result.success) {
+        ConduitGrpcSdk.Metrics?.increment('communications_success_total');
+      } else {
+        ConduitGrpcSdk.Metrics?.increment('communications_failure_total');
+      }
+    }
+  }
+
   async sendToMultipleChannels(params: IMultiChannelSendParams): Promise<{
     results: ChannelResult[];
     successCount: number;
     failureCount: number;
   }> {
-    const { channels, strategy, ...sendParams } = params;
+    const { channels, strategy, templateName, ...sendParams } = params;
     const results: ChannelResult[] = [];
     const availableChannels = channels.filter(channel =>
       this.getChannelService(channel).isAvailable(),
@@ -62,11 +134,13 @@ export class OrchestratorService {
       throw new Error('No available channels');
     }
 
-    // Send to all channels in parallel
     const promises = availableChannels.map(async channel => {
       try {
-        const service = this.getChannelService(channel);
-        const result = await service.send(sendParams);
+        const resolvedParams = await this.resolveParamsForChannel(channel, {
+          ...sendParams,
+          templateName,
+        });
+        const result = await this.sendOnChannel(channel, resolvedParams);
         results.push(result);
         return result;
       } catch (error) {
@@ -84,7 +158,8 @@ export class OrchestratorService {
     const successCount = channelResults.filter(r => r.success).length;
     const failureCount = channelResults.filter(r => !r.success).length;
 
-    // If strategy is ALL_OR_NOTHING and any channel failed, throw error
+    this.trackSendMetrics(channelResults);
+
     if (strategy === 'ALL_OR_NOTHING' && failureCount > 0) {
       const failedChannels = channelResults.filter(r => !r.success).map(r => r.channel);
       throw new Error(`Failed to send to channels: ${failedChannels.join(', ')}`);
@@ -102,7 +177,7 @@ export class OrchestratorService {
     messageId?: string;
     attempts: ChannelResult[];
   }> {
-    const { fallbackChain, ...sendParams } = params;
+    const { fallbackChain, templateName, ...sendParams } = params;
     const attempts: ChannelResult[] = [];
 
     for (const step of fallbackChain) {
@@ -119,19 +194,25 @@ export class OrchestratorService {
       }
 
       try {
-        const service = this.getChannelService(channel);
+        const resolvedParams = await this.resolveParamsForChannel(channel, {
+          ...sendParams,
+          templateName,
+        });
 
-        // Create a timeout promise
         const timeoutPromise = new Promise<never>((_, reject) => {
           setTimeout(() => reject(new Error(`Timeout after ${timeout}ms`)), timeout);
         });
 
-        // Race between the service call and timeout
-        const result = await Promise.race([service.send(sendParams), timeoutPromise]);
+        const result = await Promise.race([
+          this.sendOnChannel(channel, resolvedParams),
+          timeoutPromise,
+        ]);
 
         attempts.push(result);
 
         if (result.success) {
+          this.trackSendMetrics(attempts);
+          ConduitGrpcSdk.Metrics?.increment('fallback_chain_used_total');
           return {
             successfulChannel: channel,
             messageId: result.messageId,
@@ -148,13 +229,13 @@ export class OrchestratorService {
       }
     }
 
-    // If we get here, all channels failed
+    this.trackSendMetrics(attempts);
     throw new Error(`All fallback channels failed. Attempts: ${attempts.length}`);
   }
 
   async sendToChannel(
     channel: 'email' | 'push' | 'sms',
-    params: IChannelSendParams,
+    params: OrchestratorSendParams,
   ): Promise<ChannelResult> {
     const service = this.getChannelService(channel);
 
@@ -162,7 +243,10 @@ export class OrchestratorService {
       throw new Error(`Channel ${channel} is not available`);
     }
 
-    return service.send(params);
+    const resolvedParams = await this.resolveParamsForChannel(channel, params);
+    const result = await this.sendOnChannel(channel, resolvedParams);
+    this.trackSendMetrics([result]);
+    return result;
   }
 
   getAvailableChannels(): ('email' | 'push' | 'sms')[] {


### PR DESCRIPTION
## Problem

Unified `CommunicationTemplate` documents existed in schema and GitOps export, but operators could not manage them via Admin API or gRPC, and `templateName` on orchestrated sends was ignored. Email-only templates and multi-channel sends could not share a single resolution path.

## Summary

- [x] `CommunicationTemplateService` with validation, Handlebars resolution, and email-template migration helper
- [x] Admin REST CRUD at `/communications/templates` plus `templateName` on `/send/multiple`, `/send/fallback`, and new `/communications/send`
- [x] gRPC CRUD RPCs and real `RegisterCommunicationTemplate` implementation
- [x] Orchestrator resolves `CommunicationTemplate` first, `EmailTemplate` fallback for email (preserves external-managed email path)
- [x] GitOps import validation and email-template name collision checks (priority 30 unchanged)
- [x] `communication_templates_total` metric and unified send counters on orchestrated paths
- [x] grpc-sdk client methods and optional `templateName` on send helpers

**What kind of change does this PR introduce?**

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other (please describe)

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

**The PR fulfills these requirements:**

- [x] It's submitted to the `main` branch

## Test plan

- [ ] `POST /communications/templates` — create email+push template; verify variables auto-extracted
- [ ] `GET/PATCH/DELETE /communications/templates/:id` — round-trip CRUD
- [ ] `POST /communications/send` with `templateName` — single-channel send renders template content
- [ ] `POST /send/multiple` with `templateName` — per-channel rendered content
- [ ] Send with `templateName` matching only `EmailTemplate` — email still sends (external-managed path intact)
- [ ] Create unified template with same name as existing `EmailTemplate` — expect `ALREADY_EXISTS`
- [ ] GitOps import `communicationTemplates` record with invalid channel/content — record fails with descriptive error
- [ ] `POST /communications/templates/migrate-from-email` with `dryRun: true` — returns planned documents
- [ ] gRPC `RegisterCommunicationTemplate` + `ListCommunicationTemplates` return persisted JSON