### PR TITLE
build(deps): bump GitHub Actions checkout, upload-artifact, download-artifact

### DIFF
--- a/.github/workflows/images.build.yml
+++ b/.github/workflows/images.build.yml
@@ -37,7 +37,7 @@ jobs:
       publish_latest: ${{ steps.release.outputs.publish_latest }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
@@ -106,7 +106,7 @@ jobs:
       packages: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
@@ -141,7 +141,7 @@ jobs:
           touch "/tmp/digests/${digest#sha256:}"
 
       - name: Upload digest
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: digests-${{ matrix.target }}-amd64
           path: /tmp/digests/*
@@ -161,7 +161,7 @@ jobs:
       packages: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
@@ -196,7 +196,7 @@ jobs:
           touch "/tmp/digests/${digest#sha256:}"
 
       - name: Upload digest
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: digests-${{ matrix.target }}-arm64
           path: /tmp/digests/*
@@ -216,7 +216,7 @@ jobs:
       packages: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Log in to GHCR
         uses: docker/login-action@v4
@@ -253,13 +253,13 @@ jobs:
         run: mkdir -p /tmp/digests
 
       - name: Download amd64 digest
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: digests-${{ matrix.target }}-amd64
           path: /tmp/digests
 
       - name: Download arm64 digest
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: digests-${{ matrix.target }}-arm64
           path: /tmp/digests

--- a/.github/workflows/production.yaml
+++ b/.github/workflows/production.yaml
@@ -11,7 +11,7 @@ jobs:
   publish_sdk:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Set env
         run: |
           VERSION=$(echo "${GITHUB_REF#refs/*/}" | sed 's/^v//')
@@ -51,7 +51,7 @@ jobs:
     needs: publish_sdk
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Set env
         run: |
           VERSION=$(echo "${GITHUB_REF#refs/*/}" | sed 's/^v//')


### PR DESCRIPTION
## Summary
Combines dependabot PRs #1514, #1515, and #1516 in a single merge to avoid workflow file conflicts.

- `actions/checkout` v6 → v7 (images.build.yml + production.yaml)
- `actions/upload-artifact` v4 → v7 (images.build.yml)
- `actions/download-artifact` v4 → v8 (images.build.yml)

## Test plan
- [ ] Trigger `Build container images` workflow via workflow_dispatch after merge