### PR TITLE
fix(communications): unwrap SMS verification gRPC responses

### DIFF
--- a/modules/communications/src/Communications.ts
+++ b/modules/communications/src/Communications.ts
@@ -628,7 +628,7 @@ export default class Communications extends ManagedModule<Config> {
     }
 
     let errorMessage: string | null = null;
-    const verificationSid = await this.smsService
+    const result = await this.smsService
       .sendVerificationCode(to)
       .catch(e => (errorMessage = e.message));
     if (!isNil(errorMessage))
@@ -637,7 +637,7 @@ export default class Communications extends ManagedModule<Config> {
         message: errorMessage,
       });
 
-    return callback(null, { verificationSid });
+    return callback(null, { verificationSid: result.verificationSid });
   }
 
   async verify(call: GrpcRequest<VerifyRequest>, callback: GrpcCallback<VerifyResponse>) {
@@ -653,7 +653,7 @@ export default class Communications extends ManagedModule<Config> {
     }
 
     let errorMessage: string | null = null;
-    const verified = await this.smsService
+    const result = await this.smsService
       .verify(verificationSid, code)
       .catch(e => (errorMessage = e.message));
     if (!isNil(errorMessage))
@@ -662,7 +662,7 @@ export default class Communications extends ManagedModule<Config> {
         message: errorMessage,
       });
 
-    return callback(null, { verified });
+    return callback(null, { verified: result.verified });
   }
 
   // New Unified Service Methods


### PR DESCRIPTION
## Problem

After the communications merge in 0.17, SMS verification codes still send via Twilio Verify, but submitting the code fails with Twilio error **60200 Invalid parameter: VerificationSid**.

`SmsService.sendVerificationCode` / `verify` return `{ verificationSid }` / `{ verified }`, while the gRPC handlers treated those whole objects as the proto scalar fields. protobufjs coerced them to `"[object Object]"`, which Auth stored and later passed back to Twilio.

This did not happen in 0.16, where the SMS module called the provider directly and returned a bare string / boolean.

## Solution

- Unwrap `result.verificationSid` in `sendVerificationCode` before the gRPC callback
- Unwrap `result.verified` in `verify` the same way

## Test plan

- [ ] Deploy / run communications with Twilio Verify configured
- [ ] Trigger phone auth (or SMS verification) — confirm send still delivers an SMS
- [ ] Submit the received code — verify succeeds (no 60200)
- [ ] Confirm Auth stores a real `VE…` VerificationSid, not `"[object Object]"`