### PR TITLE
fix(ci): prevent implicit pnpm install during module-tools publish build

### DIFF
--- a/.github/workflows/production.yaml
+++ b/.github/workflows/production.yaml
@@ -80,7 +80,9 @@ jobs:
         run: pnpm version "$RELEASE_VERSION" --no-git-tag-version
         working-directory: ./libraries/grpc-sdk
       - name: build the sdk
-        run: npx turbo run build --filter=@conduitplatform/grpc-sdk --filter=@conduitplatform/module-tools
+        run: pnpm exec turbo run build --filter=@conduitplatform/grpc-sdk --filter=@conduitplatform/module-tools
+        env:
+          pnpm_config_verify_deps_before_run: "false"
       - name: Set version and publish
         run: |
           pnpm version "$RELEASE_VERSION" --no-git-tag-version


### PR DESCRIPTION
## Summary
- Fix the `publish_module_tools` release job failing at the "build the sdk" step on pnpm 11
- Use `pnpm exec turbo` and disable `verify-deps-before-run` for that step so the grpc-sdk version bump does not trigger an implicit `pnpm install` that runs workspace `prepare` scripts before library `dist/` exists

## Test plan
- [ ] Merge and cut `v0.17.0-alpha.5` release
- [ ] Confirm `publish_sdk` job succeeds
- [ ] Confirm `publish_module_tools` "build the sdk" step completes without `modules/functions` TS2307 errors
- [ ] Confirm `@conduitplatform/module-tools` publishes with grpc-sdk peer/dep aligned to release version