### PR TITLE
chore(deps): tune dependabot to reduce PR noise

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,20 +1,41 @@
-# To get started with Dependabot version updates, you'll need to specify which
-# package ecosystems to update and where the package manifests are located.
-# Please see the documentation for all configuration options:
 # https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
 
 version: 2
 updates:
-  - package-ecosystem: "npm" # See documentation for possible values
-    directory: "/" # Location of package manifests
+  - package-ecosystem: npm
+    directory: "/"
     versioning-strategy: increase
     schedule:
-      interval: "daily"
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    groups:
+      aws-sdk:
+        patterns:
+          - "@aws-sdk/*"
+      dev-dependencies:
+        dependency-type: development
+        update-types:
+          - minor
+          - patch
+      production-patch:
+        dependency-type: production
+        update-types:
+          - patch
+        exclude-patterns:
+          - "@aws-sdk/*"
     ignore:
-      - dependency-name: "graphql"
+      - dependency-name: graphql
         update-types: ["version-update:semver-major"]
-  - package-ecosystem: "github-actions"
-    # Workflow files stored in the default location of `.github/workflows`. (You don't need to specify `/.github/workflows` for `directory`. You can use `directory: "/"`.)
+      - dependency-name: "@types/node"
+        update-types: ["version-update:semver-major"]
+
+  - package-ecosystem: github-actions
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: monthly
+    open-pull-requests-limit: 3
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
## Summary
- npm: daily → weekly (Monday), grouped PRs for AWS SDK / dev deps / production patches
- cap open PRs at 5 (npm) and 3 (github-actions)
- ignore `@types/node` major bumps (track with Node runtime upgrades)
- github-actions: weekly → monthly, grouped

## Expected effect
~2–4 npm PRs/week instead of many individual daily PRs during active upstream releases.

## Test plan
- [ ] Confirm Dependabot picks up new config after merge
- [ ] Verify next update cycle opens grouped PRs instead of per-package floods