### PR TITLE
fix(communications): guard template list handlers when params are missing

### DIFF
--- a/modules/communications/src/admin/index.ts
+++ b/modules/communications/src/admin/index.ts
@@ -211,16 +211,15 @@ export class AdminHandlers {
   async getCommunicationTemplates(
     call: ParsedRouterRequest,
   ): Promise<UnparsedRouterResponse> {
-    const { sort } = call.request.params;
-    const { skip } = call.request.params ?? 0;
-    const { limit } = call.request.params ?? 25;
+    const params = call.request.params ?? {};
+    const { sort, skip, limit, search } = params;
     let query: Query<CommunicationTemplate> = {};
     let identifier;
-    if (!isNil(call.request.params.search)) {
-      if (call.request.params.search.match(/^[a-fA-F\d]{24}$/)) {
-        query = { _id: call.request.params.search };
+    if (!isNil(search)) {
+      if (search.match(/^[a-fA-F\d]{24}$/)) {
+        query = { _id: search };
       } else {
-        identifier = escapeStringRegexp(call.request.params.search);
+        identifier = escapeStringRegexp(search);
         query = { name: { $regex: `.*${identifier}.*`, $options: 'i' } };
       }
     }
@@ -328,16 +327,15 @@ export class AdminHandlers {
 
   // Email template management methods
   async getTemplates(call: ParsedRouterRequest): Promise<UnparsedRouterResponse> {
-    const { sort } = call.request.params;
-    const { skip } = call.request.params ?? 0;
-    const { limit } = call.request.params ?? 25;
+    const params = call.request.params ?? {};
+    const { sort, skip, limit, search } = params;
     let query: Query<EmailTemplate> = {};
     let identifier;
-    if (!isNil(call.request.params.search)) {
-      if (call.request.params.search.match(/^[a-fA-F\d]{24}$/)) {
-        query = { _id: call.request.params.search };
+    if (!isNil(search)) {
+      if (search.match(/^[a-fA-F\d]{24}$/)) {
+        query = { _id: search };
       } else {
-        identifier = escapeStringRegexp(call.request.params.search);
+        identifier = escapeStringRegexp(search);
         query = { name: { $regex: `.*${identifier}.*`, $options: 'i' } };
       }
     }

--- a/modules/communications/src/admin/index.ts
+++ b/modules/communications/src/admin/index.ts
@@ -211,8 +211,7 @@ export class AdminHandlers {
   async getCommunicationTemplates(
     call: ParsedRouterRequest,
   ): Promise<UnparsedRouterResponse> {
-    const params = call.request.params ?? {};
-    const { sort, skip, limit, search } = params;
+    const { sort, skip = 0, limit = 25, search } = call.request.params ?? {};
     let query: Query<CommunicationTemplate> = {};
     let identifier;
     if (!isNil(search)) {
@@ -327,8 +326,7 @@ export class AdminHandlers {
 
   // Email template management methods
   async getTemplates(call: ParsedRouterRequest): Promise<UnparsedRouterResponse> {
-    const params = call.request.params ?? {};
-    const { sort, skip, limit, search } = params;
+    const { sort, skip = 0, limit = 25, search } = call.request.params ?? {};
     let query: Query<EmailTemplate> = {};
     let identifier;
     if (!isNil(search)) {


### PR DESCRIPTION
## Summary
- Defaults `call.request.params` to `{}` in `getTemplates` and `getCommunicationTemplates`.
- Prevents destructuring `undefined` when list requests arrive without query parameters.

## Why
`GET /email/templates` with no query string could throw before the handler ran, returning a 500 instead of an empty or paginated result. This hardens the admin API against a class of request-shape failures seen when the Conduit UI loads templates on page entry.

## Related PR
- Conduit UI: https://github.com/ConduitPlatform/Conduit-UI/pull/301

## Test plan
- [ ] Call `GET /email/templates` with no query params — returns 200 with `templateDocuments` and `count`.
- [ ] Call `GET /communications/templates` with no query params — same behavior.
- [ ] Existing skip/limit/search filtering still works.