### PR TITLE
feat(chat): add file attachments to sendMessage gRPC

### DIFF
--- a/modules/chat/src/Chat.ts
+++ b/modules/chat/src/Chat.ts
@@ -214,7 +214,8 @@ export default class Chat extends ManagedModule<Config> {
     callback: GrpcCallback<Record<string, never>>,
   ) {
     const userId = call.request.userId;
-    const { roomId, message, messageType, persist } = call.request;
+    const { roomId, message, messageType, persist, files } = call.request;
+    const requestFiles = files ?? [];
 
     let errorMessage: string | null = null;
     const room = await models.ChatRoom.getInstance()
@@ -230,10 +231,48 @@ export default class Chat extends ManagedModule<Config> {
       return callback({ code: status.INVALID_ARGUMENT, message: 'invalid room' });
     }
 
+    const resolvedType = (messageType || MessageType.Text) as MessageType;
+    const isFileMessage = [MessageType.File, MessageType.Multimedia].includes(
+      resolvedType,
+    );
+
+    if (!['text', 'file', 'typing', 'multimedia', 'system'].includes(resolvedType)) {
+      return callback({
+        code: status.INVALID_ARGUMENT,
+        message:
+          'Invalid contentType, must be one of: text, file, typing, multimedia, system',
+      });
+    }
+
+    if (isFileMessage && requestFiles.length === 0) {
+      return callback({
+        code: status.INVALID_ARGUMENT,
+        message: `Files are required for ${resolvedType} messages`,
+      });
+    }
+
+    if (isFileMessage && !Array.isArray(requestFiles)) {
+      return callback({
+        code: status.INVALID_ARGUMENT,
+        message: `Files must be an array for ${resolvedType} messages`,
+      });
+    }
+
+    if (
+      [MessageType.Text, MessageType.Multimedia, MessageType.System].includes(
+        resolvedType,
+      ) &&
+      !message
+    ) {
+      return callback({
+        code: status.INVALID_ARGUMENT,
+        message: `${resolvedType} messages need to have content`,
+      });
+    }
+
     const shouldPersist = persist !== false;
     let messageId: string | undefined;
     const createdAt = new Date().toISOString();
-    const resolvedType = messageType || MessageType.Text;
 
     try {
       if (shouldPersist) {
@@ -243,6 +282,7 @@ export default class Chat extends ManagedModule<Config> {
             _id: messageId,
             message,
             messageType: resolvedType,
+            ...(requestFiles.length > 0 ? { files: requestFiles } : {}),
             senderUser: userId,
             room: roomId,
             readBy: [userId],
@@ -273,6 +313,7 @@ export default class Chat extends ManagedModule<Config> {
           sender: userId,
           content: message,
           message,
+          ...(requestFiles.length > 0 ? { files: requestFiles } : {}),
           room: roomId,
           contentType: resolvedType,
           createdAt,

--- a/modules/chat/src/chat.proto
+++ b/modules/chat/src/chat.proto
@@ -13,6 +13,7 @@ message SendMessageRequest {
   string roomId = 3;
   optional string messageType = 4;
   optional bool persist = 5;
+  repeated string files = 6;
 }
 
 message DeleteRoomRequest {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/ConduitPlatform/Conduit/blob/main/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** <!--(check at least one)-->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other (please describe)

**Does this PR introduce a breaking change?** <!-- (check one) -->

- [ ] Yes
- [x] No

<!-- If yes, please describe the impact and migration path for existing applications. -->

**The PR fulfills these requirements:**

- [x] It's submitted to the `main` branch
- [ ] When resolving a specific issue, it's referenced in the PR's description  (e.g. `fix #xxx`, where "xxx" is the issue number)

If adding a **new feature**, the PR's description includes:

- [x] A convincing reason for adding this feature <!-- to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it -->

**Other information:**

Backports the `sendMessage` gRPC file attachment support from `v0.16.x` (`b9db30e7`) onto `main`.

- Adds `repeated string files` to `SendMessageRequest` in `chat.proto`
- Extends gRPC `sendMessage` validation, persistence, and socket broadcast to match existing socket route behavior for `file` and `multimedia` messages

## Test plan
- [x] `pnpm --filter @conduitplatform/chat build`
- [ ] Manual: call gRPC `sendMessage` with `messageType: 'file'` and storage file IDs; confirm DB persistence and socket payload include `files`
- [ ] Manual: verify `INVALID_ARGUMENT` for file/multimedia messages without `files`