### PR TITLE
fix(grpc-sdk): make chat sendMessage files optional at SDK boundary

### DIFF
--- a/libraries/grpc-sdk/src/modules/chat/index.ts
+++ b/libraries/grpc-sdk/src/modules/chat/index.ts
@@ -1,6 +1,10 @@
 import { ConduitModule } from '../../classes/index.js';
 import { ChatDefinition, Room, SendMessageRequest } from '../../protoUtils/chat.js';
 
+export type SendMessageInput = Omit<SendMessageRequest, 'files'> & {
+  files?: SendMessageRequest['files'];
+};
+
 export class Chat extends ConduitModule<typeof ChatDefinition> {
   constructor(
     private readonly moduleName: string,
@@ -11,8 +15,8 @@ export class Chat extends ConduitModule<typeof ChatDefinition> {
     this.initializeClient(ChatDefinition);
   }
 
-  sendMessage(messageData: SendMessageRequest): Promise<any> {
-    return this.client!.sendMessage(messageData);
+  sendMessage(messageData: SendMessageInput): Promise<any> {
+    return this.client!.sendMessage(SendMessageRequest.fromPartial(messageData));
   }
 
   createRoom(name: string, participants: string[]): Promise<Room> {


### PR DESCRIPTION
Expose SendMessageInput with optional files and normalize via SendMessageRequest.fromPartial so existing callers are not broken by ts-proto's required repeated-field typing.

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/ConduitPlatform/Conduit/blob/main/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** <!--(check at least one)-->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other (please describe)

**Does this PR introduce a breaking change?** <!-- (check one) -->

- [ ] Yes
- [x] No

<!-- If yes, please describe the impact and migration path for existing applications. -->

**The PR fulfills these requirements:**

- [ ] It's submitted to the `main` branch
- [ ] When resolving a specific issue, it's referenced in the PR's description  (e.g. `fix #xxx`, where "xxx" is the issue number)

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature <!-- to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it -->

**Other information:**
