### PR TITLE
fix(communications): restore SMS verification and client routes

### DIFF
--- a/modules/communications/package.json
+++ b/modules/communications/package.json
@@ -10,7 +10,8 @@
   },
   "conduit": {
     "peers": {
-      "await": ["database"]
+      "await": ["database"],
+      "watch": [{ "module": "router", "edge": "rising" }]
     }
   },
   "scripts": {

--- a/modules/communications/src/Communications.ts
+++ b/modules/communications/src/Communications.ts
@@ -136,6 +136,7 @@ export default class Communications extends ManagedModule<Config> {
   private orchestratorService: OrchestratorService;
   private templateService: CommunicationTemplateService;
   private legacyModulesPendingCleanup: string[] = [];
+  private refreshAppRoutesTimeout: NodeJS.Timeout | null = null;
 
   // Provider instances
   private emailProvider: EmailProvider;
@@ -228,20 +229,13 @@ export default class Communications extends ManagedModule<Config> {
         this.templateService,
       );
 
-      // Initialize user routes for push notifications
-      if (this.grpcSdk.isAvailable('router')) {
-        this.userRouter = new PushNotificationsRoutes(
-          this.grpcServer,
-          this.grpcSdk,
-          this.pushService,
-        );
-      }
-
       // Initialize queue controller and workers
       const queueController = QueueController.getInstance(this.grpcSdk);
       queueController.addEmailStatusWorker();
       queueController.addEmailCleanupWorker();
       this.isRunning = true;
+      this.registerDeclaredPeerWatches();
+      this.scheduleAppRouteRefresh();
     }
 
     await this.emailService.initEmailProvider(config);
@@ -1021,5 +1015,45 @@ export default class Communications extends ManagedModule<Config> {
       this.smsService,
       this.templateService,
     );
+  }
+
+  protected override onDeclaredPeerConnectionUpdate(
+    moduleName: string,
+    serving: boolean,
+  ): void {
+    if (moduleName === 'router' && serving) {
+      this.scheduleAppRouteRefresh();
+    }
+  }
+
+  private scheduleAppRouteRefresh() {
+    if (this.refreshAppRoutesTimeout) {
+      clearTimeout(this.refreshAppRoutesTimeout);
+      this.refreshAppRoutesTimeout = null;
+    }
+    this.refreshAppRoutesTimeout = setTimeout(async () => {
+      try {
+        await this.refreshAppRoutes();
+      } catch (err) {
+        ConduitGrpcSdk.Logger.error(err as Error);
+      }
+      this.refreshAppRoutesTimeout = null;
+    }, 800);
+  }
+
+  private async refreshAppRoutes() {
+    if (this.userRouter) {
+      await this.userRouter.registerRoutes();
+      return;
+    }
+    if (!this.grpcSdk.isAvailable('router')) {
+      return;
+    }
+    this.userRouter = new PushNotificationsRoutes(
+      this.grpcServer,
+      this.grpcSdk,
+      this.pushService,
+    );
+    await this.userRouter.registerRoutes();
   }
 }

--- a/modules/communications/src/routes/push-notifications.routes.ts
+++ b/modules/communications/src/routes/push-notifications.routes.ts
@@ -27,13 +27,11 @@ export class PushNotificationsRoutes {
   ) {
     this.handlers = new NotificationTokensHandler(pushService);
     this._routingManager = new RoutingManager(this.grpcSdk.router!, server);
-    this.registerRoutes();
   }
 
   async registerRoutes() {
     this._routingManager.clear();
 
-    // Set notification token route
     this._routingManager.route(
       {
         bodyParams: {
@@ -51,7 +49,6 @@ export class PushNotificationsRoutes {
       this.handlers.setNotificationToken.bind(this.handlers),
     );
 
-    // Clear notification token route
     this._routingManager.route(
       {
         queryParams: {
@@ -66,7 +63,6 @@ export class PushNotificationsRoutes {
       this.handlers.clearNotificationTokens.bind(this.handlers),
     );
 
-    // Get user notifications route
     this._routingManager.route(
       {
         queryParams: {
@@ -88,7 +84,6 @@ export class PushNotificationsRoutes {
       this.handlers.getUserNotifications.bind(this.handlers),
     );
 
-    // Mark notifications as read route
     this._routingManager.route(
       {
         bodyParams: {


### PR DESCRIPTION
**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other (please describe)

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

**The PR fulfills these requirements:**

- [x] It's submitted to the `main` branch
- [ ] When resolving a specific issue, it's referenced in the PR's description

**Other information:**

SMS verification previously wrapped service responses twice, causing clients to retain `[object Object]` and Twilio Verify checks to fail with error 60200. The handlers now return the actual verification SID and status.

Communications client routes could also remain permanently unavailable when Router started after Communications. The module now watches Router availability and retries awaited registration, so `/token` and `/notifications` no longer depend on module startup order.

Validation:
- `pnpm --filter @conduitplatform/communications exec tsc --noEmit`
- `git diff --check`

A live runner deployment was not performed as part of local validation.
