### PR TITLE
fix(authentication): require sudo for admin team delete

### DIFF
--- a/modules/authentication/src/admin/team.ts
+++ b/modules/authentication/src/admin/team.ts
@@ -185,7 +185,7 @@ export class TeamsAdmin {
           teamId: ConduitObjectId.Required,
         },
         name: 'DeleteTeam',
-        description: 'Deletes a team',
+        description: 'Deletes a team (requires sudo access)',
       },
       new ConduitRouteReturnDefinition('DeleteTeam', 'String'),
       this.deleteTeam.bind(this),
@@ -375,6 +375,12 @@ export class TeamsAdmin {
   }
 
   async deleteTeam(call: ParsedRouterRequest): Promise<UnparsedRouterResponse> {
+    if (!call.request.context.jwtPayload?.sudo) {
+      throw new GrpcError(
+        status.PERMISSION_DENIED,
+        'Re-login required to enter sudo mode',
+      );
+    }
     const { teamId } = call.request.params;
     const team = await Team.getInstance().findOne({ _id: teamId });
     if (!team) {

--- a/packages/core/src/admin/middleware/Auth.middleware.ts
+++ b/packages/core/src/admin/middleware/Auth.middleware.ts
@@ -124,6 +124,7 @@ async function handleJwtToken(
       return;
     }
     req.conduit!.admin = admin;
+    req.conduit!.jwtPayload = decoded;
     next();
   } catch (error) {
     ConduitGrpcSdk.Logger.error(error as Error);

--- a/packages/core/src/admin/routes/Login.route.ts
+++ b/packages/core/src/admin/routes/Login.route.ts
@@ -69,7 +69,7 @@ export function getLoginRoute() {
       const authConfig = ConfigController.getInstance().config.auth;
       const { tokenSecret, tokenExpirationTime } = authConfig;
       const token = signToken(
-        { id: admin._id.toString() },
+        { id: admin._id.toString(), sudo: true },
         tokenSecret,
         tokenExpirationTime,
       );

--- a/packages/core/src/admin/routes/VerifyTwoFa.route.ts
+++ b/packages/core/src/admin/routes/VerifyTwoFa.route.ts
@@ -23,7 +23,8 @@ export function verifyTwoFaRoute() {
     async (req: ConduitRouteParameters) => {
       const { code } = req.params!;
       const admin = req.context!.admin;
-      return await verify2Fa(admin, code);
+      const token = await verify2Fa(admin, code);
+      return { token };
     },
   );
 }

--- a/packages/core/src/admin/utils/auth.ts
+++ b/packages/core/src/admin/utils/auth.ts
@@ -48,7 +48,7 @@ export async function verify2Fa(admin: Admin, code: string) {
   }
   const authConfig = ConfigController.getInstance().config.auth;
   const { tokenSecret, tokenExpirationTime } = authConfig;
-  return signToken({ id: admin._id }, tokenSecret, tokenExpirationTime);
+  return signToken({ id: admin._id, sudo: true }, tokenSecret, tokenExpirationTime);
 }
 
 export function generateSecret(options?: { name: string; account: string }) {


### PR DESCRIPTION
## Problem

The client API already requires a sudo JWT to delete a team, but the admin API allowed `DELETE /authentication/teams/:teamId` with any valid admin session. Conduit-UI called that endpoint directly, so team deletion bypassed the sudo gate.

## Solution

- Issue admin JWTs with `sudo: true` after successful login and 2FA verification
- Attach decoded `jwtPayload` to admin request context for module handlers
- Reject admin team delete when `jwtPayload.sudo` is missing (same error as client API)
- Preserve existing cleanup: relation deletion and `parentTeam` unset on child teams

## Test plan

- [ ] Log in to Conduit-UI and delete a non-default team — should succeed with a fresh session
- [ ] Call admin `DELETE /authentication/teams/:id` with a JWT that lacks `sudo` — expect 403 `Re-login required to enter sudo mode`
- [ ] Verify child teams lose `parentTeam` reference after parent deletion
- [ ] Verify default team still cannot be deleted