### PR TITLE
feat(communications): add mock email and SMS providers for local dev

### DIFF
--- a/modules/communications/src/config/config.ts
+++ b/modules/communications/src/config/config.ts
@@ -7,6 +7,7 @@ export default {
       default: false,
     },
     transport: {
+      doc: 'Email transport provider. Options: smtp, mailgun, mandrill, sendgrid, mailersend, amazonSes, mock (local dev - logs only)',
       format: 'String',
       default: 'smtp',
     },
@@ -226,6 +227,7 @@ export default {
       default: false,
     },
     providerName: {
+      doc: 'SMS provider. Options: twilio, awsSns, messageBird, mock (local dev - logs only)',
       format: 'String',
       default: 'twilio',
     },

--- a/modules/communications/src/providers/email/index.ts
+++ b/modules/communications/src/providers/email/index.ts
@@ -15,6 +15,7 @@ import { Indexable } from '@conduitplatform/grpc-sdk';
 import { MailersendConfig } from './mailersend/mailersend.config.js';
 import { MailersendProvider } from './mailersend/MailersendProvider.js';
 import { AmazonSesProvider } from './amazonSes/AmazonSesProvider.js';
+import { MockEmailProvider } from './mock/MockEmailProvider.js';
 
 export class EmailProvider {
   _transport?: EmailProviderClass;
@@ -103,6 +104,9 @@ export class EmailProvider {
         throw new Error('Amazon SES transport settings are missing');
       }
       this._transport = new AmazonSesProvider(transportSettings.amazonSes);
+    } else if (transport === 'mock') {
+      this._transportName = 'mock';
+      this._transport = new MockEmailProvider();
     } else {
       this._transportName = undefined;
       this._transport = undefined;

--- a/modules/communications/src/providers/email/mock/MockEmailProvider.ts
+++ b/modules/communications/src/providers/email/mock/MockEmailProvider.ts
@@ -1,0 +1,78 @@
+import { randomUUID } from 'crypto';
+import { createTransport, SentMessageInfo } from 'nodemailer';
+import Mail, { Options } from 'nodemailer/lib/mailer/index.js';
+import { ConduitGrpcSdk, Indexable } from '@conduitplatform/grpc-sdk';
+import {
+  CreateEmailTemplate,
+  DeleteEmailTemplate,
+  Template,
+  UpdateEmailTemplate,
+} from '../interfaces/index.js';
+import { EmailBuilderClass, EmailProviderClass } from '../models/index.js';
+import { NodemailerBuilder } from '../nodemailer/nodemailerBuilder.js';
+
+function formatRecipients(to: Mail.Options['to']): string {
+  if (!to) return '';
+  if (typeof to === 'string') return to;
+  if (Array.isArray(to)) {
+    return to
+      .map(recipient => (typeof recipient === 'string' ? recipient : recipient.address))
+      .join(', ');
+  }
+  return to.address;
+}
+
+function formatBodySnippet(mailOptions: Mail.Options): string {
+  const content = mailOptions.html ?? mailOptions.text ?? '';
+  const text = typeof content === 'string' ? content : '';
+  return text.length > 100 ? `${text.slice(0, 100)}...` : text;
+}
+
+export class MockEmailProvider extends EmailProviderClass {
+  constructor() {
+    super(createTransport({ jsonTransport: true }));
+  }
+
+  sendEmail(mailOptions: Mail.Options): Promise<SentMessageInfo> {
+    const messageId = `mock-${randomUUID()}`;
+    ConduitGrpcSdk.Logger.log(
+      `[MOCK EMAIL] To: ${formatRecipients(mailOptions.to)} | Subject: ${mailOptions.subject ?? ''} | Body: ${formatBodySnippet(mailOptions)}`,
+    );
+    return Promise.resolve({
+      messageId,
+      response: 'OK (mock)',
+    });
+  }
+
+  listTemplates(): Promise<Template[]> {
+    throw new Error('Method not implemented.');
+  }
+
+  getTemplateInfo(_templateName: string): Promise<Template> {
+    throw new Error('Method not implemented.');
+  }
+
+  createTemplate(_data: CreateEmailTemplate): Promise<Template> {
+    throw new Error('Method not implemented.');
+  }
+
+  getBuilder(): EmailBuilderClass<Options> {
+    return new NodemailerBuilder();
+  }
+
+  updateTemplate(_data: UpdateEmailTemplate): Promise<Template> {
+    throw new Error('Method not implemented.');
+  }
+
+  deleteTemplate(_id: string): Promise<DeleteEmailTemplate> {
+    throw new Error('Method not implemented.');
+  }
+
+  getEmailStatus(messageId: string): Promise<Indexable> {
+    return Promise.resolve({ status: 'delivered', messageId });
+  }
+
+  getMessageId(info: SentMessageInfo): string | undefined {
+    return info.messageId;
+  }
+}

--- a/modules/communications/src/providers/email/mock/MockEmailProvider.ts
+++ b/modules/communications/src/providers/email/mock/MockEmailProvider.ts
@@ -11,6 +11,9 @@ import {
 import { EmailBuilderClass, EmailProviderClass } from '../models/index.js';
 import { NodemailerBuilder } from '../nodemailer/nodemailerBuilder.js';
 
+const EXTERNAL_TEMPLATES_UNSUPPORTED =
+  'Mock provider does not support external templates';
+
 function formatRecipients(to: Mail.Options['to']): string {
   if (!to) return '';
   if (typeof to === 'string') return to;
@@ -22,12 +25,6 @@ function formatRecipients(to: Mail.Options['to']): string {
   return to.address;
 }
 
-function formatBodySnippet(mailOptions: Mail.Options): string {
-  const content = mailOptions.html ?? mailOptions.text ?? '';
-  const text = typeof content === 'string' ? content : '';
-  return text.length > 100 ? `${text.slice(0, 100)}...` : text;
-}
-
 export class MockEmailProvider extends EmailProviderClass {
   constructor() {
     super(createTransport({ jsonTransport: true }));
@@ -36,7 +33,7 @@ export class MockEmailProvider extends EmailProviderClass {
   sendEmail(mailOptions: Mail.Options): Promise<SentMessageInfo> {
     const messageId = `mock-${randomUUID()}`;
     ConduitGrpcSdk.Logger.log(
-      `[MOCK EMAIL] To: ${formatRecipients(mailOptions.to)} | Subject: ${mailOptions.subject ?? ''} | Body: ${formatBodySnippet(mailOptions)}`,
+      `[MOCK EMAIL] To: ${formatRecipients(mailOptions.to)} | Subject: ${mailOptions.subject ?? ''}`,
     );
     return Promise.resolve({
       messageId,
@@ -45,15 +42,15 @@ export class MockEmailProvider extends EmailProviderClass {
   }
 
   listTemplates(): Promise<Template[]> {
-    throw new Error('Method not implemented.');
+    return Promise.resolve([]);
   }
 
   getTemplateInfo(_templateName: string): Promise<Template> {
-    throw new Error('Method not implemented.');
+    return Promise.reject(new Error(EXTERNAL_TEMPLATES_UNSUPPORTED));
   }
 
   createTemplate(_data: CreateEmailTemplate): Promise<Template> {
-    throw new Error('Method not implemented.');
+    return Promise.reject(new Error(EXTERNAL_TEMPLATES_UNSUPPORTED));
   }
 
   getBuilder(): EmailBuilderClass<Options> {
@@ -61,11 +58,11 @@ export class MockEmailProvider extends EmailProviderClass {
   }
 
   updateTemplate(_data: UpdateEmailTemplate): Promise<Template> {
-    throw new Error('Method not implemented.');
+    return Promise.reject(new Error(EXTERNAL_TEMPLATES_UNSUPPORTED));
   }
 
-  deleteTemplate(_id: string): Promise<DeleteEmailTemplate> {
-    throw new Error('Method not implemented.');
+  deleteTemplate(id: string): Promise<DeleteEmailTemplate> {
+    return Promise.resolve({ id, message: 'OK (mock)' });
   }
 
   getEmailStatus(messageId: string): Promise<Indexable> {

--- a/modules/communications/src/providers/email/mock/MockEmailProvider.ts
+++ b/modules/communications/src/providers/email/mock/MockEmailProvider.ts
@@ -45,20 +45,22 @@ export class MockEmailProvider extends EmailProviderClass {
     return Promise.resolve([]);
   }
 
-  getTemplateInfo(_templateName: string): Promise<Template> {
-    return Promise.reject(new Error(EXTERNAL_TEMPLATES_UNSUPPORTED));
+  getTemplateInfo(templateName: string): Promise<Template> {
+    return Promise.reject(
+      new Error(`${EXTERNAL_TEMPLATES_UNSUPPORTED}: ${templateName}`),
+    );
   }
 
-  createTemplate(_data: CreateEmailTemplate): Promise<Template> {
-    return Promise.reject(new Error(EXTERNAL_TEMPLATES_UNSUPPORTED));
+  createTemplate(data: CreateEmailTemplate): Promise<Template> {
+    return Promise.reject(new Error(`${EXTERNAL_TEMPLATES_UNSUPPORTED}: ${data.name}`));
   }
 
   getBuilder(): EmailBuilderClass<Options> {
     return new NodemailerBuilder();
   }
 
-  updateTemplate(_data: UpdateEmailTemplate): Promise<Template> {
-    return Promise.reject(new Error(EXTERNAL_TEMPLATES_UNSUPPORTED));
+  updateTemplate(data: UpdateEmailTemplate): Promise<Template> {
+    return Promise.reject(new Error(`${EXTERNAL_TEMPLATES_UNSUPPORTED}: ${data.id}`));
   }
 
   deleteTemplate(id: string): Promise<DeleteEmailTemplate> {

--- a/modules/communications/src/providers/sms/mock.ts
+++ b/modules/communications/src/providers/sms/mock.ts
@@ -1,0 +1,26 @@
+import { randomUUID } from 'crypto';
+import { ConduitGrpcSdk } from '@conduitplatform/grpc-sdk';
+import { ISmsProvider } from './interfaces/ISmsProvider.js';
+
+const MOCK_VERIFICATION_CODE = '123456';
+
+export class MockSmsProvider implements ISmsProvider {
+  sendSms(to: string, message: string): Promise<any> {
+    ConduitGrpcSdk.Logger.log(`[MOCK SMS] To: ${to} | Message: ${message}`);
+    return Promise.resolve({
+      sid: `mock-sms-${randomUUID()}`,
+      status: 'sent',
+    });
+  }
+
+  sendVerificationCode(to: string): Promise<string> {
+    ConduitGrpcSdk.Logger.log(
+      `[MOCK SMS] Verification code sent to: ${to} (code: ${MOCK_VERIFICATION_CODE})`,
+    );
+    return Promise.resolve(`mock-verify-${randomUUID()}`);
+  }
+
+  verify(_verificationSid: string, code: string): Promise<boolean> {
+    return Promise.resolve(code === MOCK_VERIFICATION_CODE);
+  }
+}

--- a/modules/communications/src/providers/sms/mock.ts
+++ b/modules/communications/src/providers/sms/mock.ts
@@ -6,7 +6,7 @@ const MOCK_VERIFICATION_CODE = '123456';
 
 export class MockSmsProvider implements ISmsProvider {
   sendSms(to: string, message: string): Promise<any> {
-    ConduitGrpcSdk.Logger.log(`[MOCK SMS] To: ${to}`);
+    ConduitGrpcSdk.Logger.log(`[MOCK SMS] To: ${to} | Message: ${message}`);
     return Promise.resolve({
       sid: `mock-sms-${randomUUID()}`,
       status: 'sent',
@@ -20,7 +20,8 @@ export class MockSmsProvider implements ISmsProvider {
     return Promise.resolve(`mock-verify-${randomUUID()}`);
   }
 
-  verify(_verificationSid: string, code: string): Promise<boolean> {
+  verify(verificationSid: string, code: string): Promise<boolean> {
+    ConduitGrpcSdk.Logger.log(`[MOCK SMS] Verifying sid: ${verificationSid}`);
     return Promise.resolve(code === MOCK_VERIFICATION_CODE);
   }
 }

--- a/modules/communications/src/providers/sms/mock.ts
+++ b/modules/communications/src/providers/sms/mock.ts
@@ -6,7 +6,7 @@ const MOCK_VERIFICATION_CODE = '123456';
 
 export class MockSmsProvider implements ISmsProvider {
   sendSms(to: string, message: string): Promise<any> {
-    ConduitGrpcSdk.Logger.log(`[MOCK SMS] To: ${to} | Message: ${message}`);
+    ConduitGrpcSdk.Logger.log(`[MOCK SMS] To: ${to}`);
     return Promise.resolve({
       sid: `mock-sms-${randomUUID()}`,
       status: 'sent',

--- a/modules/communications/src/services/email.service.ts
+++ b/modules/communications/src/services/email.service.ts
@@ -20,7 +20,7 @@ import { storeEmail } from '../utils/storeEmail.js';
 import { Config } from '../config/index.js';
 import { Provider } from '../utils/index.js';
 
-const STATUS_UNSUPPORTED_TRANSPORTS = new Set(['amazonSes', 'smtp']);
+const STATUS_UNSUPPORTED_TRANSPORTS = new Set(['amazonSes', 'smtp', 'mock']);
 
 export interface IRegisterTemplateParams {
   name: string;
@@ -126,11 +126,7 @@ export class EmailService implements IChannel {
       const statusInfo = await this.getEmailStatus(messageId);
       return {
         status: (statusInfo.status || 'unknown') as
-          | 'pending'
-          | 'sent'
-          | 'delivered'
-          | 'failed'
-          | 'bounced',
+          'pending' | 'sent' | 'delivered' | 'failed' | 'bounced',
         messageId,
         timestamp: new Date(),
       };

--- a/modules/communications/src/services/sms.service.ts
+++ b/modules/communications/src/services/sms.service.ts
@@ -11,6 +11,7 @@ import { Config } from '../config/index.js';
 import { messageBirdProvider } from '../providers/sms/messageBird.js';
 import { AwsSnsProvider } from '../providers/sms/awsSns.js';
 import { TwilioProvider } from '../providers/sms/twilio.js';
+import { MockSmsProvider } from '../providers/sms/mock.js';
 
 export class SmsService implements IChannel {
   private provider?: ISmsProvider;
@@ -44,6 +45,9 @@ export class SmsService implements IChannel {
           break;
         case 'messageBird':
           this.provider = new messageBirdProvider(settings);
+          break;
+        case 'mock':
+          this.provider = new MockSmsProvider();
           break;
         default:
           ConduitGrpcSdk.Logger.error(`Unknown SMS provider: ${name}`);


### PR DESCRIPTION
## Summary

- Add `mock` email transport and SMS provider for local development without external credentials (Mailgun, Twilio, etc.).
- Mock email logs recipient + subject to stdout; mock SMS logs recipient and accepts verification code `123456`.
- Harden mock email provider external-template methods to return safe no-ops instead of 500s on admin routes.

## Relationship to #1557

This PR and [#1557](https://github.com/ConduitPlatform/Conduit/pull/1557) together implement the full local-dev mocking story for **communications** and **storage**:

| Channel / module | Local dev support | How |
|------------------|-------------------|-----|
| **Storage** | #1557 | Local storage upload/download via signed URLs (no cloud provider) |
| **Email** | This PR | `transport: "mock"` — logs to stdout, no external ESP |
| **SMS** | This PR | `providerName: "mock"` — logs to stdout, verification code `123456` |
| **Push** | Already in Conduit | `providerName: "basic"` — stores notifications in DB, no FCM/APNs delivery |

Neither PR depends on the other at the code level — they can merge independently. But for a complete local stack without external services, both are needed: storage URLs for file operations (e.g. email attachments, stored email content) and mock communications for outbound messages.

**Push notifications do not need a new mock provider.** Conduit already ships the `basic` push provider, which accepts send requests and persists notifications to the database without contacting Firebase, OneSignal, or SNS. Enable it with:

```json
"pushNotifications": { "active": true, "providerName": "basic" }
```

## Config

Recommended local-dev communications config:

```json
{
  "email": {
    "active": true,
    "transport": "mock",
    "sendingDomain": "dev.local",
    "storeEmails": { "enabled": true }
  },
  "sms": { "active": true, "providerName": "mock" },
  "pushNotifications": { "active": true, "providerName": "basic" }
}
```

**Enable `storeEmails.enabled` for email.** It defaults to `false`, so sends succeed and appear in logs but no `EmailRecord` documents are created. Turning it on lets you verify the admin list/get email endpoints (`GET /email/emails`, `GET /email/emails/:id`) and resend flows behave as expected — similar to how SMS already persists records by default.

## Expected logs

Watch the **communications module** stdout when testing. Mock providers log on send — no email body or SMS message content is included (templates can be large).

| Action | Example log line |
|--------|------------------|
| Send email | `[MOCK EMAIL] To: test@dev.local \| Subject: Welcome John` |
| Send SMS | `[MOCK SMS] To: +15551234567` |
| Send SMS verification code | `[MOCK SMS] Verification code sent to: +15551234567 (code: 123456)` |

Push (`basic` provider) does not emit a mock log line — it silently persists notifications to the database. Confirm push via `GET /push/tokens` or the notifications collection.

Admin routes also log as usual, e.g. `(admin) Request: /email/send 200 (OK)`.

## Test plan

- [ ] Enable mock email + SMS (and optionally `storeEmails.enabled`) via admin `PATCH /config/communications`
- [ ] `POST /email/send` — check server logs for `[MOCK EMAIL] To: … | Subject: …`
- [ ] `POST /sms/send` — check server logs for `[MOCK SMS] To: …`
- [ ] With `storeEmails.enabled: true`, sent emails appear in `GET /email/emails` and `GET /email/emails/:id`
- [ ] `GET /email/templates/external` returns empty list (no 500)
- [ ] SMS verification accepts code `123456` via auth phone flow — log shows `(code: 123456)`
- [ ] Push via `providerName: "basic"` stores notifications without external delivery