### PR TITLE
feat(database): disable eager collection creation for all schemas

### DIFF
--- a/modules/database/src/adapters/mongoose-adapter/MongooseSchema.ts
+++ b/modules/database/src/adapters/mongoose-adapter/MongooseSchema.ts
@@ -65,12 +65,8 @@ export class MongooseSchema extends SchemaAdapter<Model<any>> {
     this.schemaLevelReadPreference = schemaRp;
     const mongooseSchema = new Schema(cloneDeep(schema.fields as Indexable), {
       ...mo,
-      ...(isView
-        ? {
-            autoCreate: false,
-            autoIndex: false,
-          }
-        : {}),
+      autoCreate: false,
+      autoIndex: false,
     });
     this.model = mongoose.model(cloneDeep(schema.name), mongooseSchema);
   }

--- a/modules/database/src/adapters/mongoose-adapter/index.ts
+++ b/modules/database/src/adapters/mongoose-adapter/index.ts
@@ -1,4 +1,5 @@
 import { ConnectOptions, Mongoose, Types } from 'mongoose';
+import type { IndexSpecification } from 'mongodb';
 import { MongooseSchema } from './MongooseSchema.js';
 import { schemaConverter } from './SchemaConverter.js';
 import {
@@ -650,17 +651,21 @@ export class MongooseAdapter extends DatabaseAdapter<MongooseSchema> {
 
     const collection = this.mongoose.model(schemaName).collection;
     for (const [keys, rawOptions] of declaredIndexes) {
-      if (this.isDefaultIdIndex(keys)) continue;
+      const indexKeys = keys as IndexSpecification;
+      if (this.isDefaultIdIndex(indexKeys)) continue;
 
-      const options = this.sanitizeMongooseIndexOptions(rawOptions);
-      await collection.createIndex(keys, options).catch((e: Error) => {
+      const options = this.sanitizeMongooseIndexOptions(
+        rawOptions as Record<string, unknown>,
+      );
+      await collection.createIndex(indexKeys, options).catch((e: Error) => {
         throw new GrpcError(status.INTERNAL, e.message);
       });
     }
   }
 
-  private isDefaultIdIndex(keys: Record<string, unknown>): boolean {
-    const entries = Object.entries(keys);
+  private isDefaultIdIndex(keys: IndexSpecification): boolean {
+    if (!keys || typeof keys !== 'object' || Array.isArray(keys)) return false;
+    const entries = Object.entries(keys as Record<string, unknown>);
     return entries.length === 1 && entries[0][0] === '_id' && entries[0][1] === 1;
   }
 

--- a/modules/database/src/adapters/mongoose-adapter/index.ts
+++ b/modules/database/src/adapters/mongoose-adapter/index.ts
@@ -640,6 +640,39 @@ export class MongooseAdapter extends DatabaseAdapter<MongooseSchema> {
     return 'Indexes created!';
   }
 
+  private async createMongooseFieldIndexes(schemaName: string): Promise<void> {
+    const model = this.models[schemaName];
+    if (!model) throw new GrpcError(status.NOT_FOUND, 'Requested schema not found');
+    if (model.isView) return;
+
+    const declaredIndexes = model.model.schema.indexes();
+    if (!declaredIndexes.length) return;
+
+    const collection = this.mongoose.model(schemaName).collection;
+    for (const [keys, rawOptions] of declaredIndexes) {
+      if (this.isDefaultIdIndex(keys)) continue;
+
+      const options = this.sanitizeMongooseIndexOptions(rawOptions);
+      await collection.createIndex(keys, options).catch((e: Error) => {
+        throw new GrpcError(status.INTERNAL, e.message);
+      });
+    }
+  }
+
+  private isDefaultIdIndex(keys: Record<string, unknown>): boolean {
+    const entries = Object.entries(keys);
+    return entries.length === 1 && entries[0][0] === '_id' && entries[0][1] === 1;
+  }
+
+  private sanitizeMongooseIndexOptions(
+    options?: Record<string, unknown>,
+  ): Record<string, unknown> | undefined {
+    if (!options) return undefined;
+    const sanitized = { ...options };
+    delete sanitized._autoIndex;
+    return Object.keys(sanitized).length > 0 ? sanitized : undefined;
+  }
+
   async getIndexes(schemaName: string): Promise<ModelOptionsIndexes[]> {
     if (!this.models[schemaName])
       throw new GrpcError(status.NOT_FOUND, 'Requested schema not found');
@@ -805,6 +838,9 @@ export class MongooseAdapter extends DatabaseAdapter<MongooseSchema> {
 
     if (indexes && !isInstanceSync) {
       await this.createIndexes(schema.name, indexes, schema.ownerModule);
+    }
+    if (!isInstanceSync) {
+      await this.createMongooseFieldIndexes(schema.name);
     }
     return this.models[schema.name];
   }


### PR DESCRIPTION
## Summary
- Set `autoCreate: false` and `autoIndex: false` on every Mongoose schema in the database adapter, not just views.
- Collections are now created lazily on first write instead of at schema registration time, reducing empty collections on shared dev MongoDB clusters.
- Index creation remains handled explicitly by Conduit's `createIndexes()` during schema registration.

## Test plan
- [ ] Start Conduit with MongoDB and register schemas that have no custom indexes; verify no empty collections are created until the first document insert.
- [ ] Register a schema with custom indexes and confirm indexes are still created correctly.
- [ ] Run `findMany` / `findOne` against a schema whose collection has not been created yet and confirm empty results are returned without errors.
- [ ] Verify view schemas still behave correctly.