### PR TITLE
feat(storage): add GCS parity and public file URI semantics

### DIFF
--- a/modules/storage/README.mdx
+++ b/modules/storage/README.mdx
@@ -11,6 +11,13 @@ Documents may have complex structures and subcollections and can be stored local
 - AWS S3 (or any other S3-compatible provider)
 - Alibaba Cloud (Aliyun)
 
+## Public files
+
+Public files expose a stable Conduit-relative `uri` in the form `/storage/getFileUrl/:id`.
+If both the container and file are public, `url` contains the direct provider/CDN URL.
+If the container is private and the file is public, `url` is left empty and Conduit signs a provider URL on demand through `uri`.
+Private files are not allowed in public containers.
+
 ## Requirements ⚡
 
 - [Database](../database) module

--- a/modules/storage/package.json
+++ b/modules/storage/package.json
@@ -29,7 +29,8 @@
     "build:bundle": "rimraf bundle && node ../../libraries/service-bundle/dist/cli.js generate-manifest && tsup && node ../../libraries/service-bundle/dist/cli.js copy-assets && node ../../libraries/service-bundle/dist/cli.js generate-lockfile",
     "prepare": "npm run build",
     "build:docker": "docker build -t ghcr.io/conduitplatform/storage:latest -f ./Dockerfile ../../ && docker push ghcr.io/conduitplatform/storage:latest",
-    "generateTypes": "sh build.sh"
+    "generateTypes": "sh build.sh",
+    "test": "tsc -p tsconfig.test.json && node --test dist-test/adapter/StorageParamAdapter.test.js dist-test/migrations/fileUriMigration.test.js dist-test/providers/aws/acl.test.js dist-test/providers/google/folderMarkers.test.js dist-test/utils/filePrivacy.test.js"
   },
   "keywords": [],
   "author": "",

--- a/modules/storage/package.json
+++ b/modules/storage/package.json
@@ -30,7 +30,7 @@
     "prepare": "npm run build",
     "build:docker": "docker build -t ghcr.io/conduitplatform/storage:latest -f ./Dockerfile ../../ && docker push ghcr.io/conduitplatform/storage:latest",
     "generateTypes": "sh build.sh",
-    "test": "tsc -p tsconfig.test.json && node --test dist-test/adapter/StorageParamAdapter.test.js dist-test/migrations/fileUriMigration.test.js dist-test/providers/aws/acl.test.js dist-test/providers/google/folderMarkers.test.js dist-test/utils/filePrivacy.test.js"
+    "test": "tsc -p tsconfig.test.json && node --test dist-test/adapter/StorageParamAdapter.test.js dist-test/migrations/fileUriMigration.test.js dist-test/providers/aws/acl.test.js dist-test/providers/google/folderMarkers.test.js dist-test/providers/google/deleteFolder.test.js dist-test/providers/google/publicAccess.test.js dist-test/utils/filePrivacy.test.js"
   },
   "keywords": [],
   "author": "",

--- a/modules/storage/src/Storage.ts
+++ b/modules/storage/src/Storage.ts
@@ -17,6 +17,7 @@ import { status } from '@grpc/grpc-js';
 import { isEmpty, isNil } from 'lodash-es';
 import { runMigrations } from './migrations/index.js';
 import { migratePublicContainers } from './migrations/publicContainerMigration.js';
+import { migrateFileUriReferences } from './migrations/fileUriMigration.js';
 import {
   CdnConfiguration,
   cdnConfigsAreEqual,
@@ -82,6 +83,7 @@ export default class Storage extends ManagedModule<Config> {
   private enableAuthRoutes: boolean = false;
   private storageParamAdapter: StorageParamAdapter;
   private publicContainerMigrationRan: boolean = false;
+  private fileUriMigrationRan: boolean = false;
   private previousCdnConfig: CdnConfiguration = {};
   private _storageAuthzResourceDispose: (() => void) | null = null;
   private refreshAppRoutesTimeout: NodeJS.Timeout | null = null;
@@ -252,6 +254,10 @@ export default class Storage extends ManagedModule<Config> {
       if (!this.publicContainerMigrationRan && provider !== 'local') {
         this.publicContainerMigrationRan = true;
         await migratePublicContainers(this.grpcSdk, this.storageProvider);
+      }
+      if (!this.fileUriMigrationRan) {
+        this.fileUriMigrationRan = true;
+        await migrateFileUriReferences();
       }
       // Detect CDN config changes and run migration if needed (order-independent comparison)
       const currentCdnConfig = (ConfigController.getInstance().config.cdnConfiguration ??

--- a/modules/storage/src/Storage.ts
+++ b/modules/storage/src/Storage.ts
@@ -17,6 +17,7 @@ import { status } from '@grpc/grpc-js';
 import { isEmpty, isNil } from 'lodash-es';
 import { runMigrations } from './migrations/index.js';
 import { migratePublicContainers } from './migrations/publicContainerMigration.js';
+import { migrateFileUriReferences } from './migrations/fileUriMigration.js';
 import {
   CdnConfiguration,
   cdnConfigsAreEqual,
@@ -83,6 +84,7 @@ export default class Storage extends ManagedModule<Config> {
   private enableAuthRoutes: boolean = false;
   private storageParamAdapter: StorageParamAdapter;
   private publicContainerMigrationRan: boolean = false;
+  private fileUriMigrationRan: boolean = false;
   private previousCdnConfig: CdnConfiguration = {};
   private _storageAuthzResourceDispose: (() => void) | null = null;
   private refreshAppRoutesTimeout: NodeJS.Timeout | null = null;
@@ -271,6 +273,10 @@ export default class Storage extends ManagedModule<Config> {
       if (!this.publicContainerMigrationRan && provider !== 'local') {
         this.publicContainerMigrationRan = true;
         await migratePublicContainers(this.grpcSdk, this.storageProvider);
+      }
+      if (!this.fileUriMigrationRan) {
+        this.fileUriMigrationRan = true;
+        await migrateFileUriReferences();
       }
       // Detect CDN config changes and run migration if needed (order-independent comparison)
       const currentCdnConfig = (ConfigController.getInstance().config.cdnConfiguration ??

--- a/modules/storage/src/Storage.ts
+++ b/modules/storage/src/Storage.ts
@@ -275,8 +275,8 @@ export default class Storage extends ManagedModule<Config> {
         await migratePublicContainers(this.grpcSdk, this.storageProvider);
       }
       if (!this.fileUriMigrationRan) {
-        this.fileUriMigrationRan = true;
         await migrateFileUriReferences();
+        this.fileUriMigrationRan = true;
       }
       // Detect CDN config changes and run migration if needed (order-independent comparison)
       const currentCdnConfig = (ConfigController.getInstance().config.cdnConfiguration ??

--- a/modules/storage/src/adapter/StorageParamAdapter.test.ts
+++ b/modules/storage/src/adapter/StorageParamAdapter.test.ts
@@ -1,0 +1,52 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { StorageParamAdapter } from './StorageParamAdapter.js';
+
+describe('StorageParamAdapter.getFileByUrlResponse', () => {
+  const adapter = new StorageParamAdapter();
+
+  it('sets fileUrl from the provider/CDN url only', () => {
+    const response = adapter.getFileByUrlResponse({
+      url: 'https://uploads.example/presign',
+      file: {
+        _id: 'file-1',
+        url: 'https://cdn.example/public.png',
+        uri: '/storage/getFileUrl/file-1',
+        name: 'public.png',
+      },
+    });
+
+    assert.equal(response.fileUrl, 'https://cdn.example/public.png');
+    assert.equal(response.uri, '/storage/getFileUrl/file-1');
+    assert.equal(response.uploadUrl, 'https://uploads.example/presign');
+  });
+
+  it('does not copy uri into fileUrl when url is empty', () => {
+    const response = adapter.getFileByUrlResponse({
+      url: 'https://uploads.example/presign',
+      file: {
+        _id: 'file-2',
+        url: '',
+        uri: '/storage/getFileUrl/file-2',
+        name: 'private-container.png',
+      },
+    });
+
+    assert.equal(response.fileUrl, '');
+    assert.equal(response.uri, '/storage/getFileUrl/file-2');
+  });
+
+  it('does not copy uri into fileUrl when url is missing', () => {
+    const response = adapter.getFileByUrlResponse({
+      url: 'https://uploads.example/presign',
+      file: {
+        _id: 'file-3',
+        uri: '/storage/getFileUrl/file-3',
+        name: 'no-url.png',
+      },
+    });
+
+    assert.equal(response.fileUrl, '');
+    assert.equal(response.uri, '/storage/getFileUrl/file-3');
+  });
+});

--- a/modules/storage/src/adapter/StorageParamAdapter.ts
+++ b/modules/storage/src/adapter/StorageParamAdapter.ts
@@ -5,18 +5,22 @@ export class StorageParamAdapter {
   constructor() {}
 
   getFileResponse(response: UnparsedRouterResponse): FileResponse {
+    const file = response as Indexable;
     return {
-      id: (response as Indexable)._id,
-      url: (response as Indexable).url,
-      name: (response as Indexable).name,
+      id: file._id,
+      url: file.url ?? '',
+      uri: file.uri ?? '',
+      name: file.name,
     };
   }
 
   getFileByUrlResponse(response: UnparsedRouterResponse): FileByUrlResponse {
+    const file = (response as Indexable).file as Indexable;
     return {
-      id: (response as Indexable).file._id,
-      fileUrl: (response as Indexable).file.url,
-      name: (response as Indexable).file.name,
+      id: file._id,
+      fileUrl: file.url ?? file.uri ?? '',
+      uri: file.uri ?? '',
+      name: file.name,
       uploadUrl: (response as Indexable).url,
     };
   }

--- a/modules/storage/src/adapter/StorageParamAdapter.ts
+++ b/modules/storage/src/adapter/StorageParamAdapter.ts
@@ -18,7 +18,7 @@ export class StorageParamAdapter {
     const file = (response as Indexable).file as Indexable;
     return {
       id: file._id,
-      fileUrl: file.url || file.uri || '',
+      fileUrl: file.url ?? '',
       uri: file.uri ?? '',
       name: file.name,
       uploadUrl: (response as Indexable).url,

--- a/modules/storage/src/adapter/StorageParamAdapter.ts
+++ b/modules/storage/src/adapter/StorageParamAdapter.ts
@@ -18,7 +18,7 @@ export class StorageParamAdapter {
     const file = (response as Indexable).file as Indexable;
     return {
       id: file._id,
-      fileUrl: file.url ?? file.uri ?? '',
+      fileUrl: file.url || file.uri || '',
       uri: file.uri ?? '',
       name: file.name,
       uploadUrl: (response as Indexable).url,

--- a/modules/storage/src/admin/adminFile.ts
+++ b/modules/storage/src/admin/adminFile.ts
@@ -17,6 +17,7 @@ import {
   applyCdnHost,
   deepPathHandler,
   normalizeFolderPath,
+  resolvePublicFileAccessUrl,
   storeNewFile,
   validateName,
 } from '../utils/index.js';
@@ -204,10 +205,11 @@ export class AdminFileHandlers {
         throw new GrpcError(status.NOT_FOUND, 'File does not exist');
       }
       if (found.isPublic) {
+        const url = await resolvePublicFileAccessUrl(this.storageProvider, found);
         if (!call.request.params.redirect) {
-          return { result: found.url };
+          return { result: url };
         }
-        return { redirect: found.url };
+        return { redirect: url };
       }
       const options: UrlOptions = {
         download: call.request.params.download ?? false,

--- a/modules/storage/src/admin/adminFile.ts
+++ b/modules/storage/src/admin/adminFile.ts
@@ -18,6 +18,7 @@ import {
   deepPathHandler,
   normalizeFolderPath,
   resolvePublicFileAccessUrl,
+  sanitizeFileForResponse,
   storeNewFile,
   validateName,
 } from '../utils/index.js';
@@ -51,7 +52,7 @@ export class AdminFileHandlers {
       throw new GrpcError(status.NOT_FOUND, 'File does not exist');
     }
 
-    return file;
+    return sanitizeFileForResponse(file);
   }
 
   async createFile(call: ParsedRouterRequest): Promise<UnparsedRouterResponse> {

--- a/modules/storage/src/admin/index.ts
+++ b/modules/storage/src/admin/index.ts
@@ -18,7 +18,7 @@ import {
 import { status } from '@grpc/grpc-js';
 import { isEmpty, isNil } from 'lodash-es';
 import { _StorageContainer, _StorageFolder, File } from '../models/index.js';
-import { normalizeFolderPath } from '../utils/index.js';
+import { normalizeFolderPath, sanitizeFilesForResponse } from '../utils/index.js';
 import { AdminFileHandlers } from './adminFile.js';
 
 export class AdminRoutes {
@@ -58,7 +58,7 @@ export class AdminRoutes {
     const files = await File.getInstance().findMany(query, { skip, limit, sort });
     const filesCount = await File.getInstance().countDocuments(query);
 
-    return { files, filesCount };
+    return { files: await sanitizeFilesForResponse(files), filesCount };
   }
 
   async getFolders(call: ParsedRouterRequest): Promise<UnparsedRouterResponse> {

--- a/modules/storage/src/config/config.ts
+++ b/modules/storage/src/config/config.ts
@@ -26,6 +26,10 @@ export default {
       format: 'String',
       default: '',
     },
+    serviceAccountKeyJson: {
+      format: 'String',
+      default: '',
+    },
   },
   azure: {
     connectionString: { format: 'String', default: '' },

--- a/modules/storage/src/handlers/file.ts
+++ b/modules/storage/src/handlers/file.ts
@@ -18,6 +18,7 @@ import {
   applyCdnHost,
   deepPathHandler,
   normalizeFolderPath,
+  resolvePublicFileAccessUrl,
   storeNewFile,
   validateName,
 } from '../utils/index.js';
@@ -270,10 +271,11 @@ export class FileHandlers {
         throw new GrpcError(status.NOT_FOUND, 'File does not exist');
       }
       if (found.isPublic) {
+        const url = await resolvePublicFileAccessUrl(this.storageProvider, found);
         if (!call.request.params.redirect) {
-          return { result: found.url };
+          return { result: url };
         }
-        return { redirect: found.url };
+        return { redirect: url };
       }
       await this.fileAccessCheck('read', call.request, found);
       const options: UrlOptions = {

--- a/modules/storage/src/handlers/file.ts
+++ b/modules/storage/src/handlers/file.ts
@@ -19,6 +19,7 @@ import {
   deepPathHandler,
   normalizeFolderPath,
   resolvePublicFileAccessUrl,
+  sanitizeFileForResponse,
   storeNewFile,
   validateName,
 } from '../utils/index.js';
@@ -113,7 +114,7 @@ export class FileHandlers {
     if (!file.isPublic) {
       await this.fileAccessCheck('read', call.request, file);
     }
-    return file;
+    return sanitizeFileForResponse(file);
   }
 
   async createFile(call: ParsedRouterRequest): Promise<UnparsedRouterResponse> {

--- a/modules/storage/src/interfaces/IStorageProvider.ts
+++ b/modules/storage/src/interfaces/IStorageProvider.ts
@@ -49,12 +49,6 @@ export interface IStorageProvider {
 
   getSignedUrl(fileName: string, options?: UrlOptions): Promise<any | Error>;
 
-  /**
-   * Gets a publicly accessible URL for a file.
-   * @param fileName The file name/path
-   * @param containerIsPublic Whether the container is publicly accessible.
-   *        If true, returns a plain URL. If false, returns a long-lived signed URL.
-   */
   getPublicUrl(fileName: string, containerIsPublic?: boolean): Promise<string | Error>;
 
   getUploadUrl(fileName: string): Promise<string | Error>;

--- a/modules/storage/src/interfaces/StorageConfig.ts
+++ b/modules/storage/src/interfaces/StorageConfig.ts
@@ -5,6 +5,7 @@ export interface StorageConfig {
    */
   google: {
     serviceAccountKeyPath: string;
+    serviceAccountKeyJson: string;
   };
   aws: {
     accessKeyId: string;

--- a/modules/storage/src/migrations/fileUriMigration.test.ts
+++ b/modules/storage/src/migrations/fileUriMigration.test.ts
@@ -8,7 +8,8 @@ import {
 } from './fileUriMigration.js';
 
 const originalFileGetInstance = File.getInstance.bind(File);
-const originalContainerGetInstance = _StorageContainer.getInstance.bind(_StorageContainer);
+const originalContainerGetInstance =
+  _StorageContainer.getInstance.bind(_StorageContainer);
 
 afterEach(() => {
   File.getInstance = originalFileGetInstance;
@@ -19,7 +20,11 @@ describe('filesNeedingUriMigrationQuery', () => {
   it('filters public files that are missing uri', () => {
     const query = filesNeedingUriMigrationQuery();
     assert.equal(query.isPublic, true);
-    assert.deepEqual(query.$or, [{ uri: { $exists: false } }, { uri: null }, { uri: '' }]);
+    assert.deepEqual(query.$or, [
+      { uri: { $exists: false } },
+      { uri: null },
+      { uri: '' },
+    ]);
     assert.equal('_id' in query, false);
   });
 
@@ -31,28 +36,34 @@ describe('filesNeedingUriMigrationQuery', () => {
 
 describe('migrateFileUriReferences', () => {
   it('updates files in batches and clears stale urls in private containers', async () => {
-    const files = Array.from({ length: FILE_URI_MIGRATION_BATCH_SIZE + 3 }, (_, index) => ({
-      _id: `file-${String(index).padStart(3, '0')}`,
-      container: index === 0 ? 'public-bucket' : 'private-bucket',
-    }));
-    const findManyCalls: Array<{ query: Record<string, unknown>; options: Record<string, unknown> }> =
-      [];
+    const files = Array.from(
+      { length: FILE_URI_MIGRATION_BATCH_SIZE + 3 },
+      (_, index) => ({
+        _id: `file-${String(index).padStart(3, '0')}`,
+        container: index === 0 ? 'public-bucket' : 'private-bucket',
+      }),
+    );
+    const findManyCalls: Array<{
+      query: Record<string, unknown>;
+      options: Record<string, unknown>;
+    }> = [];
     const updates: Array<{ id: string; update: Record<string, string> }> = [];
 
     File.getInstance = (() => ({
-      findMany: async (query: Record<string, unknown>, options: Record<string, unknown>) => {
+      findMany: async (
+        query: Record<string, unknown>,
+        options: Record<string, unknown>,
+      ) => {
         findManyCalls.push({ query, options });
         const afterId = (query._id as { $gt?: string } | undefined)?.$gt;
-        const remaining = afterId
-          ? files.filter(file => file._id > afterId)
-          : files;
+        const remaining = afterId ? files.filter(file => file._id > afterId) : files;
         return remaining.slice(0, options.limit as number);
       },
       findByIdAndUpdate: async (id: string, update: Record<string, string>) => {
         updates.push({ id, update });
         return { _id: id, ...update };
       },
-    })) as typeof File.getInstance;
+    })) as unknown as typeof File.getInstance;
 
     _StorageContainer.getInstance = (() => ({
       findMany: async (_query: unknown, options: { limit?: number }) => {
@@ -62,7 +73,7 @@ describe('migrateFileUriReferences', () => {
         ];
         return docs.slice(0, options.limit);
       },
-    })) as typeof _StorageContainer.getInstance;
+    })) as unknown as typeof _StorageContainer.getInstance;
 
     await migrateFileUriReferences();
 
@@ -84,10 +95,10 @@ describe('migrateFileUriReferences', () => {
       findByIdAndUpdate: async () => {
         throw new Error('write failed');
       },
-    })) as typeof File.getInstance;
+    })) as unknown as typeof File.getInstance;
     _StorageContainer.getInstance = (() => ({
       findMany: async () => [{ _id: 'c2', name: 'private-bucket', isPublic: false }],
-    })) as typeof _StorageContainer.getInstance;
+    })) as unknown as typeof _StorageContainer.getInstance;
 
     await assert.rejects(() => migrateFileUriReferences(), /write failed/);
   });

--- a/modules/storage/src/migrations/fileUriMigration.test.ts
+++ b/modules/storage/src/migrations/fileUriMigration.test.ts
@@ -1,0 +1,94 @@
+import { afterEach, describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { File, _StorageContainer } from '../models/index.js';
+import {
+  FILE_URI_MIGRATION_BATCH_SIZE,
+  filesNeedingUriMigrationQuery,
+  migrateFileUriReferences,
+} from './fileUriMigration.js';
+
+const originalFileGetInstance = File.getInstance.bind(File);
+const originalContainerGetInstance = _StorageContainer.getInstance.bind(_StorageContainer);
+
+afterEach(() => {
+  File.getInstance = originalFileGetInstance;
+  _StorageContainer.getInstance = originalContainerGetInstance;
+});
+
+describe('filesNeedingUriMigrationQuery', () => {
+  it('filters public files that are missing uri', () => {
+    const query = filesNeedingUriMigrationQuery();
+    assert.equal(query.isPublic, true);
+    assert.deepEqual(query.$or, [{ uri: { $exists: false } }, { uri: null }, { uri: '' }]);
+    assert.equal('_id' in query, false);
+  });
+
+  it('cursors by _id after the last processed document', () => {
+    const query = filesNeedingUriMigrationQuery('file-199');
+    assert.deepEqual(query._id, { $gt: 'file-199' });
+  });
+});
+
+describe('migrateFileUriReferences', () => {
+  it('updates files in batches and clears stale urls in private containers', async () => {
+    const files = Array.from({ length: FILE_URI_MIGRATION_BATCH_SIZE + 3 }, (_, index) => ({
+      _id: `file-${String(index).padStart(3, '0')}`,
+      container: index === 0 ? 'public-bucket' : 'private-bucket',
+    }));
+    const findManyCalls: Array<{ query: Record<string, unknown>; options: Record<string, unknown> }> =
+      [];
+    const updates: Array<{ id: string; update: Record<string, string> }> = [];
+
+    File.getInstance = (() => ({
+      findMany: async (query: Record<string, unknown>, options: Record<string, unknown>) => {
+        findManyCalls.push({ query, options });
+        const afterId = (query._id as { $gt?: string } | undefined)?.$gt;
+        const remaining = afterId
+          ? files.filter(file => file._id > afterId)
+          : files;
+        return remaining.slice(0, options.limit as number);
+      },
+      findByIdAndUpdate: async (id: string, update: Record<string, string>) => {
+        updates.push({ id, update });
+        return { _id: id, ...update };
+      },
+    })) as typeof File.getInstance;
+
+    _StorageContainer.getInstance = (() => ({
+      findMany: async (_query: unknown, options: { limit?: number }) => {
+        const docs = [
+          { _id: 'c1', name: 'public-bucket', isPublic: true },
+          { _id: 'c2', name: 'private-bucket', isPublic: false },
+        ];
+        return docs.slice(0, options.limit);
+      },
+    })) as typeof _StorageContainer.getInstance;
+
+    await migrateFileUriReferences();
+
+    assert.equal(findManyCalls.length, 2);
+    assert.equal(findManyCalls[0].options.limit, FILE_URI_MIGRATION_BATCH_SIZE);
+    assert.deepEqual(findManyCalls[1].query._id, {
+      $gt: `file-${String(FILE_URI_MIGRATION_BATCH_SIZE - 1).padStart(3, '0')}`,
+    });
+    assert.equal(updates.length, files.length);
+    assert.equal(updates[0].update.uri, '/storage/getFileUrl/file-000');
+    assert.equal(updates[0].update.url, undefined);
+    assert.equal(updates[1].update.url, '');
+    assert.equal(updates[1].update.sourceUrl, '');
+  });
+
+  it('rethrows after a failed batch so the caller cannot mark the migration as ran', async () => {
+    File.getInstance = (() => ({
+      findMany: async () => [{ _id: 'file-1', container: 'private-bucket' }],
+      findByIdAndUpdate: async () => {
+        throw new Error('write failed');
+      },
+    })) as typeof File.getInstance;
+    _StorageContainer.getInstance = (() => ({
+      findMany: async () => [{ _id: 'c2', name: 'private-bucket', isPublic: false }],
+    })) as typeof _StorageContainer.getInstance;
+
+    await assert.rejects(() => migrateFileUriReferences(), /write failed/);
+  });
+});

--- a/modules/storage/src/migrations/fileUriMigration.ts
+++ b/modules/storage/src/migrations/fileUriMigration.ts
@@ -1,0 +1,40 @@
+import { ConduitGrpcSdk } from '@conduitplatform/grpc-sdk';
+import { buildFileUri } from '../utils/index.js';
+import { _StorageContainer, File } from '../models/index.js';
+
+export async function migrateFileUriReferences(): Promise<void> {
+  const logger = ConduitGrpcSdk.Logger;
+
+  try {
+    const publicFiles = await File.getInstance().findMany({ isPublic: true });
+    if (publicFiles.length === 0) {
+      logger.log('No public files found for URI migration');
+      return;
+    }
+
+    const containers = await _StorageContainer.getInstance().findMany({});
+    const containerIsPublic = new Map(
+      containers.map(container => [container.name, container.isPublic ?? false]),
+    );
+
+    let updated = 0;
+    for (const file of publicFiles) {
+      const isContainerPublic = containerIsPublic.get(file.container) ?? false;
+      const update: Record<string, string> = {
+        uri: buildFileUri(file._id),
+      };
+
+      if (!isContainerPublic) {
+        update.url = '';
+        update.sourceUrl = '';
+      }
+
+      await File.getInstance().findByIdAndUpdate(file._id, update);
+      updated++;
+    }
+
+    logger.log(`File URI migration completed for ${updated} public file(s)`);
+  } catch (error) {
+    logger.error(`File URI migration failed: ${(error as Error).message}`);
+  }
+}

--- a/modules/storage/src/migrations/fileUriMigration.ts
+++ b/modules/storage/src/migrations/fileUriMigration.ts
@@ -2,39 +2,98 @@ import { ConduitGrpcSdk } from '@conduitplatform/grpc-sdk';
 import { buildFileUri } from '../utils/index.js';
 import { _StorageContainer, File } from '../models/index.js';
 
+export const FILE_URI_MIGRATION_BATCH_SIZE = 200;
+
+export function filesNeedingUriMigrationQuery(afterId?: string) {
+  return {
+    isPublic: true,
+    $or: [{ uri: { $exists: false } }, { uri: null }, { uri: '' }],
+    ...(afterId ? { _id: { $gt: afterId } } : {}),
+  };
+}
+
 export async function migrateFileUriReferences(): Promise<void> {
   const logger = ConduitGrpcSdk.Logger;
+  const containerIsPublic = await loadContainerPublicity();
+  let updated = 0;
+  let scanned = 0;
+  let lastId: string | undefined;
 
   try {
-    const publicFiles = await File.getInstance().findMany({ isPublic: true });
-    if (publicFiles.length === 0) {
-      logger.log('No public files found for URI migration');
-      return;
-    }
-
-    const containers = await _StorageContainer.getInstance().findMany({});
-    const containerIsPublic = new Map(
-      containers.map(container => [container.name, container.isPublic ?? false]),
-    );
-
-    let updated = 0;
-    for (const file of publicFiles) {
-      const isContainerPublic = containerIsPublic.get(file.container) ?? false;
-      const update: Record<string, string> = {
-        uri: buildFileUri(file._id),
-      };
-
-      if (!isContainerPublic) {
-        update.url = '';
-        update.sourceUrl = '';
+    for (;;) {
+      const batch = await File.getInstance().findMany(
+        filesNeedingUriMigrationQuery(lastId),
+        {
+          skip: 0,
+          limit: FILE_URI_MIGRATION_BATCH_SIZE,
+          sort: { _id: 1 },
+          select: '_id container url sourceUrl uri',
+        },
+      );
+      if (batch.length === 0) {
+        break;
       }
 
-      await File.getInstance().findByIdAndUpdate(file._id, update);
-      updated++;
+      for (const file of batch) {
+        const isContainerPublic = containerIsPublic.get(file.container) ?? false;
+        const update: Record<string, string> = {
+          uri: buildFileUri(file._id),
+        };
+        if (!isContainerPublic) {
+          update.url = '';
+          update.sourceUrl = '';
+        }
+        await File.getInstance().findByIdAndUpdate(file._id, update);
+        updated++;
+      }
+
+      scanned += batch.length;
+      lastId = batch[batch.length - 1]._id;
+      logger.log(
+        `File URI migration progress: updated ${updated} / scanned ${scanned} public file(s)`,
+      );
+
+      if (batch.length < FILE_URI_MIGRATION_BATCH_SIZE) {
+        break;
+      }
     }
 
-    logger.log(`File URI migration completed for ${updated} public file(s)`);
+    logger.log(
+      updated === 0
+        ? 'No public files required URI migration'
+        : `File URI migration completed for ${updated} public file(s)`,
+    );
   } catch (error) {
     logger.error(`File URI migration failed: ${(error as Error).message}`);
+    throw error;
   }
+}
+
+async function loadContainerPublicity(): Promise<Map<string, boolean>> {
+  const containerIsPublic = new Map<string, boolean>();
+  let lastId: string | undefined;
+
+  for (;;) {
+    const batch = await _StorageContainer.getInstance().findMany(
+      lastId ? { _id: { $gt: lastId } } : {},
+      {
+        skip: 0,
+        limit: FILE_URI_MIGRATION_BATCH_SIZE,
+        sort: { _id: 1 },
+        select: '_id name isPublic',
+      },
+    );
+    if (batch.length === 0) {
+      break;
+    }
+    for (const container of batch) {
+      containerIsPublic.set(container.name, container.isPublic ?? false);
+    }
+    lastId = batch[batch.length - 1]._id;
+    if (batch.length < FILE_URI_MIGRATION_BATCH_SIZE) {
+      break;
+    }
+  }
+
+  return containerIsPublic;
 }

--- a/modules/storage/src/models/File.schema.ts
+++ b/modules/storage/src/models/File.schema.ts
@@ -28,6 +28,7 @@ const schema: ConduitModel = {
     default: false,
   },
   url: TYPE.String,
+  uri: TYPE.String,
   sourceUrl: TYPE.String,
   mimeType: TYPE.String,
   createdAt: TYPE.Date,
@@ -56,7 +57,8 @@ export class File extends ConduitActiveSchema<File> {
   container!: string;
   size!: number;
   isPublic?: boolean;
-  url!: string;
+  url?: string;
+  uri?: string;
   sourceUrl?: string;
   mimeType!: string;
   createdAt!: Date;

--- a/modules/storage/src/providers/aliyun/index.ts
+++ b/modules/storage/src/providers/aliyun/index.ts
@@ -157,15 +157,13 @@ export class AliyunStorage implements IStorageProvider {
     });
   }
 
-  async getPublicUrl(fileName: string, containerIsPublic?: boolean): Promise<string> {
-    if (containerIsPublic) {
-      return this._ossClient.getObjectUrl(fileName);
+  async getPublicUrl(
+    fileName: string,
+    containerIsPublic?: boolean,
+  ): Promise<string | Error> {
+    if (!containerIsPublic) {
+      return new Error('Public URL is only available for files in public containers');
     }
-
-    // For private containers with public files, generate long-lived signed URL (100 years)
-    return this._ossClient.signatureUrl(fileName, {
-      expires: 3600 * 24 * 365 * 100,
-      method: 'GET',
-    });
+    return this._ossClient.getObjectUrl(fileName);
   }
 }

--- a/modules/storage/src/providers/aws/acl.test.ts
+++ b/modules/storage/src/providers/aws/acl.test.ts
@@ -1,0 +1,31 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { awsObjectGrantRead, buildPutObjectInput } from './index.js';
+
+describe('AWS store object ACL', () => {
+  it('does not GrantRead AllUsers for a public file in a private container', () => {
+    assert.equal(
+      awsObjectGrantRead({ fileIsPublic: true, containerIsPublic: false }),
+      undefined,
+    );
+    assert.equal(buildPutObjectInput('bucket', 'key', 'body', { fileIsPublic: true }).GrantRead, undefined);
+  });
+
+  it('does not GrantRead AllUsers when only the file is public', () => {
+    assert.equal(awsObjectGrantRead({ fileIsPublic: true }), undefined);
+  });
+
+  it('grants AllUsers read only when the container is public', () => {
+    assert.equal(
+      awsObjectGrantRead({ fileIsPublic: true, containerIsPublic: true }),
+      'uri="http://acs.amazonaws.com/groups/global/AllUsers"',
+    );
+    assert.equal(
+      buildPutObjectInput('bucket', 'key', 'body', {
+        fileIsPublic: true,
+        containerIsPublic: true,
+      }).GrantRead,
+      'uri="http://acs.amazonaws.com/groups/global/AllUsers"',
+    );
+  });
+});

--- a/modules/storage/src/providers/aws/index.ts
+++ b/modules/storage/src/providers/aws/index.ts
@@ -267,8 +267,10 @@ export class AWSS3Storage implements IStorageProvider {
     });
   }
 
-  async getPublicUrl(fileName: string, _containerIsPublic?: boolean) {
-    // AWS uses bucket-level ACLs, so public URL format is the same regardless
+  async getPublicUrl(fileName: string, containerIsPublic?: boolean) {
+    if (!containerIsPublic) {
+      return new Error('Public URL is only available for files in public containers');
+    }
     const config: Config['aws'] = ConfigController.getInstance().config.aws;
     if (config.endpoint !== '') {
       // check if endpoint contains http/https or not

--- a/modules/storage/src/providers/aws/index.ts
+++ b/modules/storage/src/providers/aws/index.ts
@@ -27,6 +27,38 @@ type AwsError = { $metadata: { httpStatusCode: number } };
 type GetResult = Buffer | Error;
 type StoreResult = boolean | Error;
 
+const ALL_USERS_GRANT_READ = 'uri="http://acs.amazonaws.com/groups/global/AllUsers"';
+
+// Public read for public containers is granted by bucket policy.
+// Never GrantRead AllUsers for a public file in a private container.
+// Follow-up: strip leftover AllUsers ACLs on existing objects if needed.
+export function awsObjectGrantRead(options: {
+  fileIsPublic?: boolean;
+  containerIsPublic?: boolean;
+}): string | undefined {
+  if (!options.containerIsPublic) {
+    return undefined;
+  }
+  return ALL_USERS_GRANT_READ;
+}
+
+export function buildPutObjectInput(
+  bucket: string,
+  key: string,
+  body: unknown,
+  options?: { fileIsPublic?: boolean; containerIsPublic?: boolean },
+) {
+  return {
+    Bucket: bucket,
+    Key: key,
+    Body: body,
+    GrantRead: awsObjectGrantRead({
+      fileIsPublic: options?.fileIsPublic,
+      containerIsPublic: options?.containerIsPublic,
+    }),
+  };
+}
+
 export class AWSS3Storage implements IStorageProvider {
   private readonly _storage: S3Client;
   private _activeContainer: string = '';
@@ -54,14 +86,11 @@ export class AWSS3Storage implements IStorageProvider {
 
   async store(fileName: string, data: any, isPublic?: boolean): Promise<StoreResult> {
     await this._storage.send(
-      new PutObjectCommand({
-        Bucket: this._activeContainer,
-        Key: fileName,
-        Body: data,
-        GrantRead: isPublic
-          ? 'uri="http://acs.amazonaws.com/groups/global/AllUsers"'
-          : undefined,
-      }),
+      new PutObjectCommand(
+        buildPutObjectInput(this._activeContainer, fileName, data, {
+          fileIsPublic: isPublic,
+        }),
+      ),
     );
     return true;
   }

--- a/modules/storage/src/providers/aws/index.ts
+++ b/modules/storage/src/providers/aws/index.ts
@@ -45,7 +45,7 @@ export function awsObjectGrantRead(options: {
 export function buildPutObjectInput(
   bucket: string,
   key: string,
-  body: unknown,
+  body: PutObjectCommand['input']['Body'],
   options?: { fileIsPublic?: boolean; containerIsPublic?: boolean },
 ) {
   return {

--- a/modules/storage/src/providers/azure/index.ts
+++ b/modules/storage/src/providers/azure/index.ts
@@ -135,27 +135,17 @@ export class AzureStorage implements IStorageProvider {
     return this.blobClient(fileName).generateSasUrl(sasOptions);
   }
 
-  async getPublicUrl(fileName: string, containerIsPublic?: boolean): Promise<string> {
-    if (containerIsPublic) {
-      // Return direct URL without SAS token for public containers
-      return `${this._storage.url}${this._activeContainer}/${fileName}`;
+  async getPublicUrl(
+    fileName: string,
+    containerIsPublic?: boolean,
+  ): Promise<string | Error> {
+    if (!containerIsPublic) {
+      return new Error('Public URL is only available for files in public containers');
     }
-    // For private containers with public files, generate long-lived signed URL (99 years)
-    const containerClient = this._storage.getContainerClient(this._activeContainer);
-    const sasOptions: BlobSASSignatureValues = {
-      containerName: containerClient.containerName,
-      blobName: fileName,
-      expiresOn: new Date(new Date().setFullYear(new Date().getFullYear() + 99)),
-      permissions: BlobSASPermissions.parse('r'),
-    };
-    return this.blobClient(fileName).generateSasUrl(sasOptions);
+    return `${this._storage.url}${this._activeContainer}/${fileName}`;
   }
 
-  async store(
-    fileName: string,
-    data: any,
-    isPublic: boolean = false,
-  ): Promise<boolean | Error> {
+  async store(fileName: string, data: any): Promise<boolean | Error> {
     await this._storage
       .getContainerClient(this._activeContainer)
       .getBlockBlobClient(fileName)

--- a/modules/storage/src/providers/google/deleteFolder.test.ts
+++ b/modules/storage/src/providers/google/deleteFolder.test.ts
@@ -1,0 +1,79 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { deleteOneLevelFolder } from './index.js';
+
+type DeletedCall = { name: string; at: number };
+
+function fileStub(name: string, deleted: DeletedCall[], fail?: boolean) {
+  return {
+    name,
+    delete: async () => {
+      if (fail) {
+        throw new Error(`delete failed: ${name}`);
+      }
+      deleted.push({ name, at: deleted.length });
+    },
+  };
+}
+
+describe('deleteOneLevelFolder', () => {
+  it('deletes only this folder objects, then markers, and pages results', async () => {
+    const deleted: DeletedCall[] = [];
+    const queries: Array<{ prefix?: string; delimiter?: string; autoPaginate?: boolean; pageToken?: string }> =
+      [];
+
+    const bucket = {
+      getFiles: async (query: {
+        prefix?: string;
+        delimiter?: string;
+        autoPaginate?: boolean;
+        pageToken?: string;
+      }) => {
+        queries.push(query);
+        if (!query.pageToken) {
+          return [
+            [
+              fileStub('photos/a.jpg', deleted),
+              fileStub('photos/vacation/a.jpg', deleted),
+              fileStub('photos/.keep.txt', deleted),
+            ],
+            { pageToken: 'page-2' },
+          ] as const;
+        }
+        return [[fileStub('photos/b.jpg', deleted)], undefined] as const;
+      },
+      file: (name: string) => fileStub(name, deleted),
+    };
+
+    const count = await deleteOneLevelFolder(bucket, 'photos/');
+
+    assert.equal(count, 2);
+    assert.deepEqual(
+      deleted.map(entry => entry.name),
+      ['photos/a.jpg', 'photos/b.jpg', 'photos/.keep.txt', 'photos/keep.txt'],
+    );
+    assert.ok(deleted[0].at < deleted[2].at);
+    assert.equal(queries[0].prefix, 'photos/');
+    assert.equal(queries[0].delimiter, '/');
+    assert.equal(queries[0].autoPaginate, false);
+    assert.equal(queries[1].pageToken, 'page-2');
+  });
+
+  it('leaves markers in place when an object delete fails so folderExists can retry', async () => {
+    const deleted: DeletedCall[] = [];
+    const bucket = {
+      getFiles: async () =>
+        [
+          [fileStub('photos/a.jpg', deleted, true), fileStub('photos/.keep.txt', deleted)],
+          undefined,
+        ] as const,
+      file: (name: string) => fileStub(name, deleted),
+    };
+
+    await assert.rejects(() => deleteOneLevelFolder(bucket, 'photos/'), /delete failed: photos\/a.jpg/);
+    assert.deepEqual(
+      deleted.map(entry => entry.name),
+      [],
+    );
+  });
+});

--- a/modules/storage/src/providers/google/folderMarkers.test.ts
+++ b/modules/storage/src/providers/google/folderMarkers.test.ts
@@ -1,6 +1,12 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { folderMarkerKeys } from './index.js';
+import {
+  FOLDER_DELETE_PAGE_SIZE,
+  folderListQuery,
+  folderMarkerKeys,
+  folderObjectPrefix,
+  isDirectChildKey,
+} from './index.js';
 
 describe('GCS folder markers', () => {
   it('checks both the new name.keep.txt and legacy name/keep.txt keys', () => {
@@ -9,5 +15,36 @@ describe('GCS folder markers', () => {
 
   it('normalizes trailing slashes when looking up the legacy marker', () => {
     assert.deepEqual(folderMarkerKeys('photos/'), ['photos/.keep.txt', 'photos/keep.txt']);
+  });
+});
+
+describe('GCS folder listing helpers', () => {
+  it('normalizes the object prefix to a trailing slash', () => {
+    assert.equal(folderObjectPrefix('photos'), 'photos/');
+    assert.equal(folderObjectPrefix('photos/'), 'photos/');
+  });
+
+  it('treats only keys in the folder itself as direct children', () => {
+    assert.equal(isDirectChildKey('photos/', 'photos/a.jpg'), true);
+    assert.equal(isDirectChildKey('photos/', 'photos/.keep.txt'), true);
+    assert.equal(isDirectChildKey('photos/', 'photos/vacation/a.jpg'), false);
+    assert.equal(isDirectChildKey('photos/', 'photography/a.jpg'), false);
+    assert.equal(isDirectChildKey('photos/', 'photos/'), false);
+  });
+
+  it('lists one folder page without recursing or auto-paginating', () => {
+    assert.deepEqual(folderListQuery('photos'), {
+      prefix: 'photos/',
+      delimiter: '/',
+      autoPaginate: false,
+      maxResults: FOLDER_DELETE_PAGE_SIZE,
+    });
+    assert.deepEqual(folderListQuery('photos/', 'token-2'), {
+      prefix: 'photos/',
+      delimiter: '/',
+      autoPaginate: false,
+      maxResults: FOLDER_DELETE_PAGE_SIZE,
+      pageToken: 'token-2',
+    });
   });
 });

--- a/modules/storage/src/providers/google/folderMarkers.test.ts
+++ b/modules/storage/src/providers/google/folderMarkers.test.ts
@@ -1,0 +1,13 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { folderMarkerKeys } from './index.js';
+
+describe('GCS folder markers', () => {
+  it('checks both the new name.keep.txt and legacy name/keep.txt keys', () => {
+    assert.deepEqual(folderMarkerKeys('photos'), ['photos.keep.txt', 'photos/keep.txt']);
+  });
+
+  it('normalizes trailing slashes when looking up the legacy marker', () => {
+    assert.deepEqual(folderMarkerKeys('photos/'), ['photos/.keep.txt', 'photos/keep.txt']);
+  });
+});

--- a/modules/storage/src/providers/google/index.ts
+++ b/modules/storage/src/providers/google/index.ts
@@ -1,34 +1,76 @@
 import { IStorageProvider, StorageConfig, UrlOptions } from '../../interfaces/index.js';
-import { Storage } from '@google-cloud/storage';
+import { Bucket, Storage } from '@google-cloud/storage';
 import { ConduitGrpcSdk } from '@conduitplatform/grpc-sdk';
 import { SIGNED_URL_EXPIRY_DATE } from '../../constants/expiry.js';
 import { constructDispositionHeader } from '../../utils/index.js';
+import fs from 'fs';
 
-/**
- * WARNING: DO NOT USE THIS, IT NEEDS A REWRITE
- * @Deprecated
- */
+type GoogleServiceAccountKey = {
+  project_id?: string;
+  client_email?: string;
+  private_key?: string;
+};
+
+const OBJECT_VIEWER_ROLE = 'roles/storage.objectViewer';
+const FOLDER_MARKER_SUFFIX = '.keep.txt';
+
 export class GoogleCloudStorage implements IStorageProvider {
-  _storage: Storage;
-  _activeBucket: string = '';
+  private readonly _storage: Storage;
+  private _activeBucket: string = '';
 
   constructor(options: StorageConfig) {
-    this._storage = new Storage({
-      keyFilename: options.google.serviceAccountKeyPath,
-    });
+    this._storage = createGoogleStorageClient(options);
   }
 
-  deleteContainer(name: string): Promise<boolean | Error> {
-    throw new Error('Method not implemented.');
+  container(name: string): IStorageProvider {
+    this._activeBucket = name;
+    return this;
   }
 
-  deleteFolder(name: string): Promise<boolean | Error> {
-    throw new Error('Method not implemented.');
+  async store(
+    fileName: string,
+    data: Buffer | string,
+    _isPublic: boolean = false,
+  ): Promise<boolean | Error> {
+    await this.bucket().file(fileName).save(data);
+    return true;
+  }
+
+  async get(fileName: string, downloadPath?: string): Promise<Buffer | Error> {
+    const [contents] = await this.bucket().file(fileName).download();
+    if (downloadPath) {
+      fs.writeFileSync(downloadPath, new Uint8Array(contents));
+    }
+    return contents;
+  }
+
+  async createFolder(name: string): Promise<boolean | Error> {
+    const exists = await this.folderExists(name);
+    if (exists) return true;
+
+    await this.bucket()
+      .file(this.folderMarkerKey(name))
+      .save(Buffer.from('DO NOT DELETE'));
+    ConduitGrpcSdk.Metrics?.increment('folders_total');
+    return true;
+  }
+
+  async folderExists(name: string): Promise<boolean | Error> {
+    const [bucketExists] = await this.bucket().exists();
+    if (!bucketExists) return false;
+
+    const [markerExists] = await this.bucket().file(this.folderMarkerKey(name)).exists();
+    return markerExists;
   }
 
   async createContainer(name: string, isPublic?: boolean): Promise<boolean | Error> {
-    // Creates the new bucket
-    await this._storage.createBucket(name);
+    await this._storage.createBucket(name, {
+      iamConfiguration: {
+        uniformBucketLevelAccess: {
+          enabled: true,
+        },
+      },
+    });
     this._activeBucket = name;
     if (isPublic) {
       await this.setContainerPublicAccess(name, true);
@@ -42,136 +84,184 @@ export class GoogleCloudStorage implements IStorageProvider {
     isPublic: boolean,
   ): Promise<boolean | Error> {
     const bucket = this._storage.bucket(name);
-    if (isPublic) {
-      // Make all objects in the bucket publicly readable
-      await bucket.makePublic();
-    } else {
-      // Remove public access
-      await bucket.makePrivate({ includeFiles: true });
-    }
-    return true;
-  }
+    await ensureUniformBucketLevelAccess(bucket);
 
-  container(name: string): IStorageProvider {
-    this._activeBucket = name;
-    return this;
+    const [policy] = await bucket.iam.getPolicy({ requestedPolicyVersion: 3 });
+
+    if (isPublic) {
+      const viewerBinding = policy.bindings.find(
+        binding => binding.role === OBJECT_VIEWER_ROLE,
+      );
+      if (viewerBinding) {
+        if (!viewerBinding.members.includes('allUsers')) {
+          viewerBinding.members.push('allUsers');
+        }
+      } else {
+        policy.bindings.push({
+          role: OBJECT_VIEWER_ROLE,
+          members: ['allUsers'],
+        });
+      }
+    } else {
+      policy.bindings = policy.bindings
+        .map(binding => {
+          if (binding.role !== OBJECT_VIEWER_ROLE) return binding;
+          return {
+            ...binding,
+            members: binding.members.filter(member => member !== 'allUsers'),
+          };
+        })
+        .filter(binding => binding.members.length > 0);
+    }
+
+    await bucket.iam.setPolicy(policy);
+    return true;
   }
 
   async containerExists(name: string): Promise<boolean | Error> {
-    const exists = await this._storage.bucket(name).exists();
-    return exists[0];
+    const [exists] = await this._storage.bucket(name).exists();
+    return exists;
   }
 
-  /**
-   * Used to create a new folder
-   * @param name For the folder
-   */
-  async createFolder(name: string): Promise<boolean | Error> {
-    const bucket = await this._storage.bucket(this._activeBucket);
-    let exists = await bucket.exists();
-    if (!exists[0]) {
-      await bucket.create();
-    }
-
-    exists = await bucket.file(name + '/keep.txt').exists();
-    if (exists[0]) {
-      return true;
-    }
-    await bucket.file(name + '/keep.txt').save(Buffer.from('DO NOT DELETE'));
-    ConduitGrpcSdk.Metrics?.increment('folders_total');
+  async deleteContainer(name: string): Promise<boolean | Error> {
+    const bucket = this._storage.bucket(name);
+    await bucket.deleteFiles({ force: true });
+    await bucket.delete();
+    ConduitGrpcSdk.Metrics?.decrement('containers_total');
     return true;
   }
 
-  async folderExists(name: string): Promise<boolean | Error> {
-    const bucket = await this._storage.bucket(this._activeBucket);
-    let exists = await bucket.exists();
-    if (!exists[0]) {
-      return false;
+  async deleteFolder(name: string): Promise<boolean | Error> {
+    const exists = await this.folderExists(name);
+    if (!exists) return false;
+
+    ConduitGrpcSdk.Logger.log('Getting files list...');
+    const files = await this.listFiles(name);
+
+    ConduitGrpcSdk.Logger.log('Deleting files...');
+    let deleted = 0;
+    for (const file of files) {
+      deleted++;
+      await file.delete({ ignoreNotFound: true });
+      ConduitGrpcSdk.Logger.log(file.name);
     }
-
-    exists = await bucket.file(name + '/keep.txt').exists();
-
-    return exists[0];
+    ConduitGrpcSdk.Logger.log(`${deleted} files deleted.`);
+    ConduitGrpcSdk.Metrics?.decrement('folders_total');
+    return true;
   }
 
   async delete(fileName: string): Promise<boolean | Error> {
-    await this._storage.bucket(this._activeBucket).file(fileName).delete();
+    await this.bucket().file(fileName).delete({ ignoreNotFound: true });
     return true;
   }
 
   async exists(fileName: string): Promise<boolean | Error> {
-    await this._storage.bucket(this._activeBucket).file(fileName).exists();
-    return true;
+    const [bucketExists] = await this.bucket().exists();
+    if (!bucketExists) return false;
+
+    const [fileExists] = await this.bucket().file(fileName).exists();
+    return fileExists;
   }
 
-  async get(fileName: string, downloadPath?: string): Promise<any | Error> {
-    let promise;
-    if (downloadPath) {
-      promise = this._storage.bucket(this._activeBucket).file(fileName).download({
-        destination: downloadPath,
-      });
-    } else {
-      promise = this._storage.bucket(this._activeBucket).file(fileName).download();
-    }
-
-    return promise.then((r: any) => {
-      if (r.data && r.data[0]) {
-        return r.data[0];
-      }
-      return r;
-    });
-  }
-
-  async getSignedUrl(fileName: string, options?: UrlOptions): Promise<any | Error> {
-    this._storage
-      .bucket(this._activeBucket)
+  async getSignedUrl(fileName: string, options?: UrlOptions): Promise<string | Error> {
+    const [url] = await this.bucket()
       .file(fileName)
       .getSignedUrl({
+        version: 'v4',
         action: 'read',
         expires: SIGNED_URL_EXPIRY_DATE(),
         responseDisposition: constructDispositionHeader(fileName, options),
-      })
-      .then((r: any) => {
-        if (r.data && r.data[0]) {
-          return r.data[0];
-        }
-        return r;
       });
+    return url;
   }
 
   async getPublicUrl(
     fileName: string,
-    _containerIsPublic?: boolean,
+    containerIsPublic?: boolean,
   ): Promise<string | Error> {
-    // GCS uses bucket/file-level ACLs, publicUrl() works regardless
-    return this._storage.bucket(this._activeBucket).file(fileName).publicUrl();
-  }
-
-  async store(
-    fileName: string,
-    data: any,
-    isPublic: boolean = false,
-  ): Promise<boolean | Error> {
-    await this._storage.bucket(this._activeBucket).file(fileName).save(data);
-    if (isPublic) {
-      await this._storage.bucket(this._activeBucket).file(fileName).makePublic();
+    if (containerIsPublic) {
+      return this.bucket().file(fileName).publicUrl();
     }
-    return true;
+
+    const [url] = await this.bucket()
+      .file(fileName)
+      .getSignedUrl({
+        version: 'v4',
+        action: 'read',
+        expires: new Date(new Date().setFullYear(new Date().getFullYear() + 99)),
+      });
+    return url;
   }
 
   getUploadUrl(fileName: string): Promise<string | Error> {
-    return this._storage
-      .bucket(this._activeBucket)
+    return this.bucket()
       .file(fileName)
       .getSignedUrl({
+        version: 'v4',
         action: 'write',
         expires: SIGNED_URL_EXPIRY_DATE(),
       })
-      .then((r: any) => {
-        if (r.data && r.data[0]) {
-          return r.data[0];
-        }
-        return r;
-      });
+      .then(([url]) => url);
   }
+
+  private bucket(): Bucket {
+    return this._storage.bucket(this._activeBucket);
+  }
+
+  private folderMarkerKey(name: string): string {
+    return `${name}${FOLDER_MARKER_SUFFIX}`;
+  }
+
+  private async listFiles(folderName: string) {
+    const [files] = await this.bucket().getFiles({ prefix: folderName });
+    return files;
+  }
+}
+
+function createGoogleStorageClient(options: StorageConfig): Storage {
+  const { serviceAccountKeyPath, serviceAccountKeyJson } = options.google;
+
+  if (serviceAccountKeyJson) {
+    const credentials = parseServiceAccountKeyJson(serviceAccountKeyJson);
+    return new Storage({
+      projectId: credentials.project_id,
+      credentials: {
+        client_email: credentials.client_email,
+        private_key: credentials.private_key,
+      },
+    });
+  }
+
+  if (serviceAccountKeyPath) {
+    return new Storage({ keyFilename: serviceAccountKeyPath });
+  }
+
+  return new Storage();
+}
+
+function parseServiceAccountKeyJson(raw: string): GoogleServiceAccountKey {
+  try {
+    const credentials = JSON.parse(raw) as GoogleServiceAccountKey;
+    if (!credentials.client_email || !credentials.private_key) {
+      throw new Error('Missing client_email or private_key');
+    }
+    return credentials;
+  } catch (error) {
+    throw new Error(`Invalid google.serviceAccountKeyJson: ${(error as Error).message}`);
+  }
+}
+
+async function ensureUniformBucketLevelAccess(bucket: Bucket): Promise<void> {
+  const [metadata] = await bucket.getMetadata();
+  if (metadata.iamConfiguration?.uniformBucketLevelAccess?.enabled) {
+    return;
+  }
+
+  await bucket.setMetadata({
+    iamConfiguration: {
+      uniformBucketLevelAccess: {
+        enabled: true,
+      },
+    },
+  });
 }

--- a/modules/storage/src/providers/google/index.ts
+++ b/modules/storage/src/providers/google/index.ts
@@ -27,11 +27,7 @@ export class GoogleCloudStorage implements IStorageProvider {
     return this;
   }
 
-  async store(
-    fileName: string,
-    data: Buffer | string,
-    _isPublic: boolean = false,
-  ): Promise<boolean | Error> {
+  async store(fileName: string, data: Buffer | string): Promise<boolean | Error> {
     await this.bucket().file(fileName).save(data);
     return true;
   }
@@ -179,18 +175,10 @@ export class GoogleCloudStorage implements IStorageProvider {
     fileName: string,
     containerIsPublic?: boolean,
   ): Promise<string | Error> {
-    if (containerIsPublic) {
-      return this.bucket().file(fileName).publicUrl();
+    if (!containerIsPublic) {
+      return new Error('Public URL is only available for files in public containers');
     }
-
-    const [url] = await this.bucket()
-      .file(fileName)
-      .getSignedUrl({
-        version: 'v4',
-        action: 'read',
-        expires: new Date(new Date().setFullYear(new Date().getFullYear() + 99)),
-      });
-    return url;
+    return this.bucket().file(fileName).publicUrl();
   }
 
   getUploadUrl(fileName: string): Promise<string | Error> {

--- a/modules/storage/src/providers/google/index.ts
+++ b/modules/storage/src/providers/google/index.ts
@@ -46,7 +46,10 @@ export function folderListQuery(name: string, pageToken?: string) {
 type IamBinding = { role: string; members: string[] };
 type IamPolicy = { bindings?: IamBinding[]; [key: string]: unknown };
 
-export function applyAllUsersObjectViewer(policy: IamPolicy, isPublic: boolean): IamPolicy {
+export function applyAllUsersObjectViewer(
+  policy: IamPolicy,
+  isPublic: boolean,
+): IamPolicy {
   const bindings = (policy.bindings ?? []).map(binding => ({
     ...binding,
     members: [...binding.members],
@@ -90,7 +93,11 @@ type FolderBucket = {
   getFiles: (
     query: ReturnType<typeof folderListQuery>,
   ) => Promise<
-    [FolderFile[], { pageToken?: string } | null | undefined, { nextPageToken?: string }?]
+    readonly [
+      ReadonlyArray<FolderFile>,
+      { pageToken?: string } | null | undefined,
+      { nextPageToken?: string }?,
+    ]
   >;
   file: (name: string) => FolderFile;
 };
@@ -130,11 +137,11 @@ export async function deleteOneLevelFolder(
 
 type PublicAccessBucket = {
   iam: {
-    getPolicy: (options: { requestedPolicyVersion: number }) => Promise<[IamPolicy]>;
+    getPolicy: (options: { requestedPolicyVersion: number }) => Promise<IamPolicy[]>;
     setPolicy: (policy: IamPolicy) => Promise<unknown>;
   };
   getMetadata: () => Promise<
-    [{ iamConfiguration?: { uniformBucketLevelAccess?: { enabled?: boolean } } }]
+    Array<{ iamConfiguration?: { uniformBucketLevelAccess?: { enabled?: boolean } } }>
   >;
   setMetadata: (metadata: {
     iamConfiguration: { uniformBucketLevelAccess: { enabled: boolean } };
@@ -244,7 +251,11 @@ export class GoogleCloudStorage implements IStorageProvider {
   }
 
   async createContainer(name: string, isPublic?: boolean): Promise<boolean | Error> {
-    await createGcsContainer(this._storage as unknown as ContainerStorage, name, isPublic);
+    await createGcsContainer(
+      this._storage as unknown as ContainerStorage,
+      name,
+      isPublic,
+    );
     this._activeBucket = name;
     ConduitGrpcSdk.Metrics?.increment('containers_total');
     return true;

--- a/modules/storage/src/providers/google/index.ts
+++ b/modules/storage/src/providers/google/index.ts
@@ -19,6 +19,182 @@ export function folderMarkerKeys(name: string): string[] {
   return Array.from(new Set([`${name}${FOLDER_MARKER_SUFFIX}`, `${trimmed}/keep.txt`]));
 }
 
+export function folderObjectPrefix(name: string): string {
+  return name.endsWith('/') ? name : `${name}/`;
+}
+
+export function isDirectChildKey(prefix: string, key: string): boolean {
+  if (!key.startsWith(prefix)) {
+    return false;
+  }
+  const rest = key.slice(prefix.length);
+  return rest.length > 0 && !rest.includes('/');
+}
+
+export const FOLDER_DELETE_PAGE_SIZE = 200;
+
+export function folderListQuery(name: string, pageToken?: string) {
+  return {
+    prefix: folderObjectPrefix(name),
+    delimiter: '/',
+    autoPaginate: false as const,
+    maxResults: FOLDER_DELETE_PAGE_SIZE,
+    ...(pageToken ? { pageToken } : {}),
+  };
+}
+
+type IamBinding = { role: string; members: string[] };
+type IamPolicy = { bindings?: IamBinding[]; [key: string]: unknown };
+
+export function applyAllUsersObjectViewer(policy: IamPolicy, isPublic: boolean): IamPolicy {
+  const bindings = (policy.bindings ?? []).map(binding => ({
+    ...binding,
+    members: [...binding.members],
+  }));
+
+  if (isPublic) {
+    const viewerBinding = bindings.find(binding => binding.role === OBJECT_VIEWER_ROLE);
+    if (viewerBinding) {
+      if (!viewerBinding.members.includes('allUsers')) {
+        viewerBinding.members.push('allUsers');
+      }
+    } else {
+      bindings.push({
+        role: OBJECT_VIEWER_ROLE,
+        members: ['allUsers'],
+      });
+    }
+    return { ...policy, bindings };
+  }
+
+  return {
+    ...policy,
+    bindings: bindings
+      .map(binding => {
+        if (binding.role !== OBJECT_VIEWER_ROLE) return binding;
+        return {
+          ...binding,
+          members: binding.members.filter(member => member !== 'allUsers'),
+        };
+      })
+      .filter(binding => binding.members.length > 0),
+  };
+}
+
+type FolderFile = {
+  name: string;
+  delete: (options?: { ignoreNotFound?: boolean }) => Promise<unknown>;
+};
+
+type FolderBucket = {
+  getFiles: (
+    query: ReturnType<typeof folderListQuery>,
+  ) => Promise<
+    [FolderFile[], { pageToken?: string } | null | undefined, { nextPageToken?: string }?]
+  >;
+  file: (name: string) => FolderFile;
+};
+
+export async function deleteOneLevelFolder(
+  bucket: FolderBucket,
+  name: string,
+): Promise<number> {
+  const prefix = folderObjectPrefix(name);
+  const markers = new Set(folderMarkerKeys(name));
+  let deleted = 0;
+  let pageToken: string | undefined;
+
+  for (;;) {
+    const [files, nextQuery, apiResponse] = await bucket.getFiles(
+      folderListQuery(name, pageToken),
+    );
+    for (const file of files) {
+      if (markers.has(file.name) || !isDirectChildKey(prefix, file.name)) {
+        continue;
+      }
+      await file.delete({ ignoreNotFound: true });
+      deleted++;
+    }
+    pageToken = nextQuery?.pageToken ?? apiResponse?.nextPageToken;
+    if (!pageToken) {
+      break;
+    }
+  }
+
+  for (const key of markers) {
+    await bucket.file(key).delete({ ignoreNotFound: true });
+  }
+
+  return deleted;
+}
+
+type PublicAccessBucket = {
+  iam: {
+    getPolicy: (options: { requestedPolicyVersion: number }) => Promise<[IamPolicy]>;
+    setPolicy: (policy: IamPolicy) => Promise<unknown>;
+  };
+  getMetadata: () => Promise<
+    [{ iamConfiguration?: { uniformBucketLevelAccess?: { enabled?: boolean } } }]
+  >;
+  setMetadata: (metadata: {
+    iamConfiguration: { uniformBucketLevelAccess: { enabled: boolean } };
+  }) => Promise<unknown>;
+};
+
+export async function setBucketPublicAccess(
+  bucket: PublicAccessBucket,
+  isPublic: boolean,
+): Promise<void> {
+  const [policy] = await bucket.iam.getPolicy({ requestedPolicyVersion: 3 });
+  await bucket.iam.setPolicy(applyAllUsersObjectViewer(policy, isPublic));
+  if (isPublic) {
+    await ensureUniformBucketLevelAccess(bucket);
+  }
+}
+
+type ContainerStorage = {
+  createBucket: (
+    name: string,
+    options: { iamConfiguration: { uniformBucketLevelAccess: { enabled: boolean } } },
+  ) => Promise<unknown>;
+  bucket: (name: string) => PublicAccessBucket & {
+    deleteFiles: (options: { force: boolean }) => Promise<unknown>;
+    delete: () => Promise<unknown>;
+  };
+};
+
+export async function createGcsContainer(
+  storage: ContainerStorage,
+  name: string,
+  isPublic?: boolean,
+): Promise<void> {
+  await storage.createBucket(name, {
+    iamConfiguration: {
+      uniformBucketLevelAccess: {
+        enabled: true,
+      },
+    },
+  });
+  try {
+    if (isPublic) {
+      await setBucketPublicAccess(storage.bucket(name), true);
+    }
+  } catch (error) {
+    try {
+      const bucket = storage.bucket(name);
+      await bucket.deleteFiles({ force: true });
+      await bucket.delete();
+    } catch (cleanupError) {
+      ConduitGrpcSdk.Logger?.error(
+        `Failed to clean up GCS bucket "${name}" after public-access setup failed: ${
+          (cleanupError as Error).message
+        }`,
+      );
+    }
+    throw error;
+  }
+}
+
 export class GoogleCloudStorage implements IStorageProvider {
   private readonly _storage: Storage;
   private _activeBucket: string = '';
@@ -68,17 +244,8 @@ export class GoogleCloudStorage implements IStorageProvider {
   }
 
   async createContainer(name: string, isPublic?: boolean): Promise<boolean | Error> {
-    await this._storage.createBucket(name, {
-      iamConfiguration: {
-        uniformBucketLevelAccess: {
-          enabled: true,
-        },
-      },
-    });
+    await createGcsContainer(this._storage as unknown as ContainerStorage, name, isPublic);
     this._activeBucket = name;
-    if (isPublic) {
-      await this.setContainerPublicAccess(name, true);
-    }
     ConduitGrpcSdk.Metrics?.increment('containers_total');
     return true;
   }
@@ -87,38 +254,10 @@ export class GoogleCloudStorage implements IStorageProvider {
     name: string,
     isPublic: boolean,
   ): Promise<boolean | Error> {
-    const bucket = this._storage.bucket(name);
-    await ensureUniformBucketLevelAccess(bucket);
-
-    const [policy] = await bucket.iam.getPolicy({ requestedPolicyVersion: 3 });
-
-    if (isPublic) {
-      const viewerBinding = policy.bindings.find(
-        binding => binding.role === OBJECT_VIEWER_ROLE,
-      );
-      if (viewerBinding) {
-        if (!viewerBinding.members.includes('allUsers')) {
-          viewerBinding.members.push('allUsers');
-        }
-      } else {
-        policy.bindings.push({
-          role: OBJECT_VIEWER_ROLE,
-          members: ['allUsers'],
-        });
-      }
-    } else {
-      policy.bindings = policy.bindings
-        .map(binding => {
-          if (binding.role !== OBJECT_VIEWER_ROLE) return binding;
-          return {
-            ...binding,
-            members: binding.members.filter(member => member !== 'allUsers'),
-          };
-        })
-        .filter(binding => binding.members.length > 0);
-    }
-
-    await bucket.iam.setPolicy(policy);
+    await setBucketPublicAccess(
+      this._storage.bucket(name) as unknown as PublicAccessBucket,
+      isPublic,
+    );
     return true;
   }
 
@@ -139,17 +278,11 @@ export class GoogleCloudStorage implements IStorageProvider {
     const exists = await this.folderExists(name);
     if (!exists) return false;
 
-    ConduitGrpcSdk.Logger.log('Getting files list...');
-    const files = await this.listFiles(name);
-
-    ConduitGrpcSdk.Logger.log('Deleting files...');
-    let deleted = 0;
-    for (const file of files) {
-      deleted++;
-      await file.delete({ ignoreNotFound: true });
-      ConduitGrpcSdk.Logger.log(file.name);
-    }
-    ConduitGrpcSdk.Logger.log(`${deleted} files deleted.`);
+    const deleted = await deleteOneLevelFolder(
+      this.bucket() as unknown as FolderBucket,
+      name,
+    );
+    ConduitGrpcSdk.Logger?.log(`Deleted ${deleted} object(s) from folder ${name}`);
     ConduitGrpcSdk.Metrics?.decrement('folders_total');
     return true;
   }
@@ -207,11 +340,6 @@ export class GoogleCloudStorage implements IStorageProvider {
   private folderMarkerKey(name: string): string {
     return `${name}${FOLDER_MARKER_SUFFIX}`;
   }
-
-  private async listFiles(folderName: string) {
-    const [files] = await this.bucket().getFiles({ prefix: folderName });
-    return files;
-  }
 }
 
 function createGoogleStorageClient(options: StorageConfig): Storage {
@@ -247,7 +375,7 @@ function parseServiceAccountKeyJson(raw: string): GoogleServiceAccountKey {
   }
 }
 
-async function ensureUniformBucketLevelAccess(bucket: Bucket): Promise<void> {
+async function ensureUniformBucketLevelAccess(bucket: PublicAccessBucket): Promise<void> {
   const [metadata] = await bucket.getMetadata();
   if (metadata.iamConfiguration?.uniformBucketLevelAccess?.enabled) {
     return;

--- a/modules/storage/src/providers/google/index.ts
+++ b/modules/storage/src/providers/google/index.ts
@@ -12,7 +12,12 @@ type GoogleServiceAccountKey = {
 };
 
 const OBJECT_VIEWER_ROLE = 'roles/storage.objectViewer';
-const FOLDER_MARKER_SUFFIX = '.keep.txt';
+export const FOLDER_MARKER_SUFFIX = '.keep.txt';
+
+export function folderMarkerKeys(name: string): string[] {
+  const trimmed = name.replace(/\/+$/, '');
+  return Array.from(new Set([`${name}${FOLDER_MARKER_SUFFIX}`, `${trimmed}/keep.txt`]));
+}
 
 export class GoogleCloudStorage implements IStorageProvider {
   private readonly _storage: Storage;
@@ -55,8 +60,11 @@ export class GoogleCloudStorage implements IStorageProvider {
     const [bucketExists] = await this.bucket().exists();
     if (!bucketExists) return false;
 
-    const [markerExists] = await this.bucket().file(this.folderMarkerKey(name)).exists();
-    return markerExists;
+    for (const key of folderMarkerKeys(name)) {
+      const [markerExists] = await this.bucket().file(key).exists();
+      if (markerExists) return true;
+    }
+    return false;
   }
 
   async createContainer(name: string, isPublic?: boolean): Promise<boolean | Error> {

--- a/modules/storage/src/providers/google/publicAccess.test.ts
+++ b/modules/storage/src/providers/google/publicAccess.test.ts
@@ -1,0 +1,145 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  applyAllUsersObjectViewer,
+  createGcsContainer,
+  setBucketPublicAccess,
+} from './index.js';
+
+const OBJECT_VIEWER_ROLE = 'roles/storage.objectViewer';
+
+describe('applyAllUsersObjectViewer', () => {
+  it('adds an objectViewer allUsers binding when making a bucket public', () => {
+    const updated = applyAllUsersObjectViewer({ bindings: [] }, true);
+    assert.deepEqual(updated.bindings, [
+      { role: OBJECT_VIEWER_ROLE, members: ['allUsers'] },
+    ]);
+  });
+
+  it('treats missing bindings as an empty list', () => {
+    const updated = applyAllUsersObjectViewer({}, true);
+    assert.equal(updated.bindings?.[0]?.members.includes('allUsers'), true);
+  });
+
+  it('strips allUsers without dropping other objectViewer members', () => {
+    const updated = applyAllUsersObjectViewer(
+      {
+        bindings: [
+          { role: OBJECT_VIEWER_ROLE, members: ['allUsers', 'user:owner@example.com'] },
+          { role: 'roles/storage.admin', members: ['user:admin@example.com'] },
+        ],
+      },
+      false,
+    );
+    assert.deepEqual(updated.bindings, [
+      { role: OBJECT_VIEWER_ROLE, members: ['user:owner@example.com'] },
+      { role: 'roles/storage.admin', members: ['user:admin@example.com'] },
+    ]);
+  });
+});
+
+describe('setBucketPublicAccess', () => {
+  it('grants IAM before enabling UBLA when making a bucket public', async () => {
+    const calls: string[] = [];
+    const bucket = {
+      iam: {
+        getPolicy: async () => {
+          calls.push('getPolicy');
+          return [{ bindings: [] }];
+        },
+        setPolicy: async () => {
+          calls.push('setPolicy');
+        },
+      },
+      getMetadata: async () => {
+        calls.push('getMetadata');
+        return [{ iamConfiguration: { uniformBucketLevelAccess: { enabled: false } } }];
+      },
+      setMetadata: async () => {
+        calls.push('setMetadata');
+      },
+    };
+
+    await setBucketPublicAccess(bucket, true);
+    assert.deepEqual(calls, ['getPolicy', 'setPolicy', 'getMetadata', 'setMetadata']);
+    assert.ok(calls.indexOf('setPolicy') < calls.indexOf('setMetadata'));
+  });
+
+  it('does not enable UBLA when making a bucket private', async () => {
+    const calls: string[] = [];
+    const bucket = {
+      iam: {
+        getPolicy: async () => [{ bindings: [] }],
+        setPolicy: async () => {
+          calls.push('setPolicy');
+        },
+      },
+      getMetadata: async () => {
+        calls.push('getMetadata');
+        return [{}];
+      },
+      setMetadata: async () => {
+        calls.push('setMetadata');
+      },
+    };
+
+    await setBucketPublicAccess(bucket, false);
+    assert.deepEqual(calls, ['setPolicy']);
+  });
+});
+
+describe('createGcsContainer', () => {
+  it('deletes a bucket it just created when public IAM setup fails', async () => {
+    const calls: string[] = [];
+    const storage = {
+      createBucket: async () => {
+        calls.push('createBucket');
+      },
+      bucket: () => ({
+        iam: {
+          getPolicy: async () => [{ bindings: [] }],
+          setPolicy: async () => {
+            calls.push('setPolicy');
+            throw new Error('iam denied');
+          },
+        },
+        getMetadata: async () => [{}],
+        setMetadata: async () => {
+          calls.push('setMetadata');
+        },
+        deleteFiles: async () => {
+          calls.push('deleteFiles');
+        },
+        delete: async () => {
+          calls.push('deleteBucket');
+        },
+      }),
+    };
+
+    await assert.rejects(() => createGcsContainer(storage, 'uploads', true), /iam denied/);
+    assert.deepEqual(calls, ['createBucket', 'setPolicy', 'deleteFiles', 'deleteBucket']);
+  });
+
+  it('does not delete the bucket when setBucketPublicAccess is used on an existing bucket', async () => {
+    const calls: string[] = [];
+    const bucket = {
+      iam: {
+        getPolicy: async () => [{ bindings: [] }],
+        setPolicy: async () => {
+          throw new Error('iam denied');
+        },
+      },
+      getMetadata: async () => [{}],
+      setMetadata: async () => {},
+      deleteFiles: async () => {
+        calls.push('deleteFiles');
+      },
+      delete: async () => {
+        calls.push('deleteBucket');
+      },
+    };
+
+    await assert.rejects(() => setBucketPublicAccess(bucket, true), /iam denied/);
+    assert.deepEqual(calls, []);
+  });
+});

--- a/modules/storage/src/providers/local/index.ts
+++ b/modules/storage/src/providers/local/index.ts
@@ -72,8 +72,6 @@ function isWithinRoot(rootPath: string, targetPath: string): boolean {
 }
 
 export class LocalStorage implements IStorageProvider {
-  private static readonly PUBLIC_URL_EXPIRY = 1000 * 60 * 60 * 24 * 365 * 99;
-
   _rootStoragePath: string;
   _storagePath: string;
   _activeContainer: string;
@@ -458,9 +456,7 @@ export class LocalStorage implements IStorageProvider {
       return Promise.reject(new Error('Local storage server is not running'));
     }
     const relativePath = `${this._activeContainer}/${fileName}`;
-    return Promise.resolve(
-      this.signUrl(relativePath, 'GET', undefined, LocalStorage.PUBLIC_URL_EXPIRY),
-    );
+    return Promise.resolve(this.signUrl(relativePath, 'GET'));
   }
 
   getSignedUrl(fileName: string, options?: UrlOptions): Promise<string | Error> {

--- a/modules/storage/src/storage.proto
+++ b/modules/storage/src/storage.proto
@@ -46,6 +46,7 @@ message FileResponse {
   string id = 1;
   string url = 2;
   string name = 3;
+  string uri = 4;
 }
 
 message GetFileDataResponse {
@@ -72,6 +73,7 @@ message FileByUrlResponse {
   string fileUrl = 2;
   string name = 3;
   string uploadUrl = 4;
+  string uri = 5;
 }
 
 message UpdateFileByUrlRequest {

--- a/modules/storage/src/utils/filePrivacy.test.ts
+++ b/modules/storage/src/utils/filePrivacy.test.ts
@@ -1,0 +1,108 @@
+import { afterEach, describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { status } from '@grpc/grpc-js';
+import { GrpcError } from '@conduitplatform/grpc-sdk';
+import { _StorageContainer } from '../models/index.js';
+import {
+  sanitizeFilesForResponse,
+  stripPrivateContainerUrls,
+  validateFilePrivacy,
+} from './index.js';
+
+const originalGetInstance = _StorageContainer.getInstance.bind(_StorageContainer);
+
+afterEach(() => {
+  _StorageContainer.getInstance = originalGetInstance;
+});
+
+function stubContainers(docs: Array<{ name: string; isPublic?: boolean }>) {
+  _StorageContainer.getInstance = (() => ({
+    findOne: async (query: { name: string }) =>
+      docs.find(doc => doc.name === query.name) ?? null,
+    findMany: async (query: { name?: { $in: string[] } }) => {
+      const names = query.name?.$in;
+      return names ? docs.filter(doc => names.includes(doc.name)) : docs;
+    },
+  })) as typeof _StorageContainer.getInstance;
+}
+
+describe('validateFilePrivacy', () => {
+  it('rejects a private or omitted file in a public container', async () => {
+    stubContainers([{ name: 'public-bucket', isPublic: true }]);
+
+    await assert.rejects(
+      () => validateFilePrivacy('public-bucket', false),
+      (error: unknown) =>
+        error instanceof GrpcError &&
+        error.code === status.INVALID_ARGUMENT &&
+        error.message === 'Files in public containers must be public',
+    );
+    await assert.rejects(
+      () => validateFilePrivacy('public-bucket'),
+      (error: unknown) => error instanceof GrpcError && error.code === status.INVALID_ARGUMENT,
+    );
+  });
+
+  it('allows a public file in a public container and any file in a private container', async () => {
+    stubContainers([
+      { name: 'public-bucket', isPublic: true },
+      { name: 'private-bucket', isPublic: false },
+    ]);
+
+    await validateFilePrivacy('public-bucket', true);
+    await validateFilePrivacy('private-bucket', true);
+    await validateFilePrivacy('private-bucket', false);
+    await validateFilePrivacy('private-bucket');
+  });
+});
+
+describe('sanitizeFileForResponse', () => {
+  it('strips url and sourceUrl for files in private containers', async () => {
+    stubContainers([{ name: 'private-bucket', isPublic: false }]);
+
+    const [sanitized] = await sanitizeFilesForResponse([
+      {
+        _id: 'file-1',
+        name: 'secret.png',
+        container: 'private-bucket',
+        url: 'https://stale.example/secret.png',
+        sourceUrl: 'https://s3.example/secret.png',
+        uri: '/storage/getFileUrl/file-1',
+      } as never,
+    ]);
+
+    assert.equal(sanitized.uri, '/storage/getFileUrl/file-1');
+    assert.equal(sanitized.url, undefined);
+    assert.equal(sanitized.sourceUrl, undefined);
+  });
+
+  it('keeps provider/CDN urls for files in public containers', async () => {
+    stubContainers([{ name: 'public-bucket', isPublic: true }]);
+
+    const [sanitized] = await sanitizeFilesForResponse([
+      {
+        _id: 'file-2',
+        name: 'banner.png',
+        container: 'public-bucket',
+        url: 'https://cdn.example/banner.png',
+        sourceUrl: 'https://s3.example/banner.png',
+        uri: '/storage/getFileUrl/file-2',
+      } as never,
+    ]);
+
+    assert.equal(sanitized.url, 'https://cdn.example/banner.png');
+    assert.equal(sanitized.sourceUrl, 'https://s3.example/banner.png');
+  });
+
+  it('treats an unknown container as private when stripping urls', () => {
+    const sanitized = stripPrivateContainerUrls(
+      {
+        url: 'https://stale.example/file.png',
+        sourceUrl: 'https://s3.example/file.png',
+      },
+      false,
+    );
+    assert.equal(sanitized.url, undefined);
+    assert.equal(sanitized.sourceUrl, undefined);
+  });
+});

--- a/modules/storage/src/utils/filePrivacy.test.ts
+++ b/modules/storage/src/utils/filePrivacy.test.ts
@@ -23,7 +23,7 @@ function stubContainers(docs: Array<{ name: string; isPublic?: boolean }>) {
       const names = query.name?.$in;
       return names ? docs.filter(doc => names.includes(doc.name)) : docs;
     },
-  })) as typeof _StorageContainer.getInstance;
+  })) as unknown as typeof _StorageContainer.getInstance;
 }
 
 describe('validateFilePrivacy', () => {
@@ -39,7 +39,8 @@ describe('validateFilePrivacy', () => {
     );
     await assert.rejects(
       () => validateFilePrivacy('public-bucket'),
-      (error: unknown) => error instanceof GrpcError && error.code === status.INVALID_ARGUMENT,
+      (error: unknown) =>
+        error instanceof GrpcError && error.code === status.INVALID_ARGUMENT,
     );
   });
 

--- a/modules/storage/src/utils/index.ts
+++ b/modules/storage/src/utils/index.ts
@@ -77,6 +77,79 @@ export async function deepPathHandler(
   }
 }
 
+export function buildFileUri(fileId: string): string {
+  return `/storage/getFileUrl/${fileId}`;
+}
+
+export function getStorageFileKey(folder: string, name?: string): string {
+  return (folder === '/' ? '' : folder) + (name ?? '');
+}
+
+type FileReferences = {
+  sourceUrl?: string;
+  url?: string;
+  uri?: string;
+};
+
+export async function resolveFileReferences(
+  storageProvider: IStorageProvider,
+  params: {
+    container: string;
+    folder: string;
+    name?: string;
+    isPublic?: boolean;
+    fileId: string;
+  },
+): Promise<FileReferences> {
+  if (!params.isPublic) {
+    return {};
+  }
+
+  const containerDoc = await _StorageContainer
+    .getInstance()
+    .findOne({ name: params.container }, { readPreference: 'primary' });
+  const containerIsPublic = containerDoc?.isPublic ?? false;
+  const uri = buildFileUri(params.fileId);
+  const fileName = getStorageFileKey(params.folder, params.name);
+
+  if (!containerIsPublic) {
+    return { sourceUrl: '', url: '', uri };
+  }
+
+  const publicUrlResult = await storageProvider
+    .container(params.container)
+    .getPublicUrl(fileName, true);
+  if (publicUrlResult instanceof Error) {
+    throw publicUrlResult;
+  }
+
+  return {
+    sourceUrl: publicUrlResult,
+    url: applyCdnHost(publicUrlResult, params.container),
+    uri,
+  };
+}
+
+export async function resolvePublicFileAccessUrl(
+  storageProvider: IStorageProvider,
+  file: File,
+): Promise<string> {
+  if (file.url) {
+    return file.url;
+  }
+
+  const rawUrl = await storageProvider
+    .container(file.container)
+    .getSignedUrl(getStorageFileKey(file.folder, file.name), {
+      download: false,
+      fileName: file.alias ?? file.name,
+    });
+  if (rawUrl instanceof Error) {
+    throw rawUrl;
+  }
+  return applyCdnHost(rawUrl, file.container) ?? rawUrl;
+}
+
 export async function storeNewFile(
   storageProvider: IStorageProvider,
   params: IFileParams,
@@ -86,31 +159,12 @@ export async function storeNewFile(
   await validateFilePrivacy(container, isPublic);
   const buffer = Buffer.from(data as string, 'base64');
   const size = buffer.byteLength;
-  const fileName = (folder === '/' ? '' : folder) + name;
+  const fileName = getStorageFileKey(folder, name);
   await storageProvider.container(container).store(fileName, buffer, isPublic);
-
-  // Get container public status for URL generation
-  const containerDoc = await _StorageContainer
-    .getInstance()
-    .findOne({ name: container }, { readPreference: 'primary' });
-  const containerIsPublic = containerDoc?.isPublic ?? false;
-
-  // Get raw storage URL (sourceUrl) and CDN-applied URL (url)
-  let sourceUrl: string | undefined;
-  if (isPublic) {
-    const publicUrlResult = await storageProvider
-      .container(container)
-      .getPublicUrl(fileName, containerIsPublic);
-    if (publicUrlResult instanceof Error) {
-      throw publicUrlResult;
-    }
-    sourceUrl = publicUrlResult;
-  }
-  const url = applyCdnHost(sourceUrl, container);
 
   ConduitGrpcSdk.Metrics?.increment('files_total');
   ConduitGrpcSdk.Metrics?.increment('storage_size_bytes_total', size);
-  return await File.getInstance().create({
+  const file = await File.getInstance().create({
     name,
     alias,
     mimeType,
@@ -118,9 +172,17 @@ export async function storeNewFile(
     container: container,
     size,
     isPublic,
-    sourceUrl,
-    url,
   });
+  const refs = await resolveFileReferences(storageProvider, {
+    container,
+    folder,
+    name,
+    isPublic,
+    fileId: file._id,
+  });
+  return refs.uri || refs.url || refs.sourceUrl
+    ? ((await File.getInstance().findByIdAndUpdate(file._id, refs)) as File)
+    : file;
 }
 
 export async function _createFileUploadUrl(
@@ -130,29 +192,10 @@ export async function _createFileUploadUrl(
   const { name, alias, container, folder, mimeType, isPublic, size } = params;
   // Validate file privacy against container settings
   await validateFilePrivacy(container, isPublic);
-  const fileName = (folder === '/' ? '' : folder) + name;
+  const fileName = getStorageFileKey(folder, name);
   await storageProvider
     .container(container)
     .store(fileName, Buffer.from('PENDING UPLOAD'), isPublic);
-
-  // Get container public status for URL generation
-  const containerDoc = await _StorageContainer
-    .getInstance()
-    .findOne({ name: container }, { readPreference: 'primary' });
-  const containerIsPublic = containerDoc?.isPublic ?? false;
-
-  // Get raw storage URL (sourceUrl) and CDN-applied URL (url)
-  let sourceUrl: string | undefined;
-  if (isPublic) {
-    const publicUrlResult = await storageProvider
-      .container(container)
-      .getPublicUrl(fileName, containerIsPublic);
-    if (publicUrlResult instanceof Error) {
-      throw publicUrlResult;
-    }
-    sourceUrl = publicUrlResult;
-  }
-  const publicUrl = applyCdnHost(sourceUrl, container);
 
   ConduitGrpcSdk.Metrics?.increment('files_total');
   ConduitGrpcSdk.Metrics?.increment('storage_size_bytes_total', size);
@@ -164,14 +207,23 @@ export async function _createFileUploadUrl(
     folder: folder,
     container: container,
     isPublic,
-    sourceUrl,
-    url: publicUrl,
   });
+  const refs = await resolveFileReferences(storageProvider, {
+    container,
+    folder,
+    name,
+    isPublic,
+    fileId: file._id,
+  });
+  const storedFile =
+    refs.uri || refs.url || refs.sourceUrl
+      ? ((await File.getInstance().findByIdAndUpdate(file._id, refs)) as File)
+      : file;
   const uploadUrl = (await storageProvider
     .container(container)
     .getUploadUrl(fileName)) as string;
   return {
-    file,
+    file: storedFile,
     url: uploadUrl,
   };
 }
@@ -182,43 +234,34 @@ export async function _updateFile(
   params: IFileParams,
 ): Promise<File> {
   const { name, alias, data, folder, container, mimeType } = params;
+  await validateFilePrivacy(container, file.isPublic);
   const onlyDataUpdate =
     name === file.name && folder === file.folder && container === file.container;
   await storageProvider
     .container(container)
-    .store((folder === '/' ? '' : folder) + name, data, file.isPublic);
+    .store(getStorageFileKey(folder, name), data, file.isPublic);
   if (!onlyDataUpdate) {
     await storageProvider
       .container(file.container)
-      .delete((file.folder === '/' ? '' : file.folder) + file.name);
+      .delete(getStorageFileKey(file.folder, file.name));
   }
 
-  // Get container public status for URL generation
-  const containerDoc = await _StorageContainer
-    .getInstance()
-    .findOne({ name: container }, { readPreference: 'primary' });
-  const containerIsPublic = containerDoc?.isPublic ?? false;
-
-  // Get raw storage URL (sourceUrl) and CDN-applied URL (url)
-  let sourceUrl: string | undefined;
-  if (file.isPublic) {
-    const publicUrlResult = await storageProvider
-      .container(container)
-      .getPublicUrl((folder === '/' ? '' : folder) + name, containerIsPublic);
-    if (publicUrlResult instanceof Error) {
-      throw publicUrlResult;
-    }
-    sourceUrl = publicUrlResult;
-  }
-  const url = applyCdnHost(sourceUrl, container);
+  const refs = await resolveFileReferences(storageProvider, {
+    container,
+    folder,
+    name,
+    isPublic: file.isPublic,
+    fileId: file._id,
+  });
 
   const updatedFile = (await File.getInstance().findByIdAndUpdate(file._id, {
     name,
     alias,
     folder,
     container,
-    sourceUrl,
-    url,
+    sourceUrl: refs.sourceUrl,
+    url: refs.url,
+    uri: refs.uri,
     mimeType,
   })) as File;
   updateFileMetrics(file.size, (data as Buffer).byteLength);
@@ -231,6 +274,14 @@ export async function _updateFileUploadUrl(
   params: IFileParams,
 ): Promise<{ file: File; url: string }> {
   const { name, alias, folder, container, mimeType, size } = params;
+  await validateFilePrivacy(container, file.isPublic);
+  const refs = await resolveFileReferences(storageProvider, {
+    container,
+    folder,
+    name,
+    isPublic: file.isPublic,
+    fileId: file._id,
+  });
   let updatedFile;
   const onlyDataUpdate =
     name === file.name && folder === file.folder && container === file.container;
@@ -238,46 +289,31 @@ export async function _updateFileUploadUrl(
     updatedFile = await File.getInstance().findByIdAndUpdate(file._id, {
       mimeType,
       alias,
+      sourceUrl: refs.sourceUrl,
+      url: refs.url,
+      uri: refs.uri,
       ...{ size: size ?? file.size },
     });
   } else {
     await storageProvider
       .container(container)
       .store(
-        (folder === '/' ? '' : folder) + name,
+        getStorageFileKey(folder, name),
         Buffer.from('PENDING UPLOAD'),
         file.isPublic,
       );
     await storageProvider
       .container(file.container)
-      .delete((file.folder === '/' ? '' : file.folder) + file.name);
-
-    // Get container public status for URL generation
-    const containerDoc = await _StorageContainer
-      .getInstance()
-      .findOne({ name: container }, { readPreference: 'primary' });
-    const containerIsPublic = containerDoc?.isPublic ?? false;
-
-    // Get raw storage URL (sourceUrl) and CDN-applied URL (url)
-    let sourceUrl: string | undefined;
-    if (file.isPublic) {
-      const publicUrlResult = await storageProvider
-        .container(container)
-        .getPublicUrl((folder === '/' ? '' : folder) + name, containerIsPublic);
-      if (publicUrlResult instanceof Error) {
-        throw publicUrlResult;
-      }
-      sourceUrl = publicUrlResult;
-    }
-    const url = applyCdnHost(sourceUrl, container);
+      .delete(getStorageFileKey(file.folder, file.name));
 
     updatedFile = await File.getInstance().findByIdAndUpdate(file._id, {
       name,
       alias,
       folder,
       container,
-      sourceUrl,
-      url,
+      sourceUrl: refs.sourceUrl,
+      url: refs.url,
+      uri: refs.uri,
       mimeType,
       ...{ size: size ?? file.size },
     });
@@ -285,15 +321,17 @@ export async function _updateFileUploadUrl(
   if (!isNil(size)) updateFileMetrics(file.size, size!);
   const uploadUrl = (await storageProvider
     .container(container)
-    .getUploadUrl((folder === '/' ? '' : folder) + name)) as string;
+    .getUploadUrl(getStorageFileKey(folder, name))) as string;
   return { file: updatedFile!, url: uploadUrl };
 }
 
 export function updateFileMetrics(currentSize: number, newSize: number) {
   const fileSizeDiff = Math.abs(currentSize - newSize);
-  fileSizeDiff < 0
-    ? ConduitGrpcSdk.Metrics?.increment('storage_size_bytes_total', fileSizeDiff)
-    : ConduitGrpcSdk.Metrics?.decrement('storage_size_bytes_total', fileSizeDiff);
+  if (newSize > currentSize) {
+    ConduitGrpcSdk.Metrics?.increment('storage_size_bytes_total', fileSizeDiff);
+  } else {
+    ConduitGrpcSdk.Metrics?.decrement('storage_size_bytes_total', fileSizeDiff);
+  }
 }
 
 export async function validateName(
@@ -369,13 +407,6 @@ export function applyCdnHost(
   }
 }
 
-/**
- * Validates file privacy settings against container's public status.
- * Files in public containers cannot be marked as private.
- * @param containerName The name of the container
- * @param isFilePublic Whether the file is being marked as public
- * @throws GrpcError if validation fails
- */
 export async function validateFilePrivacy(
   containerName: string,
   isFilePublic?: boolean,
@@ -383,10 +414,10 @@ export async function validateFilePrivacy(
   const container = await _StorageContainer
     .getInstance()
     .findOne({ name: containerName }, { readPreference: 'primary' });
-  if (container?.isPublic && isFilePublic === false) {
+  if (container?.isPublic && !isFilePublic) {
     throw new GrpcError(
       status.INVALID_ARGUMENT,
-      'Files in public containers cannot be private',
+      'Files in public containers must be public',
     );
   }
 }

--- a/modules/storage/src/utils/index.ts
+++ b/modules/storage/src/utils/index.ts
@@ -190,9 +190,11 @@ export async function storeNewFile(
     isPublic,
     fileId: file._id,
   });
-  return refs.uri || refs.url || refs.sourceUrl
-    ? ((await File.getInstance().findByIdAndUpdate(file._id, refs)) as File)
-    : file;
+  const storedFile =
+    refs.uri || refs.url || refs.sourceUrl
+      ? ((await File.getInstance().findByIdAndUpdate(file._id, refs)) as File)
+      : file;
+  return sanitizeFileForResponse(storedFile);
 }
 
 export async function _createFileUploadUrl(
@@ -233,7 +235,7 @@ export async function _createFileUploadUrl(
     .container(container)
     .getUploadUrl(fileName)) as string;
   return {
-    file: storedFile,
+    file: await sanitizeFileForResponse(storedFile),
     url: uploadUrl,
   };
 }
@@ -275,7 +277,7 @@ export async function _updateFile(
     mimeType,
   })) as File;
   updateFileMetrics(file.size, (data as Buffer).byteLength);
-  return updatedFile;
+  return sanitizeFileForResponse(updatedFile);
 }
 
 export async function _updateFileUploadUrl(
@@ -332,7 +334,7 @@ export async function _updateFileUploadUrl(
   const uploadUrl = (await storageProvider
     .container(container)
     .getUploadUrl(getStorageFileKey(folder, name))) as string;
-  return { file: updatedFile!, url: uploadUrl };
+  return { file: await sanitizeFileForResponse(updatedFile!), url: uploadUrl };
 }
 
 export function updateFileMetrics(currentSize: number, newSize: number) {
@@ -432,18 +434,39 @@ export async function validateFilePrivacy(
   }
 }
 
-export async function sanitizeFileForResponse(file: File): Promise<File> {
-  const containerDoc = await _StorageContainer
-    .getInstance()
-    .findOne({ name: file.container }, { readPreference: 'primary' });
-  const containerIsPublic = containerDoc?.isPublic ?? false;
+export function stripPrivateContainerUrls<T extends Pick<File, 'url' | 'sourceUrl'>>(
+  file: T,
+  containerIsPublic: boolean,
+): T {
+  if (containerIsPublic) {
+    return file;
+  }
+  const sanitized = { ...file };
+  delete sanitized.url;
+  delete sanitized.sourceUrl;
+  return sanitized;
+}
 
-  if (!containerIsPublic) {
-    const sanitized = { ...file };
-    delete sanitized.url;
-    delete sanitized.sourceUrl;
-    return sanitized as File;
+export async function sanitizeFileForResponse(file: File): Promise<File> {
+  const [sanitized] = await sanitizeFilesForResponse([file]);
+  return sanitized;
+}
+
+export async function sanitizeFilesForResponse(files: File[]): Promise<File[]> {
+  if (files.length === 0) {
+    return files;
   }
 
-  return file;
+  const containerNames = [...new Set(files.map(file => file.container))];
+  const containers = await _StorageContainer.getInstance().findMany(
+    { name: { $in: containerNames } },
+    { select: 'name isPublic', readPreference: 'primary' },
+  );
+  const containerIsPublic = new Map(
+    containers.map(container => [container.name, container.isPublic ?? false]),
+  );
+
+  return files.map(file =>
+    stripPrivateContainerUrls(file, containerIsPublic.get(file.container) ?? false),
+  );
 }

--- a/modules/storage/src/utils/index.ts
+++ b/modules/storage/src/utils/index.ts
@@ -116,6 +116,11 @@ export async function resolveFileReferences(
     return { sourceUrl: '', url: '', uri };
   }
 
+  const config = ConfigController.getInstance().config;
+  if (config.provider === 'local') {
+    return { sourceUrl: '', url: '', uri };
+  }
+
   const publicUrlResult = await storageProvider
     .container(params.container)
     .getPublicUrl(fileName, true);
@@ -425,4 +430,20 @@ export async function validateFilePrivacy(
       'Files in public containers must be public',
     );
   }
+}
+
+export async function sanitizeFileForResponse(file: File): Promise<File> {
+  const containerDoc = await _StorageContainer
+    .getInstance()
+    .findOne({ name: file.container }, { readPreference: 'primary' });
+  const containerIsPublic = containerDoc?.isPublic ?? false;
+
+  if (!containerIsPublic) {
+    const sanitized = { ...file };
+    delete sanitized.url;
+    delete sanitized.sourceUrl;
+    return sanitized as File;
+  }
+
+  return file;
 }

--- a/modules/storage/src/utils/index.ts
+++ b/modules/storage/src/utils/index.ts
@@ -134,7 +134,12 @@ export async function resolvePublicFileAccessUrl(
   storageProvider: IStorageProvider,
   file: File,
 ): Promise<string> {
-  if (file.url) {
+  const containerDoc = await _StorageContainer
+    .getInstance()
+    .findOne({ name: file.container }, { readPreference: 'primary' });
+  const containerIsPublic = containerDoc?.isPublic ?? false;
+
+  if (containerIsPublic && file.url) {
     return file.url;
   }
 

--- a/modules/storage/tsconfig.json
+++ b/modules/storage/tsconfig.json
@@ -67,5 +67,5 @@
     "forceConsistentCasingInFileNames": true /* Disallow inconsistently-cased references to the same file. */
   },
   "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist", "bundle", "tsup.config.ts"]
+  "exclude": ["node_modules", "dist", "bundle", "tsup.config.ts", "src/**/*.test.ts"]
 }

--- a/modules/storage/tsconfig.test.json
+++ b/modules/storage/tsconfig.test.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist-test",
+    "rootDir": "./src",
+    "declaration": false,
+    "sourceMap": false
+  },
+  "include": ["src/**/*"],
+  "exclude": []
+}


### PR DESCRIPTION
## Summary

This expands the original GCS provider rewrite into a broader public-file URL contract for the storage module.

**GCS provider parity:**
- Implements the missing `IStorageProvider` methods for containers, folders, files, and signed URLs.
- Fixes `exists` so it returns the provider result instead of always returning `true`.
- Supports service account key file, inline JSON (`google.serviceAccountKeyJson`), and Application Default Credentials.
- Uses Uniform Bucket-Level Access and IAM (`roles/storage.objectViewer` for `allUsers`) for public buckets.

**Public file URL semantics:**
- Adds `File.uri` as a stable Conduit-relative path (`/storage/getFileUrl/:id`).
- Keeps `File.url` / `sourceUrl` as direct provider/CDN URLs only when both the container and file are public.
- Allows public files in private containers by storing `uri` only and signing provider URLs on demand through Conduit.
- Rejects private files in public containers, including omitted `isPublic` values.
- Removes unsupported 99/100-year signed URL branches from GCS, Azure, Aliyun, and AWS `getPublicUrl` handling.
- Adds a migration to backfill `uri` and clear stale direct URLs for public files in private containers.

## Validation

- [x] `npm run build` in `modules/storage`
- [x] `npm run build` in `libraries/grpc-sdk`
- [x] Focused ESLint on touched storage TypeScript files
- [x] Composer 2.5 deslop pass
- [x] Composer 2.5 verification pass

## Manual test plan

- [ ] Configure storage provider `google` with a GCS bucket or emulator.
- [ ] Verify GCS auth via key file path, inline JSON, and ADC.
- [ ] Public container + public file stores `sourceUrl`, `url`, and `uri`.
- [ ] Public container + omitted/false `isPublic` throws a clear validation error.
- [ ] Private container + public file stores `uri` only; unauthenticated `GET /storage/getFileUrl/:id` returns a fresh signed URL.
- [ ] Private container + private file still requires auth and signs on demand.
- [ ] Folder/container/file lifecycle methods work for GCS, including `exists` returning `false` for missing files.
- [ ] Existing public files are migrated with `uri`, and private-container public files have stale direct URLs cleared.