### PR TITLE
fix(admin): strip undeclared config keys so MCP settings updates succeed

### DIFF
--- a/packages/core/src/Core.ts
+++ b/packages/core/src/Core.ts
@@ -3,6 +3,7 @@ import { GrpcServer } from './GrpcServer.js';
 import { isNil } from 'lodash-es';
 import AppConfigSchema, { Config as ConfigSchema } from './config/index.js';
 import convict from 'convict';
+import { stripUndeclaredConfigParams } from './utils/stripUndeclaredConfigParams.js';
 
 export class Core {
   private static _instance: Core;
@@ -34,7 +35,10 @@ export class Core {
 
   async setConfig(moduleConfig: any): Promise<any> {
     const previousConfig = await this.configManager.get('core');
-    let config = { ...previousConfig, ...moduleConfig };
+    let config = stripUndeclaredConfigParams(AppConfigSchema as Record<string, any>, {
+      ...previousConfig,
+      ...moduleConfig,
+    });
     try {
       this.config.load(config).validate({
         allowed: 'strict',

--- a/packages/core/src/Core.ts
+++ b/packages/core/src/Core.ts
@@ -35,7 +35,7 @@ export class Core {
 
   async setConfig(moduleConfig: any): Promise<any> {
     const previousConfig = await this.configManager.get('core');
-    let config = stripUndeclaredConfigParams(AppConfigSchema as Record<string, any>, {
+    let config = stripUndeclaredConfigParams(AppConfigSchema, {
       ...previousConfig,
       ...moduleConfig,
     });

--- a/packages/core/src/admin/AdminModule.ts
+++ b/packages/core/src/admin/AdminModule.ts
@@ -119,21 +119,8 @@ export default class AdminModule {
       previousConfig,
       AdminConfigRawSchema,
     );
-    // Drop undeclared keys left in stored config after schema removals (e.g. transports.proxy).
-    let adminConfig = stripUndeclaredConfigParams(
-      AdminConfigRawSchema as Record<string, any>,
-      loadedConfig,
-    );
-    try {
-      this.config.load(adminConfig).validate({ allowed: 'strict' });
-      adminConfig = this.config.getProperties();
-      await this.configManager.set('admin', adminConfig);
-    } catch (e) {
-      ConduitGrpcSdk.Logger.warn(
-        `Could not sanitize admin config on startup: ${(e as Error).message}`,
-      );
-      adminConfig = loadedConfig;
-    }
+    const adminConfig = stripUndeclaredConfigParams(AdminConfigRawSchema, loadedConfig);
+    await this.configManager.set('admin', adminConfig);
     ConfigController.getInstance().config = adminConfig;
     const __filename = fileURLToPath(import.meta.url);
     const __dirname = path.dirname(__filename);
@@ -309,16 +296,11 @@ export default class AdminModule {
 
   async setConfig(moduleConfig: any) {
     const previousConfig = await this.configManager.get('admin');
-    const config = merge(previousConfig, moduleConfig);
+    let config = merge(previousConfig, moduleConfig);
     await generateConfigDefaults(config);
-    // Strip legacy undeclared keys (e.g. transports.proxy) before strict validation.
-    // Convict getProperties() retains undeclared keys that were loaded, so warn+get is not enough.
-    const sanitizedConfig = stripUndeclaredConfigParams(
-      AppConfigSchema as Record<string, any>,
-      config,
-    );
+    config = stripUndeclaredConfigParams(AppConfigSchema, config);
     try {
-      this.config.load(sanitizedConfig).validate({
+      this.config.load(config).validate({
         allowed: 'strict',
       });
     } catch (e) {
@@ -326,11 +308,11 @@ export default class AdminModule {
       this.config.load(previousConfig);
       throw new ConduitError('INVALID_ARGUMENT', 400, (e as Error).message);
     }
-    const updatedConfig = this.config.getProperties();
-    this.grpcSdk.bus!.publish('core:config:update', JSON.stringify(updatedConfig));
-    ConfigController.getInstance().config = updatedConfig;
+    config = this.config.getProperties();
+    this.grpcSdk.bus!.publish('core:config:update', JSON.stringify(config));
+    ConfigController.getInstance().config = config;
     this.onConfig();
-    return updatedConfig;
+    return config;
   }
 
   protected onConfig() {

--- a/packages/core/src/admin/AdminModule.ts
+++ b/packages/core/src/admin/AdminModule.ts
@@ -46,6 +46,7 @@ import { loadReadinessConfig } from '../health/config.js';
 import { getReadinessMiddleware } from '../health/readinessMiddleware.js';
 import { ReadinessService } from '../health/ReadinessService.js';
 import type { CoreHealthProvider } from '../health/types.js';
+import { stripUndeclaredConfigParams } from '../utils/stripUndeclaredConfigParams.js';
 
 export default class AdminModule {
   grpcSdk: ConduitGrpcSdk;
@@ -113,11 +114,27 @@ export default class AdminModule {
     const previousConfig =
       (await this.configManager.get('admin')) ?? this.config.getProperties();
     await generateConfigDefaults(previousConfig);
-    ConfigController.getInstance().config = await this.configManager.configurePackage(
+    const loadedConfig = await this.configManager.configurePackage(
       'admin',
       previousConfig,
       AdminConfigRawSchema,
     );
+    // Drop undeclared keys left in stored config after schema removals (e.g. transports.proxy).
+    let adminConfig = stripUndeclaredConfigParams(
+      AdminConfigRawSchema as Record<string, any>,
+      loadedConfig,
+    );
+    try {
+      this.config.load(adminConfig).validate({ allowed: 'strict' });
+      adminConfig = this.config.getProperties();
+      await this.configManager.set('admin', adminConfig);
+    } catch (e) {
+      ConduitGrpcSdk.Logger.warn(
+        `Could not sanitize admin config on startup: ${(e as Error).message}`,
+      );
+      adminConfig = loadedConfig;
+    }
+    ConfigController.getInstance().config = adminConfig;
     const __filename = fileURLToPath(import.meta.url);
     const __dirname = path.dirname(__filename);
     await server.addService(
@@ -294,8 +311,14 @@ export default class AdminModule {
     const previousConfig = await this.configManager.get('admin');
     const config = merge(previousConfig, moduleConfig);
     await generateConfigDefaults(config);
+    // Strip legacy undeclared keys (e.g. transports.proxy) before strict validation.
+    // Convict getProperties() retains undeclared keys that were loaded, so warn+get is not enough.
+    const sanitizedConfig = stripUndeclaredConfigParams(
+      AppConfigSchema as Record<string, any>,
+      config,
+    );
     try {
-      this.config.load(config).validate({
+      this.config.load(sanitizedConfig).validate({
         allowed: 'strict',
       });
     } catch (e) {
@@ -303,10 +326,11 @@ export default class AdminModule {
       this.config.load(previousConfig);
       throw new ConduitError('INVALID_ARGUMENT', 400, (e as Error).message);
     }
-    this.grpcSdk.bus!.publish('core:config:update', JSON.stringify(config));
-    ConfigController.getInstance().config = config;
+    const updatedConfig = this.config.getProperties();
+    this.grpcSdk.bus!.publish('core:config:update', JSON.stringify(updatedConfig));
+    ConfigController.getInstance().config = updatedConfig;
     this.onConfig();
-    return config;
+    return updatedConfig;
   }
 
   protected onConfig() {

--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -2,8 +2,6 @@ import { Indexable } from '@conduitplatform/grpc-sdk';
 
 import * as deepdash from 'deepdash-es/standalone';
 
-export { stripUndeclaredConfigParams } from './stripUndeclaredConfigParams.js';
-
 export default function parseConfigSchema(schema: Indexable) {
   delete schema.doc;
   deepdash.eachDeep(schema, (value: any, key: string | number, parentValue: any) => {

--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -2,6 +2,8 @@ import { Indexable } from '@conduitplatform/grpc-sdk';
 
 import * as deepdash from 'deepdash-es/standalone';
 
+export { stripUndeclaredConfigParams } from './stripUndeclaredConfigParams.js';
+
 export default function parseConfigSchema(schema: Indexable) {
   delete schema.doc;
   deepdash.eachDeep(schema, (value: any, key: string | number, parentValue: any) => {

--- a/packages/core/src/utils/stripUndeclaredConfigParams.ts
+++ b/packages/core/src/utils/stripUndeclaredConfigParams.ts
@@ -1,25 +1,21 @@
-/**
- * Convict `getProperties()` retains undeclared keys that were loaded into the config.
- * After schema removals (e.g. transports.proxy), stored config can still contain those
- * keys; merging them back in and validating with `allowed: 'strict'` fails.
- * This keeps only keys declared in the Convict schema document.
- */
+import { Indexable } from '@conduitplatform/grpc-sdk';
+
 function isConvictLeaf(node: unknown): boolean {
   if (!node || typeof node !== 'object' || Array.isArray(node)) {
     return false;
   }
-  const record = node as Record<string, unknown>;
-  return 'format' in record || 'default' in record || 'type' in record || 'env' in record;
+  return 'format' in node || 'default' in node || 'type' in node || 'env' in node;
 }
 
+/** Keeps only keys declared in a Convict schema document. */
 export function stripUndeclaredConfigParams(
-  schema: Record<string, any>,
-  config: Record<string, any> | null | undefined,
-): Record<string, any> {
+  schema: Indexable,
+  config: Indexable,
+): Indexable {
   if (!config || typeof config !== 'object' || Array.isArray(config)) {
-    return config as Record<string, any>;
+    return config;
   }
-  const result: Record<string, any> = {};
+  const result: Indexable = {};
   for (const key of Object.keys(schema)) {
     if (!(key in config)) continue;
     const schemaNode = schema[key];

--- a/packages/core/src/utils/stripUndeclaredConfigParams.ts
+++ b/packages/core/src/utils/stripUndeclaredConfigParams.ts
@@ -1,0 +1,33 @@
+/**
+ * Convict `getProperties()` retains undeclared keys that were loaded into the config.
+ * After schema removals (e.g. transports.proxy), stored config can still contain those
+ * keys; merging them back in and validating with `allowed: 'strict'` fails.
+ * This keeps only keys declared in the Convict schema document.
+ */
+function isConvictLeaf(node: unknown): boolean {
+  if (!node || typeof node !== 'object' || Array.isArray(node)) {
+    return false;
+  }
+  const record = node as Record<string, unknown>;
+  return 'format' in record || 'default' in record || 'type' in record || 'env' in record;
+}
+
+export function stripUndeclaredConfigParams(
+  schema: Record<string, any>,
+  config: Record<string, any> | null | undefined,
+): Record<string, any> {
+  if (!config || typeof config !== 'object' || Array.isArray(config)) {
+    return config as Record<string, any>;
+  }
+  const result: Record<string, any> = {};
+  for (const key of Object.keys(schema)) {
+    if (!(key in config)) continue;
+    const schemaNode = schema[key];
+    if (isConvictLeaf(schemaNode)) {
+      result[key] = config[key];
+    } else if (schemaNode && typeof schemaNode === 'object') {
+      result[key] = stripUndeclaredConfigParams(schemaNode, config[key]);
+    }
+  }
+  return result;
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Admin settings updates (including enabling MCP) fail on deployments that still have the removed `transports.proxy` key in stored admin config:

```
INVALID_ARGUMENT: configuration param 'transports.proxy' not declared in the schema
```

This is a server-side issue: `AdminModule.setConfig` merges the PATCH body with the previous stored config, so the deprecated key is reintroduced even when the UI sends a clean payload. Convict then rejects it under `allowed: 'strict'`. Convict’s `getProperties()` also retains undeclared keys that were loaded, so switching to `allowed: 'warn'` alone would not clean them.

## Changes

- Add `stripUndeclaredConfigParams` to keep only Convict-schema-declared keys
- Strip undeclared keys in `AdminModule.setConfig` before strict validation, and persist `getProperties()`
- Strip undeclared keys from admin config on startup and rewrite stored config
- Apply the same strip-before-validate guard in `Core.setConfig`

## Test plan

- [ ] On a deployment whose stored admin config still includes `transports.proxy`, PATCH `/config/admin` to enable `transports.mcp` and confirm it succeeds
- [ ] Confirm the saved admin config no longer contains `transports.proxy`
- [ ] Restart Core and confirm GET `/config/admin` no longer returns `transports.proxy`
- [ ] Confirm still-invalid declared values (wrong types) continue to return `INVALID_ARGUMENT`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-583f6067-d5e7-4cb3-afde-1ab2a1b5bc62?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-583f6067-d5e7-4cb3-afde-1ab2a1b5bc62&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

