### PR TITLE
fix(database): split schema PUT vs PATCH for honest field updates

### DIFF
--- a/modules/database/jest.config.cjs
+++ b/modules/database/jest.config.cjs
@@ -1,0 +1,15 @@
+/** @type {import('ts-jest').JestConfigWithTsJest} */
+module.exports = {
+  testEnvironment: 'node',
+  extensionsToTreatAsEsm: ['.ts'],
+  moduleNameMapper: {
+    '^(\\.{1,2}/.*)\\.js$': '$1',
+  },
+  transform: {
+    '^.+\\.tsx?$': [
+      'ts-jest',
+      { useESM: true, tsconfig: '<rootDir>/tsconfig.jest.json' },
+    ],
+  },
+  testMatch: ['<rootDir>/src/**/__tests__/**/*.test.ts'],
+};

--- a/modules/database/package.json
+++ b/modules/database/package.json
@@ -25,7 +25,8 @@
     "build": "rimraf dist && tsc",
     "postbuild": "copyfiles -u 1 src/*.proto ./dist/ && copyfiles -u 3 src/adapters/mongoose-adapter/deep-populate.js ./dist/adapters/mongoose-adapter/",
     "build:docker": "docker build -t ghcr.io/conduitplatform/database:latest -f ./Dockerfile ../../ && docker push ghcr.io/conduitplatform/database:latest",
-    "generateTypes": "sh build.sh"
+    "generateTypes": "sh build.sh",
+    "test": "NODE_OPTIONS=--experimental-vm-modules jest"
   },
   "license": "ISC",
   "dependencies": {
@@ -63,12 +64,16 @@
     "registry": "https://npm.pkg.github.com/"
   },
   "devDependencies": {
+    "@jest/globals": "^30.3.0",
     "@types/convict": "^6.1.6",
+    "@types/jest": "^30.0.0",
     "@types/object-hash": "^3.0.6",
     "@types/lodash-es": "^4.17.12",
     "@types/node": "24.13.2",
     "copyfiles": "^2.4.1",
+    "jest": "^30.3.0",
     "rimraf": "^6.1.3",
+    "ts-jest": "^29.4.9",
     "ts-proto": "^2.11.9",
     "typescript": "~6.0.3"
   }

--- a/modules/database/src/admin/__tests__/schema.admin.put-patch.test.ts
+++ b/modules/database/src/admin/__tests__/schema.admin.put-patch.test.ts
@@ -1,0 +1,202 @@
+import { describe, expect, it, jest } from '@jest/globals';
+import { status } from '@grpc/grpc-js';
+import { ConduitGrpcSdk, ParsedRouterRequest } from '@conduitplatform/grpc-sdk';
+import { SchemaAdmin } from '../schema.admin.js';
+import { DatabaseAdapter } from '../../adapters/DatabaseAdapter.js';
+import { MongooseSchema } from '../../adapters/mongoose-adapter/MongooseSchema.js';
+import { SequelizeSchema } from '../../adapters/sequelize-adapter/SequelizeSchema.js';
+import { SchemaController } from '../../controllers/cms/schema.controller.js';
+import { CustomEndpointController } from '../../controllers/customEndpoints/customEndpoint.controller.js';
+
+function makeCall(params: Record<string, unknown>): ParsedRouterRequest {
+  return { request: { params } } as unknown as ParsedRouterRequest;
+}
+
+function makeRequestedSchema(overrides: Record<string, unknown> = {}) {
+  return {
+    _id: 'schema-1',
+    name: 'TestSchema',
+    fields: { title: 'String' },
+    modelOptions: {
+      conduit: {
+        cms: { enabled: true },
+        authorization: { enabled: false },
+        permissions: {
+          extendable: true,
+          canCreate: true,
+          canModify: 'Everything',
+          canDelete: true,
+        },
+      },
+    },
+    ...overrides,
+  };
+}
+
+function setup(requestedSchema: ReturnType<typeof makeRequestedSchema>) {
+  const findOne = jest.fn().mockResolvedValue(requestedSchema);
+  const deleteMany = jest.fn().mockResolvedValue(undefined);
+  const getSchemaModel = jest.fn().mockReturnValue({ model: { findOne, deleteMany } });
+  const isAvailable = jest.fn().mockReturnValue(true);
+  const createSchema = jest
+    .fn()
+    .mockImplementation((schema: unknown) => Promise.resolve(schema));
+
+  const database = { getSchemaModel } as unknown as DatabaseAdapter<
+    MongooseSchema | SequelizeSchema
+  >;
+  const grpcSdk = { isAvailable } as unknown as ConduitGrpcSdk;
+  const schemaController = { createSchema } as unknown as SchemaController;
+  const customEndpointController = {} as unknown as CustomEndpointController;
+
+  const admin = new SchemaAdmin(
+    grpcSdk,
+    database,
+    schemaController,
+    customEndpointController,
+  );
+  return { admin, findOne, deleteMany, getSchemaModel, isAvailable, createSchema };
+}
+
+function schemaNameArgs(getSchemaModel: ReturnType<typeof setup>['getSchemaModel']) {
+  return getSchemaModel.mock.calls.map((call: unknown[]) => call[0]);
+}
+
+describe('SchemaAdmin PUT/PATCH split', () => {
+  describe('putSchema', () => {
+    it('replaces the fields map entirely instead of merging', async () => {
+      const requestedSchema = makeRequestedSchema({
+        fields: { title: 'String', legacy: 'String' },
+      });
+      const { admin, createSchema } = setup(requestedSchema);
+
+      await admin.putSchema(makeCall({ id: 'schema-1', fields: { name: 'String' } }));
+
+      expect(createSchema).toHaveBeenCalledTimes(1);
+      const [writtenSchema, operation] = createSchema.mock.calls[0];
+      expect(writtenSchema.fields).toEqual({ name: 'String' });
+      expect(operation).toBe('update');
+    });
+
+    it('throws INVALID_ARGUMENT when fields is missing', async () => {
+      const { admin } = setup(makeRequestedSchema());
+
+      await expect(admin.putSchema(makeCall({ id: 'schema-1' }))).rejects.toMatchObject({
+        code: status.INVALID_ARGUMENT,
+      });
+    });
+
+    it('throws INVALID_ARGUMENT when fields is an empty object', async () => {
+      const { admin } = setup(makeRequestedSchema());
+
+      await expect(
+        admin.putSchema(makeCall({ id: 'schema-1', fields: {} })),
+      ).rejects.toMatchObject({ code: status.INVALID_ARGUMENT });
+    });
+
+    it('validates the fields being written, not the schema previous state', async () => {
+      const { admin } = setup(makeRequestedSchema());
+
+      await expect(
+        admin.putSchema(
+          makeCall({ id: 'schema-1', fields: { bad: { type: 'NotARealType' } } }),
+        ),
+      ).rejects.toMatchObject({ code: status.INTERNAL });
+    });
+
+    it('wipes existing documents when enabling authorization', async () => {
+      const requestedSchema = makeRequestedSchema();
+      const { admin, getSchemaModel, deleteMany } = setup(requestedSchema);
+
+      await admin.putSchema(
+        makeCall({
+          id: 'schema-1',
+          fields: { title: 'String' },
+          conduitOptions: { authorization: { enabled: true } },
+        }),
+      );
+
+      expect(schemaNameArgs(getSchemaModel)).toContain('TestSchema');
+      expect(deleteMany).toHaveBeenCalledWith({});
+    });
+
+    it('throws FAILED_PRECONDITION when enabling authorization without the service available', async () => {
+      const { admin, isAvailable } = setup(makeRequestedSchema());
+      isAvailable.mockReturnValue(false);
+
+      await expect(
+        admin.putSchema(
+          makeCall({
+            id: 'schema-1',
+            fields: { title: 'String' },
+            conduitOptions: { authorization: { enabled: true } },
+          }),
+        ),
+      ).rejects.toMatchObject({ code: status.FAILED_PRECONDITION });
+    });
+  });
+
+  describe('patchSchema', () => {
+    it('updates conduitOptions only, preserving existing fields', async () => {
+      const requestedSchema = makeRequestedSchema({
+        fields: { title: 'String', legacy: 'String' },
+      });
+      const { admin, createSchema } = setup(requestedSchema);
+
+      await admin.patchSchema(
+        makeCall({ id: 'schema-1', conduitOptions: { cms: { enabled: false } } }),
+      );
+
+      expect(createSchema).toHaveBeenCalledTimes(1);
+      const [writtenSchema] = createSchema.mock.calls[0];
+      expect(writtenSchema.fields).toEqual({ title: 'String', legacy: 'String' });
+      expect(writtenSchema.modelOptions.conduit.cms.enabled).toBe(false);
+    });
+
+    it('throws INVALID_ARGUMENT when neither fields nor conduitOptions are provided', async () => {
+      const { admin } = setup(makeRequestedSchema());
+
+      await expect(admin.patchSchema(makeCall({ id: 'schema-1' }))).rejects.toMatchObject(
+        {
+          code: status.INVALID_ARGUMENT,
+        },
+      );
+    });
+
+    it('delegates to putSchema and fully replaces fields when fields are provided (deprecation bridge)', async () => {
+      const requestedSchema = makeRequestedSchema({
+        fields: { title: 'String', legacy: 'String' },
+      });
+      const { admin, createSchema } = setup(requestedSchema);
+      const putSchemaSpy = jest.spyOn(admin, 'putSchema');
+      const warnSpy = jest
+        .spyOn(ConduitGrpcSdk.Logger, 'warn')
+        .mockImplementation(() => {});
+
+      const call = makeCall({ id: 'schema-1', fields: { name: 'String' } });
+      await admin.patchSchema(call);
+
+      expect(putSchemaSpy).toHaveBeenCalledWith(call);
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      expect(warnSpy.mock.calls[0][0]).toMatch(/PUT/);
+      const [writtenSchema] = createSchema.mock.calls[0];
+      expect(writtenSchema.fields).toEqual({ name: 'String' });
+
+      warnSpy.mockRestore();
+    });
+
+    it('wipes existing documents when enabling authorization via conduitOptions', async () => {
+      const requestedSchema = makeRequestedSchema();
+      const { admin, deleteMany } = setup(requestedSchema);
+
+      await admin.patchSchema(
+        makeCall({
+          id: 'schema-1',
+          conduitOptions: { authorization: { enabled: true } },
+        }),
+      );
+
+      expect(deleteMany).toHaveBeenCalledWith({});
+    });
+  });
+});

--- a/modules/database/src/admin/index.ts
+++ b/modules/database/src/admin/index.ts
@@ -22,11 +22,7 @@ import { SchemaAdmin } from './schema.admin.js';
 import { SchemaController } from '../controllers/cms/schema.controller.js';
 import { CustomEndpointController } from '../controllers/customEndpoints/customEndpoint.controller.js';
 import { CustomEndpoints, DeclaredSchema, PendingSchemas } from '../models/index.js';
-import {
-  ConduitOptions,
-  SchemaFieldsRequired,
-  SchemaFieldsOptional,
-} from '../interfaces/index.js';
+import { ConduitOptions, SchemaFieldsRequired } from '../interfaces/index.js';
 
 export class AdminHandlers {
   private readonly schemaAdmin: SchemaAdmin;
@@ -178,13 +174,28 @@ export class AdminHandlers {
     this.routingManager.route(
       {
         path: '/schemas/:id',
-        action: ConduitRouteActions.PATCH,
-        description: `Updates a schema.`,
+        action: ConduitRouteActions.UPDATE,
+        description: `Replaces the entire schema fields map. Call GET /database/schemas/:id first and send the complete merged fields object. Optionally update conduitOptions.`,
         urlParams: {
           id: { type: TYPE.String, required: true },
         },
         bodyParams: {
-          fields: SchemaFieldsOptional,
+          fields: SchemaFieldsRequired,
+          conduitOptions: ConduitOptions,
+        },
+      },
+      new ConduitRouteReturnDefinition('PutSchema', '_DeclaredSchema'),
+      this.schemaAdmin.putSchema.bind(this.schemaAdmin),
+    );
+    this.routingManager.route(
+      {
+        path: '/schemas/:id',
+        action: ConduitRouteActions.PATCH,
+        description: `Updates schema settings (conduitOptions) only. Does not modify fields. Use PUT /database/schemas/:id for field updates.`,
+        urlParams: {
+          id: { type: TYPE.String, required: true },
+        },
+        bodyParams: {
           conduitOptions: ConduitOptions,
         },
       },

--- a/modules/database/src/admin/schema.admin.ts
+++ b/modules/database/src/admin/schema.admin.ts
@@ -275,36 +275,19 @@ export class SchemaAdmin {
       .model.findOne({ name }, { readPreference: 'primary' });
   }
 
-  async patchSchema(call: ParsedRouterRequest): Promise<UnparsedRouterResponse> {
+  async putSchema(call: ParsedRouterRequest): Promise<UnparsedRouterResponse> {
     const { id, fields } = call.request.params;
-    const requestedSchema = await this.checkRequestedSchema(id);
-    requestedSchema.fields = fields ?? requestedSchema.fields;
-    if (
-      !requestedSchema.modelOptions.conduit.authorization?.enabled &&
-      call.request.params.conduitOptions?.authorization?.enabled
-    ) {
-      // wipe all data when enabling authz
-      await this.database.getSchemaModel(requestedSchema.name).model.deleteMany({});
-    }
-    const modelOptions = SchemaConverter.getModelOptions({
-      cmsSchema: true,
-      cms: call.request.params.conduitOptions?.cms,
-      authorization: call.request.params.conduitOptions?.authorization,
-      permissions: call.request.params.conduitOptions?.permissions,
-      readPreference: call.request.params.conduitOptions?.readPreference,
-      existingModelOptions: requestedSchema.modelOptions,
-    });
-    if (
-      call.request.params.conduitOptions?.authorization?.enabled &&
-      !this.grpcSdk.isAvailable('authorization')
-    ) {
+    if (isNil(fields) || isEmpty(fields)) {
       throw new GrpcError(
-        status.FAILED_PRECONDITION,
-        'Authorization service is not available',
+        status.INVALID_ARGUMENT,
+        "Argument 'fields' is required and must be a non-empty object!",
       );
     }
+    const requestedSchema = await this.checkRequestedSchema(id);
+    requestedSchema.fields = fields;
+    const modelOptions = await this.applySchemaOptionsUpdate(call, requestedSchema);
     try {
-      validateSchemaInput(requestedSchema.name, fields, modelOptions);
+      validateSchemaInput(requestedSchema.name, requestedSchema.fields, modelOptions);
     } catch (err: unknown) {
       throw new GrpcError(status.INTERNAL, (err as Error).message);
     }
@@ -313,6 +296,66 @@ export class SchemaAdmin {
       new ConduitSchema(requestedSchema.name, requestedSchema.fields, modelOptions),
       'update',
     );
+  }
+
+  async patchSchema(call: ParsedRouterRequest): Promise<UnparsedRouterResponse> {
+    const { fields, conduitOptions } = call.request.params;
+    if (!isNil(fields)) {
+      ConduitGrpcSdk.Logger.warn(
+        "PATCH /schemas/:id with 'fields' is deprecated and will be removed in a future release. Use PUT /schemas/:id to update schema fields instead.",
+      );
+      return this.putSchema(call);
+    }
+    if (isNil(conduitOptions)) {
+      throw new GrpcError(
+        status.INVALID_ARGUMENT,
+        "Argument 'conduitOptions' is required!",
+      );
+    }
+    const requestedSchema = await this.checkRequestedSchema(call.request.params.id);
+    const modelOptions = await this.applySchemaOptionsUpdate(call, requestedSchema);
+    try {
+      validateSchemaInput(requestedSchema.name, undefined, modelOptions);
+    } catch (err: unknown) {
+      throw new GrpcError(status.INTERNAL, (err as Error).message);
+    }
+
+    return this.schemaController.createSchema(
+      new ConduitSchema(requestedSchema.name, requestedSchema.fields, modelOptions),
+      'update',
+    );
+  }
+
+  private async applySchemaOptionsUpdate(
+    call: ParsedRouterRequest,
+    requestedSchema: ConduitDatabaseSchema,
+  ) {
+    const conduitOptions = call.request.params.conduitOptions;
+    if (
+      !requestedSchema.modelOptions.conduit?.authorization?.enabled &&
+      conduitOptions?.authorization?.enabled
+    ) {
+      // wipe all data when enabling authz
+      await this.database.getSchemaModel(requestedSchema.name).model.deleteMany({});
+    }
+    const modelOptions = SchemaConverter.getModelOptions({
+      cmsSchema: true,
+      cms: conduitOptions?.cms,
+      authorization: conduitOptions?.authorization,
+      permissions: conduitOptions?.permissions,
+      readPreference: conduitOptions?.readPreference,
+      existingModelOptions: requestedSchema.modelOptions,
+    });
+    if (
+      conduitOptions?.authorization?.enabled &&
+      !this.grpcSdk.isAvailable('authorization')
+    ) {
+      throw new GrpcError(
+        status.FAILED_PRECONDITION,
+        'Authorization service is not available',
+      );
+    }
+    return modelOptions;
   }
 
   async deleteSchema(call: ParsedRouterRequest): Promise<UnparsedRouterResponse> {

--- a/modules/database/src/utils/utilities.ts
+++ b/modules/database/src/utils/utilities.ts
@@ -56,7 +56,7 @@ export function wrongFields(schemaFields: string[], updateFields: string[]): boo
 
 export function validateSchemaInput(
   name: string,
-  fields: ConduitModel,
+  fields: ConduitModel | undefined,
   modelOptions: ConduitSchemaOptions,
 ) {
   if (!isNil(name) && !isString(name))

--- a/modules/database/tsconfig.jest.json
+++ b/modules/database/tsconfig.jest.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "isolatedModules": true
+  }
+}

--- a/modules/database/tsconfig.json
+++ b/modules/database/tsconfig.json
@@ -65,5 +65,6 @@
 
     /* Advanced Options */
     "forceConsistentCasingInFileNames": true /* Disallow inconsistently-cased references to the same file. */
-  }
+  },
+  "exclude": ["src/**/__tests__/**"]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -850,9 +850,15 @@ importers:
         specifier: ^6.0.1
         version: 6.0.1
     devDependencies:
+      '@jest/globals':
+        specifier: ^30.3.0
+        version: 30.4.1
       '@types/convict':
         specifier: ^6.1.6
         version: 6.1.6
+      '@types/jest':
+        specifier: ^30.0.0
+        version: 30.0.0
       '@types/lodash-es':
         specifier: ^4.17.12
         version: 4.17.12
@@ -865,9 +871,15 @@ importers:
       copyfiles:
         specifier: ^2.4.1
         version: 2.4.1
+      jest:
+        specifier: ^30.3.0
+        version: 30.4.2(@types/node@24.13.2)(ts-node@10.9.2(@types/node@24.13.2)(typescript@6.0.3))
       rimraf:
         specifier: ^6.1.3
         version: 6.1.3
+      ts-jest:
+        specifier: ^29.4.9
+        version: 29.4.11(@babel/core@7.29.7)(@jest/transform@30.4.1)(@jest/types@30.4.1)(babel-jest@30.4.1(@babel/core@7.29.7))(jest-util@30.4.1)(jest@30.4.2(@types/node@24.13.2)(ts-node@10.9.2(@types/node@24.13.2)(typescript@6.0.3)))(typescript@6.0.3)
       ts-proto:
         specifier: ^2.11.9
         version: 2.11.9
@@ -14468,7 +14480,7 @@ snapshots:
     dependencies:
       hosted-git-info: 4.1.0
       is-core-module: 2.16.2
-      semver: 7.8.4
+      semver: 7.8.5
       validate-npm-package-license: 3.0.4
 
   normalize-path@3.0.0: {}
@@ -15743,7 +15755,7 @@ snapshots:
       json5: 2.2.3
       lodash.memoize: 4.1.2
       make-error: 1.3.6
-      semver: 7.8.4
+      semver: 7.8.5
       type-fest: 4.41.0
       typescript: 6.0.3
       yargs-parser: 21.1.1


### PR DESCRIPTION
## Summary
- Adds `PUT /database/schemas/:id` for full field-map replacement (`put_database_schemas_id` in MCP)
- Narrows `PATCH /database/schemas/:id` to `conduitOptions` only (`patch_database_schemas_id`)
- Keeps a deprecation bridge: PATCH with `fields` logs a warning and delegates to PUT
- Adds jest coverage for PUT/PATCH handler behavior in the database module

## Why
MCP agents treated PATCH as partial merge and lost fields when sending incremental updates. PUT makes full-replacement semantics explicit; PATCH is reserved for CMS/auth settings.

## Related
- Conduit-UI: `feat/schema-put-patch-split` (schema editor uses PUT)
- conduit-cursor-plugin: `feat/schema-put-patch-docs` (agent skill updates)

## Test plan
- [x] `cd modules/database && pnpm run build`
- [x] `cd modules/database && pnpm run test` (10 tests)
- [ ] Manual: create schema, PUT full fields, PATCH conduitOptions only
- [ ] Manual: verify MCP exposes `put_database_schemas_id` with required `fields`