### PR TITLE
feat(storage): add URL upload/download support for local storage provider

### DIFF
--- a/modules/storage/src/Storage.ts
+++ b/modules/storage/src/Storage.ts
@@ -209,6 +209,14 @@ export default class Storage extends ManagedModule<Config> {
         config.aws.usePathStyle = false;
       }
     }
+    if (config.provider === 'local') {
+      const secret = config.local?.signingSecret?.trim() ?? '';
+      if (secret && !/^[0-9a-fA-F]{64}$/.test(secret)) {
+        throw new Error(
+          "local.signingSecret must be a 64-character hex string (32 bytes). Generate one with: node -e \"console.log(require('crypto').randomBytes(32).toString('hex'))\"",
+        );
+      }
+    }
     return config;
   }
 

--- a/modules/storage/src/Storage.ts
+++ b/modules/storage/src/Storage.ts
@@ -221,6 +221,9 @@ export default class Storage extends ManagedModule<Config> {
       this._storageAuthzResourceDispose?.();
       this._storageAuthzResourceDispose = null;
       this.disposeDeclaredPeerWatches();
+      if (this.storageProvider?.dispose) {
+        await this.storageProvider.dispose();
+      }
       this.updateHealth(HealthCheckStatus.NOT_SERVING);
     } else {
       this.registerDeclaredPeerWatches();
@@ -238,6 +241,9 @@ export default class Storage extends ManagedModule<Config> {
       } else {
         this._storageAuthzResourceDispose?.();
         this._storageAuthzResourceDispose = null;
+      }
+      if (this.storageProvider?.dispose) {
+        await this.storageProvider.dispose();
       }
       this.storageProvider = createStorageProvider(provider, {
         local,

--- a/modules/storage/src/Storage.ts
+++ b/modules/storage/src/Storage.ts
@@ -51,6 +51,7 @@ import {
 import { StorageParamAdapter } from './adapter/StorageParamAdapter.js';
 import { FileResource } from './authz/index.js';
 import { AdminFileHandlers } from './admin/adminFile.js';
+import { randomBytes } from 'node:crypto';
 import { fileURLToPath } from 'node:url';
 
 const __filename = fileURLToPath(import.meta.url);
@@ -210,11 +211,15 @@ export default class Storage extends ManagedModule<Config> {
       }
     }
     if (config.provider === 'local') {
-      const secret = config.local?.signingSecret?.trim() ?? '';
-      if (secret && !/^[0-9a-fA-F]{64}$/.test(secret)) {
+      const secret = config.local.signingSecret?.trim() ?? '';
+      if (!secret) {
+        config.local.signingSecret = randomBytes(32).toString('hex');
+      } else if (!/^[0-9a-fA-F]{64}$/.test(secret)) {
         throw new Error(
           "local.signingSecret must be a 64-character hex string (32 bytes). Generate one with: node -e \"console.log(require('crypto').randomBytes(32).toString('hex'))\"",
         );
+      } else {
+        config.local.signingSecret = secret;
       }
     }
     return config;

--- a/modules/storage/src/config/config.ts
+++ b/modules/storage/src/config/config.ts
@@ -87,6 +87,11 @@ export default {
       default: '',
       doc: 'External base URL for local storage file URLs. Leave empty to auto-derive from httpPort (http://localhost:{httpPort}). Override when the storage server is behind a reverse proxy or running in Docker.',
     },
+    signingSecret: {
+      format: 'String',
+      default: '',
+      doc: 'Hex-encoded HMAC secret for signing file URLs. If empty, a random secret is generated on startup (URLs will not survive restarts).',
+    },
   },
   suffixOnNameConflict: {
     format: 'Boolean',

--- a/modules/storage/src/config/config.ts
+++ b/modules/storage/src/config/config.ts
@@ -77,6 +77,16 @@ export default {
       format: 'String',
       default: '/var/tmp',
     },
+    httpPort: {
+      format: 'Number',
+      default: 3100,
+      doc: 'Port for the local storage HTTP file server (serves uploads/downloads)',
+    },
+    httpBaseUrl: {
+      format: 'String',
+      default: 'http://localhost:3100',
+      doc: 'Base URL for local storage file URLs (override for Docker/CI)',
+    },
   },
   suffixOnNameConflict: {
     format: 'Boolean',

--- a/modules/storage/src/config/config.ts
+++ b/modules/storage/src/config/config.ts
@@ -90,7 +90,7 @@ export default {
     signingSecret: {
       format: 'String',
       default: '',
-      doc: 'Hex-encoded HMAC secret for signing file URLs. If empty, a random secret is generated on startup (URLs will not survive restarts).',
+      doc: 'Hex-encoded HMAC secret (64 hex chars / 32 bytes) for signing file URLs. Required for URLs to survive restarts — without it, a random secret is generated on startup and any public file URLs already stored in the database (sourceUrl/url) become invalid.',
     },
   },
   suffixOnNameConflict: {

--- a/modules/storage/src/config/config.ts
+++ b/modules/storage/src/config/config.ts
@@ -84,8 +84,8 @@ export default {
     },
     httpBaseUrl: {
       format: 'String',
-      default: 'http://localhost:3100',
-      doc: 'Base URL for local storage file URLs (override for Docker/CI)',
+      default: '',
+      doc: 'External base URL for local storage file URLs. Leave empty to auto-derive from httpPort (http://localhost:{httpPort}). Override when the storage server is behind a reverse proxy or running in Docker.',
     },
   },
   suffixOnNameConflict: {

--- a/modules/storage/src/config/config.ts
+++ b/modules/storage/src/config/config.ts
@@ -90,7 +90,7 @@ export default {
     signingSecret: {
       format: 'String',
       default: '',
-      doc: 'Hex-encoded HMAC secret (64 hex chars / 32 bytes) for signing file URLs. Required for URLs to survive restarts — without it, a random secret is generated on startup and any public file URLs already stored in the database (sourceUrl/url) become invalid.',
+      doc: 'Hex-encoded HMAC secret (64 hex chars / 32 bytes) for signing file URLs. Leave empty to generate and persist a random secret on first configure (survives restarts).',
     },
   },
   suffixOnNameConflict: {

--- a/modules/storage/src/interfaces/IStorageProvider.ts
+++ b/modules/storage/src/interfaces/IStorageProvider.ts
@@ -58,4 +58,9 @@ export interface IStorageProvider {
   getPublicUrl(fileName: string, containerIsPublic?: boolean): Promise<string | Error>;
 
   getUploadUrl(fileName: string): Promise<string | Error>;
+
+  /**
+   * Releases provider resources (e.g. local HTTP file server).
+   */
+  dispose?(): Promise<void>;
 }

--- a/modules/storage/src/interfaces/StorageConfig.ts
+++ b/modules/storage/src/interfaces/StorageConfig.ts
@@ -24,5 +24,7 @@ export interface StorageConfig {
   };
   local: {
     storagePath: string;
+    httpPort: number;
+    httpBaseUrl: string;
   };
 }

--- a/modules/storage/src/interfaces/StorageConfig.ts
+++ b/modules/storage/src/interfaces/StorageConfig.ts
@@ -26,5 +26,6 @@ export interface StorageConfig {
     storagePath: string;
     httpPort: number;
     httpBaseUrl: string;
+    signingSecret: string;
   };
 }

--- a/modules/storage/src/providers/local/index.ts
+++ b/modules/storage/src/providers/local/index.ts
@@ -7,15 +7,17 @@ import {
   createReadStream,
   createWriteStream,
   existsSync,
+  lstatSync,
   mkdirSync,
   readFile,
+  realpathSync,
   rmSync,
   unlink,
   writeFile,
 } from 'fs';
 import { createHmac, randomBytes, timingSafeEqual } from 'crypto';
 import { createServer, IncomingMessage, Server, ServerResponse } from 'http';
-import { dirname, extname, resolve, sep } from 'path';
+import { basename, dirname, extname, resolve, sep } from 'path';
 import { ConduitGrpcSdk } from '@conduitplatform/grpc-sdk';
 import { SIGNED_URL_EXPIRY } from '../../constants/expiry.js';
 import { constructDispositionHeader } from '../../utils/index.js';
@@ -52,6 +54,21 @@ const MIME_TYPES: Record<string, string> = {
 
 function getMimeType(filePath: string): string {
   return MIME_TYPES[extname(filePath).toLowerCase()] ?? 'application/octet-stream';
+}
+
+function canonicalizeSignedExtraParams(params?: URLSearchParams): string {
+  const canonicalParams = new URLSearchParams();
+  for (const key of ['download', 'fileName'] as const) {
+    const value = params?.get(key);
+    if (value != null) {
+      canonicalParams.set(key, value);
+    }
+  }
+  return canonicalParams.toString();
+}
+
+function isWithinRoot(rootPath: string, targetPath: string): boolean {
+  return targetPath === rootPath || targetPath.startsWith(rootPath + sep);
 }
 
 export class LocalStorage implements IStorageProvider {
@@ -98,6 +115,7 @@ export class LocalStorage implements IStorageProvider {
    */
   private startHttpServer(): void {
     const rootPath = resolve(this._rootStoragePath);
+    const realRoot = realpathSync(rootPath);
 
     this._httpServer = createServer((req: IncomingMessage, res: ServerResponse) => {
       res.setHeader('Access-Control-Allow-Origin', '*');
@@ -118,7 +136,13 @@ export class LocalStorage implements IStorageProvider {
         return res.end('Bad request');
       }
 
-      const relativePath = decodeURIComponent(url.pathname).replace(/^\/+/, '');
+      let relativePath: string;
+      try {
+        relativePath = decodeURIComponent(url.pathname).replace(/^\/+/, '');
+      } catch {
+        res.writeHead(400);
+        return res.end('Bad request');
+      }
       const filePath = resolve(rootPath, relativePath);
 
       // Path traversal protection: resolved path must stay within rootPath
@@ -135,19 +159,36 @@ export class LocalStorage implements IStorageProvider {
         res.writeHead(403);
         return res.end('Signature required');
       }
-      if (!this.verifyRequest(req.method!, relativePath, sig!, expires!)) {
+      if (
+        !this.verifyRequest(req.method!, relativePath, sig!, expires!, url.searchParams)
+      ) {
         res.writeHead(403);
         return res.end('Invalid or expired signature');
       }
 
       if (req.method === 'GET') {
-        if (!existsSync(filePath)) {
-          res.writeHead(404);
-          return res.end('Not found');
+        let realFilePath: string;
+        try {
+          realFilePath = realpathSync(filePath);
+        } catch (err) {
+          if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
+            res.writeHead(404);
+            return res.end('Not found');
+          }
+          res.writeHead(403);
+          return res.end('Forbidden');
+        }
+        if (!isWithinRoot(realRoot, realFilePath)) {
+          res.writeHead(403);
+          return res.end('Forbidden');
         }
         res.setHeader('Content-Type', getMimeType(filePath));
         const download = url.searchParams.get('download') === 'true';
         const fileNameParam = url.searchParams.get('fileName') ?? undefined;
+        if (fileNameParam && /["\r\n]/.test(fileNameParam)) {
+          res.writeHead(400);
+          return res.end('Bad request');
+        }
         const baseName = relativePath.split('/').pop() ?? relativePath;
         const disposition = constructDispositionHeader(baseName, {
           download,
@@ -156,7 +197,7 @@ export class LocalStorage implements IStorageProvider {
         if (disposition) {
           res.setHeader('Content-Disposition', disposition);
         }
-        const stream = createReadStream(filePath);
+        const stream = createReadStream(realFilePath);
         stream.on('error', () => {
           if (!res.headersSent) {
             res.writeHead(500);
@@ -165,13 +206,51 @@ export class LocalStorage implements IStorageProvider {
         });
         stream.pipe(res);
       } else if (req.method === 'PUT') {
+        const parentPath = dirname(filePath);
         try {
-          mkdirSync(dirname(filePath), { recursive: true });
+          mkdirSync(parentPath, { recursive: true });
         } catch {
           res.writeHead(500);
           return res.end('Failed to create directory');
         }
-        const writeStream = createWriteStream(filePath);
+        let realParentPath: string;
+        try {
+          realParentPath = realpathSync(parentPath);
+        } catch {
+          res.writeHead(403);
+          return res.end('Forbidden');
+        }
+        if (!isWithinRoot(realRoot, realParentPath)) {
+          res.writeHead(403);
+          return res.end('Forbidden');
+        }
+        const realTargetPath = resolve(realParentPath, basename(filePath));
+        if (!isWithinRoot(realRoot, realTargetPath)) {
+          res.writeHead(403);
+          return res.end('Forbidden');
+        }
+        let targetExists = false;
+        try {
+          lstatSync(realTargetPath);
+          targetExists = true;
+        } catch (err) {
+          if ((err as NodeJS.ErrnoException).code !== 'ENOENT') {
+            res.writeHead(403);
+            return res.end('Forbidden');
+          }
+        }
+        if (targetExists) {
+          try {
+            if (!isWithinRoot(realRoot, realpathSync(realTargetPath))) {
+              res.writeHead(403);
+              return res.end('Forbidden');
+            }
+          } catch {
+            res.writeHead(403);
+            return res.end('Forbidden');
+          }
+        }
+        const writeStream = createWriteStream(realTargetPath);
         req.pipe(writeStream);
         writeStream.on('finish', () => {
           res.writeHead(200, { 'Content-Type': 'application/json' });
@@ -207,7 +286,8 @@ export class LocalStorage implements IStorageProvider {
     expiryMs: number = SIGNED_URL_EXPIRY,
   ): string {
     const expires = Date.now() + expiryMs;
-    const payload = `${method}:${relativePath}:${expires}`;
+    const canonicalExtra = canonicalizeSignedExtraParams(extraParams);
+    const payload = `${method}:${relativePath}:${expires}:${canonicalExtra}`;
     const sig = createHmac('sha256', this._signingSecret).update(payload).digest('hex');
     const params = extraParams ?? new URLSearchParams();
     params.set('expires', expires.toString());
@@ -220,10 +300,12 @@ export class LocalStorage implements IStorageProvider {
     relativePath: string,
     sig: string,
     expires: string,
+    extraParams: URLSearchParams,
   ): boolean {
     const expiresNum = Number(expires);
     if (isNaN(expiresNum) || Date.now() > expiresNum) return false;
-    const payload = `${method}:${relativePath}:${expires}`;
+    const canonicalExtra = canonicalizeSignedExtraParams(extraParams);
+    const payload = `${method}:${relativePath}:${expires}:${canonicalExtra}`;
     const expected = createHmac('sha256', this._signingSecret).update(payload).digest();
     const provided = Buffer.from(sig, 'hex');
     if (expected.length !== provided.length) return false;

--- a/modules/storage/src/providers/local/index.ts
+++ b/modules/storage/src/providers/local/index.ts
@@ -7,7 +7,6 @@ import {
   createReadStream,
   createWriteStream,
   existsSync,
-  mkdir,
   mkdirSync,
   readFile,
   rmSync,
@@ -171,6 +170,7 @@ export class LocalStorage implements IStorageProvider {
     if (!this._httpServer) return;
     const server = this._httpServer;
     this._httpServer = null;
+    server.closeAllConnections();
     await new Promise<void>(res => {
       server.close(() => res());
     });
@@ -231,8 +231,10 @@ export class LocalStorage implements IStorageProvider {
     if (fileName !== self._activeContainer) {
       path += fileName;
     }
+    const resolvedPath = resolve(path);
+    mkdirSync(dirname(resolvedPath), { recursive: true });
     return new Promise(function (res, reject) {
-      writeFile(resolve(path), data, function (err) {
+      writeFile(resolvedPath, data, function (err) {
         if (err) reject(err);
         else {
           res(true);
@@ -243,25 +245,15 @@ export class LocalStorage implements IStorageProvider {
 
   async createFolder(name: string): Promise<boolean | Error> {
     const self = this;
-    return new Promise(async function (res, reject) {
-      let path = self._storagePath + '/' + self._activeContainer;
-      const containerExists = await self.folderExists(self._activeContainer);
-      if (!containerExists) {
-        mkdir(path, function (err) {
-          if (err) reject(err);
-        });
-      }
-      if (self._activeContainer !== name) {
-        path = self._storagePath + '/' + self._activeContainer + '/' + name;
-        mkdir(resolve(path), function (err) {
-          if (err) reject(err);
-          else res(true);
-        });
-      }
-      ConduitGrpcSdk.Metrics?.increment('folders_total');
-      ConduitGrpcSdk.Metrics?.increment('containers_total');
-      res(true);
-    });
+    let path = self._storagePath + '/' + self._activeContainer;
+    mkdirSync(resolve(path), { recursive: true });
+    if (self._activeContainer !== name) {
+      path = self._storagePath + '/' + self._activeContainer + '/' + name;
+      mkdirSync(resolve(path), { recursive: true });
+    }
+    ConduitGrpcSdk.Metrics?.increment('folders_total');
+    ConduitGrpcSdk.Metrics?.increment('containers_total');
+    return true;
   }
 
   folderExists(name: string): Promise<boolean | Error> {

--- a/modules/storage/src/providers/local/index.ts
+++ b/modules/storage/src/providers/local/index.ts
@@ -1,28 +1,73 @@
-import { IStorageProvider, StorageConfig } from '../../interfaces/index.js';
+import { IStorageProvider, StorageConfig, UrlOptions } from '../../interfaces/index.js';
 import {
   access,
   accessSync,
   chmod,
   constants,
+  createReadStream,
+  createWriteStream,
   existsSync,
   mkdir,
+  mkdirSync,
   readFile,
   rmSync,
   unlink,
   writeFile,
 } from 'fs';
-import { resolve } from 'path';
+import { createServer, IncomingMessage, Server, ServerResponse } from 'http';
+import { dirname, extname, resolve, sep } from 'path';
 import { ConduitGrpcSdk } from '@conduitplatform/grpc-sdk';
+import { constructDispositionHeader } from '../../utils/index.js';
+
+const MIME_TYPES: Record<string, string> = {
+  '.txt': 'text/plain',
+  '.html': 'text/html',
+  '.htm': 'text/html',
+  '.css': 'text/css',
+  '.js': 'text/javascript',
+  '.json': 'application/json',
+  '.xml': 'application/xml',
+  '.csv': 'text/csv',
+  '.pdf': 'application/pdf',
+  '.zip': 'application/zip',
+  '.png': 'image/png',
+  '.jpg': 'image/jpeg',
+  '.jpeg': 'image/jpeg',
+  '.gif': 'image/gif',
+  '.webp': 'image/webp',
+  '.svg': 'image/svg+xml',
+  '.bmp': 'image/bmp',
+  '.ico': 'image/x-icon',
+  '.mp3': 'audio/mpeg',
+  '.wav': 'audio/wav',
+  '.mp4': 'video/mp4',
+  '.webm': 'video/webm',
+  '.mov': 'video/quicktime',
+  '.doc': 'application/msword',
+  '.docx': 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+  '.xls': 'application/vnd.ms-excel',
+  '.xlsx': 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+};
+
+function getMimeType(filePath: string): string {
+  return MIME_TYPES[extname(filePath).toLowerCase()] ?? 'application/octet-stream';
+}
 
 export class LocalStorage implements IStorageProvider {
   _rootStoragePath: string;
   _storagePath: string;
   _activeContainer: string;
+  private _httpPort: number;
+  private _httpBaseUrl: string;
+  private _httpServer: Server | null = null;
 
   constructor(options?: StorageConfig) {
     this._activeContainer = '';
     this._rootStoragePath = options && options.local ? options.local.storagePath : '';
     this._storagePath = this._rootStoragePath;
+    this._httpPort = options?.local?.httpPort ?? 3100;
+    this._httpBaseUrl =
+      options?.local?.httpBaseUrl ?? `http://localhost:${this._httpPort}`;
     if (this._storagePath !== '') {
       try {
         accessSync(this._storagePath, constants.R_OK | constants.W_OK);
@@ -34,11 +79,105 @@ export class LocalStorage implements IStorageProvider {
           ConduitGrpcSdk.Logger.log('Permissions changed');
         });
       }
+      this.startHttpServer();
     }
   }
 
+  /**
+   * Serves uploads/downloads for URLs returned by getUploadUrl(), getSignedUrl()
+   * and getPublicUrl(). Mirrors the presigned-URL pattern used by cloud providers,
+   * but reads/writes directly against the local filesystem.
+   */
+  private startHttpServer(): void {
+    const rootPath = resolve(this._rootStoragePath);
+
+    this._httpServer = createServer((req: IncomingMessage, res: ServerResponse) => {
+      res.setHeader('Access-Control-Allow-Origin', '*');
+      res.setHeader('Access-Control-Allow-Methods', 'GET, PUT, OPTIONS');
+      res.setHeader('Access-Control-Allow-Headers', 'Content-Type, x-ms-blob-type');
+      res.setHeader('Access-Control-Max-Age', '86400');
+
+      if (req.method === 'OPTIONS') {
+        res.writeHead(204);
+        return res.end();
+      }
+
+      let url: URL;
+      try {
+        url = new URL(req.url ?? '/', `http://localhost:${this._httpPort}`);
+      } catch {
+        res.writeHead(400);
+        return res.end('Bad request');
+      }
+
+      const relativePath = decodeURIComponent(url.pathname).replace(/^\/+/, '');
+      const filePath = resolve(rootPath, relativePath);
+
+      // Path traversal protection: resolved path must stay within rootPath
+      if (!relativePath || !filePath.startsWith(rootPath + sep)) {
+        res.writeHead(403);
+        return res.end('Forbidden');
+      }
+
+      if (req.method === 'GET') {
+        if (!existsSync(filePath)) {
+          res.writeHead(404);
+          return res.end('Not found');
+        }
+        res.setHeader('Content-Type', getMimeType(filePath));
+        const download = url.searchParams.get('download') === 'true';
+        const fileNameParam = url.searchParams.get('fileName') ?? undefined;
+        const baseName = relativePath.split('/').pop() ?? relativePath;
+        const disposition = constructDispositionHeader(baseName, {
+          download,
+          fileName: fileNameParam,
+        });
+        if (disposition) {
+          res.setHeader('Content-Disposition', disposition);
+        }
+        createReadStream(filePath).pipe(res);
+      } else if (req.method === 'PUT') {
+        mkdirSync(dirname(filePath), { recursive: true });
+        const writeStream = createWriteStream(filePath);
+        req.pipe(writeStream);
+        writeStream.on('finish', () => {
+          res.writeHead(200, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ success: true }));
+        });
+        writeStream.on('error', err => {
+          res.writeHead(500);
+          res.end(err.message);
+        });
+      } else {
+        res.writeHead(405);
+        res.end('Method not allowed');
+      }
+    });
+
+    this._httpServer.on('error', err => {
+      ConduitGrpcSdk.Logger.error(
+        new Error(`[LocalStorage] HTTP file server error: ${(err as Error).message}`),
+      );
+    });
+
+    this._httpServer.listen(this._httpPort, () => {
+      ConduitGrpcSdk.Logger.log(
+        `[LocalStorage] HTTP file server listening on port ${this._httpPort}`,
+      );
+    });
+  }
+
+  async dispose(): Promise<void> {
+    if (!this._httpServer) return;
+    const server = this._httpServer;
+    this._httpServer = null;
+    await new Promise<void>(res => {
+      server.close(() => res());
+    });
+  }
+
   getUploadUrl(fileName: string): Promise<string | Error> {
-    throw new Error('Method not implemented.');
+    return Promise.resolve(`${this._httpBaseUrl}/${this._activeContainer}/${fileName}`);
   }
 
   deleteContainer(name: string): Promise<boolean | Error> {
@@ -85,7 +224,7 @@ export class LocalStorage implements IStorageProvider {
     });
   }
 
-  store(fileName: string, data: any): Promise<boolean | Error> {
+  store(fileName: string, data: any, _isPublic?: boolean): Promise<boolean | Error> {
     const self = this;
     let path = self._storagePath + '/' + self._activeContainer + '/';
 
@@ -172,12 +311,18 @@ export class LocalStorage implements IStorageProvider {
     });
   }
 
-  getPublicUrl(_fileName: string, _containerIsPublic?: boolean): Promise<string | Error> {
-    throw new Error('Method not implemented!');
+  getPublicUrl(fileName: string, _containerIsPublic?: boolean): Promise<string | Error> {
+    return Promise.resolve(`${this._httpBaseUrl}/${this._activeContainer}/${fileName}`);
   }
 
-  getSignedUrl(fileName: string): Promise<any> {
-    throw new Error('Method not implemented!| Error');
+  getSignedUrl(fileName: string, options?: UrlOptions): Promise<string | Error> {
+    const params = new URLSearchParams();
+    if (options?.download) params.set('download', 'true');
+    if (options?.fileName) params.set('fileName', options.fileName);
+    const query = params.toString() ? `?${params.toString()}` : '';
+    return Promise.resolve(
+      `${this._httpBaseUrl}/${this._activeContainer}/${fileName}${query}`,
+    );
   }
 
   container(name: string): IStorageProvider {
@@ -189,19 +334,15 @@ export class LocalStorage implements IStorageProvider {
     return this.folderExists(name);
   }
 
-  createContainer(name: string, isPublic?: boolean): Promise<boolean | Error> {
-    if (isPublic) {
-      return Promise.reject(
-        new Error('Public containers are not supported with local storage provider'),
-      );
-    }
+  createContainer(name: string, _isPublic?: boolean): Promise<boolean | Error> {
+    // Local storage serves all files through the embedded HTTP file server;
+    // public/private access is enforced at the Conduit handler layer, not
+    // at the storage-provider layer, so container-level ACLs don't apply here.
     this._activeContainer = name;
     return this.createFolder(name);
   }
 
   setContainerPublicAccess(_name: string, _isPublic: boolean): Promise<boolean | Error> {
-    return Promise.reject(
-      new Error('Public containers are not supported with local storage provider'),
-    );
+    return Promise.resolve(true);
   }
 }

--- a/modules/storage/src/providers/local/index.ts
+++ b/modules/storage/src/providers/local/index.ts
@@ -13,9 +13,11 @@ import {
   unlink,
   writeFile,
 } from 'fs';
+import { createHmac, randomBytes, timingSafeEqual } from 'crypto';
 import { createServer, IncomingMessage, Server, ServerResponse } from 'http';
 import { dirname, extname, resolve, sep } from 'path';
 import { ConduitGrpcSdk } from '@conduitplatform/grpc-sdk';
+import { SIGNED_URL_EXPIRY } from '../../constants/expiry.js';
 import { constructDispositionHeader } from '../../utils/index.js';
 
 const MIME_TYPES: Record<string, string> = {
@@ -59,6 +61,7 @@ export class LocalStorage implements IStorageProvider {
   private _httpPort: number;
   private _httpBaseUrl: string;
   private _httpServer: Server | null = null;
+  private _signingSecret: Buffer;
 
   constructor(options?: StorageConfig) {
     this._activeContainer = '';
@@ -67,6 +70,7 @@ export class LocalStorage implements IStorageProvider {
     this._httpPort = options?.local?.httpPort ?? 3100;
     this._httpBaseUrl =
       options?.local?.httpBaseUrl || `http://localhost:${this._httpPort}`;
+    this._signingSecret = randomBytes(32);
     if (this._storagePath !== '') {
       try {
         accessSync(this._storagePath, constants.R_OK | constants.W_OK);
@@ -116,6 +120,19 @@ export class LocalStorage implements IStorageProvider {
       if (!relativePath || !filePath.startsWith(rootPath + sep)) {
         res.writeHead(403);
         return res.end('Forbidden');
+      }
+
+      const sig = url.searchParams.get('sig');
+      const expires = url.searchParams.get('expires');
+      const hasSig = sig !== null && expires !== null;
+
+      if (req.method === 'PUT' && !hasSig) {
+        res.writeHead(403);
+        return res.end('Signature required');
+      }
+      if (hasSig && !this.verifyRequest(req.method!, relativePath, sig!, expires!)) {
+        res.writeHead(403);
+        return res.end('Invalid or expired signature');
       }
 
       if (req.method === 'GET') {
@@ -171,6 +188,35 @@ export class LocalStorage implements IStorageProvider {
     });
   }
 
+  private signUrl(
+    relativePath: string,
+    method: 'GET' | 'PUT',
+    extraParams?: URLSearchParams,
+  ): string {
+    const expires = Date.now() + SIGNED_URL_EXPIRY;
+    const payload = `${method}:${relativePath}:${expires}`;
+    const sig = createHmac('sha256', this._signingSecret).update(payload).digest('hex');
+    const params = extraParams ?? new URLSearchParams();
+    params.set('expires', expires.toString());
+    params.set('sig', sig);
+    return `${this._httpBaseUrl}/${relativePath}?${params.toString()}`;
+  }
+
+  private verifyRequest(
+    method: string,
+    relativePath: string,
+    sig: string,
+    expires: string,
+  ): boolean {
+    const expiresNum = Number(expires);
+    if (isNaN(expiresNum) || Date.now() > expiresNum) return false;
+    const payload = `${method}:${relativePath}:${expires}`;
+    const expected = createHmac('sha256', this._signingSecret).update(payload).digest();
+    const provided = Buffer.from(sig, 'hex');
+    if (expected.length !== provided.length) return false;
+    return timingSafeEqual(expected, provided);
+  }
+
   async dispose(): Promise<void> {
     if (!this._httpServer) return;
     const server = this._httpServer;
@@ -185,7 +231,8 @@ export class LocalStorage implements IStorageProvider {
     if (!this._httpServer) {
       return Promise.reject(new Error('Local storage server is not running'));
     }
-    return Promise.resolve(`${this._httpBaseUrl}/${this._activeContainer}/${fileName}`);
+    const relativePath = `${this._activeContainer}/${fileName}`;
+    return Promise.resolve(this.signUrl(relativePath, 'PUT'));
   }
 
   deleteContainer(name: string): Promise<boolean | Error> {
@@ -322,13 +369,11 @@ export class LocalStorage implements IStorageProvider {
     if (!this._httpServer) {
       return Promise.reject(new Error('Local storage server is not running'));
     }
-    const params = new URLSearchParams();
-    if (options?.download) params.set('download', 'true');
-    if (options?.fileName) params.set('fileName', options.fileName);
-    const query = params.toString() ? `?${params.toString()}` : '';
-    return Promise.resolve(
-      `${this._httpBaseUrl}/${this._activeContainer}/${fileName}${query}`,
-    );
+    const relativePath = `${this._activeContainer}/${fileName}`;
+    const extraParams = new URLSearchParams();
+    if (options?.download) extraParams.set('download', 'true');
+    if (options?.fileName) extraParams.set('fileName', options.fileName);
+    return Promise.resolve(this.signUrl(relativePath, 'GET', extraParams));
   }
 
   container(name: string): IStorageProvider {

--- a/modules/storage/src/providers/local/index.ts
+++ b/modules/storage/src/providers/local/index.ts
@@ -66,7 +66,7 @@ export class LocalStorage implements IStorageProvider {
     this._storagePath = this._rootStoragePath;
     this._httpPort = options?.local?.httpPort ?? 3100;
     this._httpBaseUrl =
-      options?.local?.httpBaseUrl ?? `http://localhost:${this._httpPort}`;
+      options?.local?.httpBaseUrl || `http://localhost:${this._httpPort}`;
     if (this._storagePath !== '') {
       try {
         accessSync(this._storagePath, constants.R_OK | constants.W_OK);
@@ -136,7 +136,12 @@ export class LocalStorage implements IStorageProvider {
         }
         createReadStream(filePath).pipe(res);
       } else if (req.method === 'PUT') {
-        mkdirSync(dirname(filePath), { recursive: true });
+        try {
+          mkdirSync(dirname(filePath), { recursive: true });
+        } catch {
+          res.writeHead(500);
+          return res.end('Failed to create directory');
+        }
         const writeStream = createWriteStream(filePath);
         req.pipe(writeStream);
         writeStream.on('finish', () => {
@@ -177,6 +182,9 @@ export class LocalStorage implements IStorageProvider {
   }
 
   getUploadUrl(fileName: string): Promise<string | Error> {
+    if (!this._httpServer) {
+      return Promise.reject(new Error('Local storage server is not running'));
+    }
     return Promise.resolve(`${this._httpBaseUrl}/${this._activeContainer}/${fileName}`);
   }
 
@@ -304,10 +312,16 @@ export class LocalStorage implements IStorageProvider {
   }
 
   getPublicUrl(fileName: string, _containerIsPublic?: boolean): Promise<string | Error> {
+    if (!this._httpServer) {
+      return Promise.reject(new Error('Local storage server is not running'));
+    }
     return Promise.resolve(`${this._httpBaseUrl}/${this._activeContainer}/${fileName}`);
   }
 
   getSignedUrl(fileName: string, options?: UrlOptions): Promise<string | Error> {
+    if (!this._httpServer) {
+      return Promise.reject(new Error('Local storage server is not running'));
+    }
     const params = new URLSearchParams();
     if (options?.download) params.set('download', 'true');
     if (options?.fileName) params.set('fileName', options.fileName);

--- a/modules/storage/src/providers/local/index.ts
+++ b/modules/storage/src/providers/local/index.ts
@@ -70,9 +70,9 @@ export class LocalStorage implements IStorageProvider {
     this._rootStoragePath = options && options.local ? options.local.storagePath : '';
     this._storagePath = this._rootStoragePath;
     this._httpPort = options?.local?.httpPort ?? 3100;
-    this._httpBaseUrl =
-      options?.local?.httpBaseUrl || `http://localhost:${this._httpPort}`;
-    const configSecret = options?.local?.signingSecret;
+    const rawBaseUrl = options?.local?.httpBaseUrl?.replace(/\/+$/, '') ?? '';
+    this._httpBaseUrl = rawBaseUrl || `http://localhost:${this._httpPort}`;
+    const configSecret = options?.local?.signingSecret?.trim();
     this._signingSecret = configSecret
       ? Buffer.from(configSecret, 'hex')
       : randomBytes(32);
@@ -156,7 +156,14 @@ export class LocalStorage implements IStorageProvider {
         if (disposition) {
           res.setHeader('Content-Disposition', disposition);
         }
-        createReadStream(filePath).pipe(res);
+        const stream = createReadStream(filePath);
+        stream.on('error', () => {
+          if (!res.headersSent) {
+            res.writeHead(500);
+          }
+          res.end();
+        });
+        stream.pipe(res);
       } else if (req.method === 'PUT') {
         try {
           mkdirSync(dirname(filePath), { recursive: true });

--- a/modules/storage/src/providers/local/index.ts
+++ b/modules/storage/src/providers/local/index.ts
@@ -234,7 +234,7 @@ export class LocalStorage implements IStorageProvider {
   }
 
   getUploadUrl(fileName: string): Promise<string | Error> {
-    if (!this._httpServer) {
+    if (!this._httpServer?.listening) {
       return Promise.reject(new Error('Local storage server is not running'));
     }
     const relativePath = `${this._activeContainer}/${fileName}`;
@@ -365,7 +365,7 @@ export class LocalStorage implements IStorageProvider {
   }
 
   getPublicUrl(fileName: string, _containerIsPublic?: boolean): Promise<string | Error> {
-    if (!this._httpServer) {
+    if (!this._httpServer?.listening) {
       return Promise.reject(new Error('Local storage server is not running'));
     }
     const relativePath = `${this._activeContainer}/${fileName}`;
@@ -375,7 +375,7 @@ export class LocalStorage implements IStorageProvider {
   }
 
   getSignedUrl(fileName: string, options?: UrlOptions): Promise<string | Error> {
-    if (!this._httpServer) {
+    if (!this._httpServer?.listening) {
       return Promise.reject(new Error('Local storage server is not running'));
     }
     const relativePath = `${this._activeContainer}/${fileName}`;

--- a/modules/storage/src/providers/local/index.ts
+++ b/modules/storage/src/providers/local/index.ts
@@ -55,6 +55,8 @@ function getMimeType(filePath: string): string {
 }
 
 export class LocalStorage implements IStorageProvider {
+  private static readonly PUBLIC_URL_EXPIRY = 1000 * 60 * 60 * 24 * 365 * 99;
+
   _rootStoragePath: string;
   _storagePath: string;
   _activeContainer: string;
@@ -70,7 +72,10 @@ export class LocalStorage implements IStorageProvider {
     this._httpPort = options?.local?.httpPort ?? 3100;
     this._httpBaseUrl =
       options?.local?.httpBaseUrl || `http://localhost:${this._httpPort}`;
-    this._signingSecret = randomBytes(32);
+    const configSecret = options?.local?.signingSecret;
+    this._signingSecret = configSecret
+      ? Buffer.from(configSecret, 'hex')
+      : randomBytes(32);
     if (this._storagePath !== '') {
       try {
         accessSync(this._storagePath, constants.R_OK | constants.W_OK);
@@ -126,11 +131,11 @@ export class LocalStorage implements IStorageProvider {
       const expires = url.searchParams.get('expires');
       const hasSig = sig !== null && expires !== null;
 
-      if (req.method === 'PUT' && !hasSig) {
+      if (!hasSig) {
         res.writeHead(403);
         return res.end('Signature required');
       }
-      if (hasSig && !this.verifyRequest(req.method!, relativePath, sig!, expires!)) {
+      if (!this.verifyRequest(req.method!, relativePath, sig!, expires!)) {
         res.writeHead(403);
         return res.end('Invalid or expired signature');
       }
@@ -192,8 +197,9 @@ export class LocalStorage implements IStorageProvider {
     relativePath: string,
     method: 'GET' | 'PUT',
     extraParams?: URLSearchParams,
+    expiryMs: number = SIGNED_URL_EXPIRY,
   ): string {
-    const expires = Date.now() + SIGNED_URL_EXPIRY;
+    const expires = Date.now() + expiryMs;
     const payload = `${method}:${relativePath}:${expires}`;
     const sig = createHmac('sha256', this._signingSecret).update(payload).digest('hex');
     const params = extraParams ?? new URLSearchParams();
@@ -362,7 +368,10 @@ export class LocalStorage implements IStorageProvider {
     if (!this._httpServer) {
       return Promise.reject(new Error('Local storage server is not running'));
     }
-    return Promise.resolve(`${this._httpBaseUrl}/${this._activeContainer}/${fileName}`);
+    const relativePath = `${this._activeContainer}/${fileName}`;
+    return Promise.resolve(
+      this.signUrl(relativePath, 'GET', undefined, LocalStorage.PUBLIC_URL_EXPIRY),
+    );
   }
 
   getSignedUrl(fileName: string, options?: UrlOptions): Promise<string | Error> {


### PR DESCRIPTION
## Summary

- Add an embedded HTTP file server to the local storage provider so `getUploadUrl`, `getSignedUrl`, and `getPublicUrl` work the same way as cloud providers (presigned-URL pattern on port 3100 by default).
- Implement provider lifecycle cleanup via `dispose()` so the HTTP server is torn down and recreated on config changes (activate, deactivate, provider switch).
- Fix local provider directory creation: `store()` now creates parent dirs before writing, and `createFolder()` uses synchronous recursive `mkdirSync` instead of racy async `mkdir` callbacks.

## Test plan

- [x] `POST /storage/upload` with a new folder path succeeds without manually creating directories
- [x] `PUT` to the returned upload URL writes file bytes to disk
- [x] `GET` on the local storage URL serves the file with correct MIME type (text + image)
- [x] `GET /storage/getFileUrl/:id` returns the local storage URL for private files
- [ ] Verify HTTP server restarts cleanly when storage config changes (port/path/provider switch)
- [ ] Verify module deactivation calls `dispose()` and releases port 3100