### PR TITLE
fix(routing): capture raw body for non-JSON webhook content types

### DIFF
--- a/libraries/hermes/src/index.ts
+++ b/libraries/hermes/src/index.ts
@@ -412,6 +412,20 @@ export class ConduitRoutingController {
     );
     // verify retains buffer until route gate clears req.rawBody
     this.registerMiddleware(
+      express.raw({
+        limit: '50mb',
+        type: req => {
+          const ct = req.headers['content-type'] || '';
+          return (
+            !ct.startsWith('application/json') &&
+            !ct.startsWith('application/x-www-form-urlencoded')
+          );
+        },
+        verify: captureRequestRawBody,
+      }),
+      false,
+    );
+    this.registerMiddleware(
       express.json({ limit: '50mb', verify: captureRequestRawBody }),
       false,
     );


### PR DESCRIPTION
## Summary

Adds `express.raw()` middleware for non-JSON/non-urlencoded content types, complementing PR #1488.

After the colleague's fixes on #1488 (form body capture, `captureRawHeaders` flag, post-extraction gating), the only remaining gap was support for webhooks that send non-standard content types such as `application/xml` or `application/octet-stream`.

## Changes

### `libraries/hermes/src/index.ts`
- Added `express.raw()` middleware before `express.json()` with a `type` filter that skips JSON and urlencoded content types.
- Uses the existing `captureRequestRawBody` helper for consistency with the json/urlencoded parsers.
- Middleware order: route middleware → `express.raw()` → `express.json()` → `express.urlencoded()` → cookieParser → static.

## Notes

- Raw bytes are still captured at middleware level (required for signature verification), but gRPC forwarding remains gated by `captureRawBody` / `captureRawHeaders` flags in the route handler (handled by #1488).
- No proto changes.