### PR TITLE
fix(authentication): case-insensitive email lookup in verifyEmailWithCode

### DIFF
--- a/modules/authentication/src/handlers/local.ts
+++ b/modules/authentication/src/handlers/local.ts
@@ -725,8 +725,12 @@ export class LocalHandlers implements IAuthenticationStrategy {
   }
 
   async verifyEmailWithCode(call: ParsedRouterRequest): Promise<UnparsedRouterResponse> {
-    const { email, code } = call.request.params;
-    const foundUser = await User.getInstance().findOne({ email });
+    const email = call.request.params.email.toLowerCase();
+    const { code } = call.request.params;
+    const foundUser = await User.getInstance().findOne(
+      { email },
+      { readPreference: 'primary' },
+    );
     if (!foundUser) {
       throw new GrpcError(status.NOT_FOUND, 'User not found');
     }


### PR DESCRIPTION
## Summary

`POST /authentication/local/verify-email` intermittently returns 404 `User not found` when the client sends the email with different casing than it was stored with (e.g. autofill producing `John.Doe@Gmail.com`):

```
[ERROR]: 5 NOT_FOUND: User not found
[INFO]: POST /authentication/local/verify-email 404
```

## Cause

`verifyEmailWithCode` (introduced in #1092) is the only email-bearing handler in `modules/authentication/src/handlers/local.ts` that skips the `toLowerCase()` normalization applied by every sibling handler (`register`, `authenticate`, `forgotPassword`, `resendVerificationEmail`, `changeEmail`). Since registration stores emails lowercased, the raw client-provided email breaks both:

- the `User.getInstance().findOne({ email })` lookup, and
- the `sha256(email)` Redis key for the OTP — the OTP is stored under the hash of the lowercased email (via `handleEmailVerification` / `resendVerificationEmail`), so even if the user lookup succeeded, the OTP key would not match.

This is the same bug class previously fixed in #648 and #649 for older handlers.

## Fix

- Lowercase the email at the top of `verifyEmailWithCode`; the same local variable feeds both the user lookup and the OTP hash.
- Add `{ readPreference: 'primary' }` to the user lookup, matching the `Token.getInstance().findOne` calls in the same method that were patched in the v0.17 changes — without it, a freshly registered user can be missed on deployments where `queryDefaults.readPreference` routes reads to secondaries.

## Tests

The authentication module currently has no handler test infrastructure (no test script or test files; only the database module has Jest tests), so no regression test is included.