### PR TITLE
feat(chat): add file attachments to sendMessage gRPC

### DIFF
--- a/modules/chat/src/Chat.ts
+++ b/modules/chat/src/Chat.ts
@@ -175,7 +175,8 @@ export default class Chat extends ManagedModule<Config> {
 
   async sendMessage(call: GrpcRequest<SendMessageRequest>, callback: GrpcCallback<null>) {
     const userId = call.request.userId;
-    const { roomId, message, messageType, persist } = call.request;
+    const { roomId, message, messageType, persist, files } = call.request;
+    const requestFiles = files ?? [];
 
     let errorMessage: string | null = null;
     const room = await models.ChatRoom.getInstance()
@@ -191,10 +192,48 @@ export default class Chat extends ManagedModule<Config> {
       return callback({ code: status.INVALID_ARGUMENT, message: 'invalid room' });
     }
 
+    const resolvedType = (messageType || MessageType.Text) as MessageType;
+    const isFileMessage = [MessageType.File, MessageType.Multimedia].includes(
+      resolvedType,
+    );
+
+    if (!['text', 'file', 'typing', 'multimedia', 'system'].includes(resolvedType)) {
+      return callback({
+        code: status.INVALID_ARGUMENT,
+        message:
+          'Invalid contentType, must be one of: text, file, typing, multimedia, system',
+      });
+    }
+
+    if (isFileMessage && requestFiles.length === 0) {
+      return callback({
+        code: status.INVALID_ARGUMENT,
+        message: `Files are required for ${resolvedType} messages`,
+      });
+    }
+
+    if (isFileMessage && !Array.isArray(requestFiles)) {
+      return callback({
+        code: status.INVALID_ARGUMENT,
+        message: `Files must be an array for ${resolvedType} messages`,
+      });
+    }
+
+    if (
+      [MessageType.Text, MessageType.Multimedia, MessageType.System].includes(
+        resolvedType,
+      ) &&
+      !message
+    ) {
+      return callback({
+        code: status.INVALID_ARGUMENT,
+        message: `${resolvedType} messages need to have content`,
+      });
+    }
+
     const shouldPersist = persist !== false;
     let messageId: string | undefined;
     const createdAt = new Date().toISOString();
-    const resolvedType = messageType || MessageType.Text;
 
     try {
       if (shouldPersist) {
@@ -204,6 +243,7 @@ export default class Chat extends ManagedModule<Config> {
             _id: messageId,
             message,
             messageType: resolvedType,
+            ...(requestFiles.length > 0 ? { files: requestFiles } : {}),
             senderUser: userId,
             room: roomId,
             readBy: [userId],
@@ -234,6 +274,7 @@ export default class Chat extends ManagedModule<Config> {
           sender: userId,
           content: message,
           message,
+          ...(requestFiles.length > 0 ? { files: requestFiles } : {}),
           room: roomId,
           contentType: resolvedType,
           createdAt,

--- a/modules/chat/src/chat.proto
+++ b/modules/chat/src/chat.proto
@@ -13,6 +13,7 @@ message SendMessageRequest {
   string roomId = 3;
   optional string messageType = 4;
   optional bool persist = 5;
+  repeated string files = 6;
 }
 
 message DeleteRoomRequest {


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Adds storage file ID support to the chat module `sendMessage` gRPC API so trusted server-side callers can send `file` and `multimedia` messages with the same semantics as socket messages.

- Extend `SendMessageRequest` in `chat.proto` with `repeated string files = 6`
- Validate `file` / `multimedia` messages require at least one file ID
- Persist and broadcast `files` only when file IDs are present
- Keep existing text/system callers backward compatible

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Regenerated chat/grpc-sdk proto types locally (`pnpm --filter @conduitplatform/chat run generateTypes`, `pnpm --filter @conduitplatform/grpc-sdk run protoc`)
- [x] Verified `Chat.ts` has no new linter issues

**Test Configuration**:
* Firmware version:
* Hardware:
* Toolchain: Node.js, pnpm, protoc/ts-proto
* SDK: `@conduitplatform/grpc-sdk` on `v0.16.x`

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules