### PR TITLE
refactor(functions): deslop cron scheduler from #1507

### DIFF
--- a/modules/authentication/src/handlers/twoFa.ts
+++ b/modules/authentication/src/handlers/twoFa.ts
@@ -535,7 +535,7 @@ export class TwoFa implements IAuthenticationStrategy {
   }
 
   private async enableAuthenticator2Fa(user: User): Promise<string> {
-    const secret = await node2fa.generateSecret({
+    const secret = node2fa.generateSecret({
       //to do: add logic for app name insertion
       name: 'Conduit',
       // add another string when mail is not available

--- a/modules/functions/package.json
+++ b/modules/functions/package.json
@@ -25,7 +25,7 @@
     "build:bundle": "rimraf bundle && node ../../libraries/service-bundle/dist/cli.js generate-manifest && tsup && node ../../libraries/service-bundle/dist/cli.js copy-assets && node ../../libraries/service-bundle/dist/cli.js generate-lockfile",
     "prepare": "npm run build",
     "generateTypes": "sh build.sh",
-    "test": "tsc -p tsconfig.test.json && node --test dist-test/controllers/*.test.js",
+    "test": "tsc -p tsconfig.test.json && node --test dist-test/__tests__/*.test.js",
     "build:docker": "docker build -t ghcr.io/conduitplatform/functions:latest -f ./Dockerfile ../../ && docker push ghcr.io/conduitplatform/functions:latest"
   },
   "directories": {

--- a/modules/functions/src/Functions.ts
+++ b/modules/functions/src/Functions.ts
@@ -76,7 +76,6 @@ export default class Functions extends ManagedModule<Config> {
     if (moduleName !== 'router' || !serving || this.isRunning) return;
     this.isRunning = true;
     this.functionsController = new FunctionController(this.grpcServer, this.grpcSdk);
-    CronQueueController.getInstance(this.grpcSdk);
     this.adminRouter = new AdminHandlers(
       this.grpcServer,
       this.grpcSdk,

--- a/modules/functions/src/__tests__/cron.utils.test.ts
+++ b/modules/functions/src/__tests__/cron.utils.test.ts
@@ -8,7 +8,7 @@ import {
   parseCronJobFunctionId,
   planCronSync,
   validateCronPattern,
-} from './cron.utils.js';
+} from '../controllers/cron.utils.js';
 
 describe('cron.utils', () => {
   describe('parseCronJobFunctionId', () => {

--- a/modules/functions/src/__tests__/utils.background.test.ts
+++ b/modules/functions/src/__tests__/utils.background.test.ts
@@ -3,7 +3,7 @@ import assert from 'node:assert/strict';
 import { ConduitGrpcSdk } from '@conduitplatform/grpc-sdk';
 import { FunctionExecutions } from '../models/index.js';
 import type { Functions } from '../models/index.js';
-import { compileFunctionCode, executeBackgroundFunction } from './utils.js';
+import { compileFunctionCode, executeBackgroundFunction } from '../controllers/utils.js';
 
 const originalGetInstance = FunctionExecutions.getInstance;
 

--- a/modules/functions/src/controllers/cronQueue.controller.ts
+++ b/modules/functions/src/controllers/cronQueue.controller.ts
@@ -61,6 +61,40 @@ export class CronQueueController {
     return this.cronQueue.getRepeatableJobs();
   }
 
+  private async executeCronJob(job: Job<{ functionId: string }>): Promise<void> {
+    const func = await Functions.getInstance().findOne(
+      { _id: job.data.functionId },
+      { readPreference: 'primary' },
+    );
+    if (!func || func.functionType !== 'cron') {
+      return;
+    }
+    const cronPattern = getCronPatternFromInputs(func.inputs);
+    if (!cronPattern) {
+      ConduitGrpcSdk.Logger.warn(
+        `Cron function ${func.name} (${func._id}) has no pattern; skipping tick`,
+      );
+      return;
+    }
+    const compiled =
+      this.compiledFunctions.get(func._id) ?? compileFunctionCode(func.functionCode);
+    const scheduledAt = new Date().toISOString();
+    ConduitGrpcSdk.Logger.log(
+      `Cron tick for ${func.name} (${cronPattern}) at ${scheduledAt}`,
+    );
+    await executeBackgroundFunction(
+      func,
+      {
+        scheduledAt,
+        cronPattern,
+        trigger: 'cron',
+      },
+      compiled,
+      this.grpcSdk,
+    );
+    ConduitGrpcSdk.Logger.log(`Cron execution completed for ${func.name}`);
+  }
+
   async ensureWorker(lockDuration: number): Promise<Worker | undefined> {
     if (!this.shouldSchedule()) {
       return this.cronWorker;
@@ -75,39 +109,7 @@ export class CronQueueController {
     }
     this.cronWorker = new Worker(
       CRON_QUEUE_NAME,
-      async (job: Job<{ functionId: string }>) => {
-        const func = await Functions.getInstance().findOne(
-          { _id: job.data.functionId },
-          { readPreference: 'primary' },
-        );
-        if (!func || func.functionType !== 'cron') {
-          return;
-        }
-        const cronPattern = getCronPatternFromInputs(func.inputs);
-        if (!cronPattern) {
-          ConduitGrpcSdk.Logger.warn(
-            `Cron function ${func.name} (${func._id}) has no pattern; skipping tick`,
-          );
-          return;
-        }
-        const compiled =
-          this.compiledFunctions.get(func._id) ?? compileFunctionCode(func.functionCode);
-        const scheduledAt = new Date().toISOString();
-        ConduitGrpcSdk.Logger.log(
-          `Cron tick for ${func.name} (${cronPattern}) at ${scheduledAt}`,
-        );
-        await executeBackgroundFunction(
-          func,
-          {
-            scheduledAt,
-            cronPattern,
-            trigger: 'cron',
-          },
-          compiled,
-          this.grpcSdk,
-        );
-        ConduitGrpcSdk.Logger.log(`Cron execution completed for ${func.name}`);
-      },
+      job => this.executeCronJob(job),
       {
         concurrency: 1,
         lockDuration,
@@ -220,25 +222,21 @@ export class CronQueueController {
     }
   }
 
+  private lockDurationFromTimeouts(timeouts: Array<number | undefined>): number {
+    const maxTimeout = timeouts.reduce(
+      (max, timeout) => Math.max(max, timeout ?? DEFAULT_FUNCTION_TIMEOUT_MS),
+      DEFAULT_FUNCTION_TIMEOUT_MS,
+    );
+    return maxTimeout + LOCK_BUFFER_MS;
+  }
+
   private async lockDurationForCronFunctions(): Promise<number> {
     type CronTimeout = Pick<Functions, 'timeout'>;
     const cronDocs = (await Functions.getInstance().findMany(
       { functionType: 'cron' },
       { select: 'timeout', readPreference: 'primary' },
     )) as CronTimeout[];
-    const maxTimeout = cronDocs.reduce(
-      (max, func) => Math.max(max, func.timeout ?? DEFAULT_FUNCTION_TIMEOUT_MS),
-      DEFAULT_FUNCTION_TIMEOUT_MS,
-    );
-    return maxTimeout + LOCK_BUFFER_MS;
-  }
-
-  private lockDurationFromFunctions(cronFunctions: Functions[]): number {
-    const maxTimeout = cronFunctions.reduce(
-      (max, func) => Math.max(max, func.timeout ?? DEFAULT_FUNCTION_TIMEOUT_MS),
-      DEFAULT_FUNCTION_TIMEOUT_MS,
-    );
-    return maxTimeout + LOCK_BUFFER_MS;
+    return this.lockDurationFromTimeouts(cronDocs.map(func => func.timeout));
   }
 
   private async reconcileCronJobs(): Promise<number> {
@@ -270,9 +268,6 @@ export class CronQueueController {
       try {
         if (item.existingKey) {
           await this.cronQueue.removeRepeatableByKey(item.existingKey);
-          updated += 1;
-        } else {
-          registered += 1;
         }
         await this.cronQueue.add(
           CRON_JOB_NAME,
@@ -284,23 +279,23 @@ export class CronQueueController {
             removeOnFail: { age: 24 * 3600 },
           },
         );
+        if (item.existingKey) {
+          updated += 1;
+        } else {
+          registered += 1;
+        }
       } catch (err) {
         ConduitGrpcSdk.Logger.error(
           `Failed to schedule cron job ${item.jobId}: ${(err as Error).message}`,
         );
         errors += 1;
-        if (item.existingKey) {
-          updated -= 1;
-        } else {
-          registered -= 1;
-        }
       }
     }
 
     ConduitGrpcSdk.Logger.log(
       `Cron sync complete: registered=${registered}, updated=${updated}, unchanged=${plan.unchangedJobIds.length}, removed=${removed}, skipped=${plan.skipped.length}, errors=${errors}`,
     );
-    return this.lockDurationFromFunctions(cronFunctions);
+    return this.lockDurationFromTimeouts(cronFunctions.map(func => func.timeout));
   }
 
   private setupWorkerEventHandlers(worker: Worker): void {

--- a/modules/functions/src/controllers/cronQueue.controller.ts
+++ b/modules/functions/src/controllers/cronQueue.controller.ts
@@ -107,18 +107,14 @@ export class CronQueueController {
       this.cronWorker = undefined;
       this.workerLockDuration = 0;
     }
-    this.cronWorker = new Worker(
-      CRON_QUEUE_NAME,
-      job => this.executeCronJob(job),
-      {
-        concurrency: 1,
-        lockDuration,
-        maxStalledCount: 0,
-        removeOnComplete: { age: 3600, count: 1000 },
-        removeOnFail: { age: 24 * 3600 },
-        connection: this.redisConnection,
-      },
-    );
+    this.cronWorker = new Worker(CRON_QUEUE_NAME, job => this.executeCronJob(job), {
+      concurrency: 1,
+      lockDuration,
+      maxStalledCount: 0,
+      removeOnComplete: { age: 3600, count: 1000 },
+      removeOnFail: { age: 24 * 3600 },
+      connection: this.redisConnection,
+    });
     this.workerLockDuration = lockDuration;
     this.setupWorkerEventHandlers(this.cronWorker);
     if (!this.shouldSchedule()) {

--- a/modules/functions/src/controllers/cronQueue.controller.ts
+++ b/modules/functions/src/controllers/cronQueue.controller.ts
@@ -223,10 +223,10 @@ export class CronQueueController {
   }
 
   private lockDurationFromTimeouts(timeouts: Array<number | undefined>): number {
-    const maxTimeout = timeouts.reduce(
-      (max, timeout) => Math.max(max, timeout ?? DEFAULT_FUNCTION_TIMEOUT_MS),
-      DEFAULT_FUNCTION_TIMEOUT_MS,
-    );
+    let maxTimeout = DEFAULT_FUNCTION_TIMEOUT_MS;
+    for (const timeout of timeouts) {
+      maxTimeout = Math.max(maxTimeout, timeout ?? DEFAULT_FUNCTION_TIMEOUT_MS);
+    }
     return maxTimeout + LOCK_BUFFER_MS;
   }
 

--- a/modules/functions/src/controllers/function.controller.ts
+++ b/modules/functions/src/controllers/function.controller.ts
@@ -6,12 +6,12 @@ import {
   ConduitSocketOptions,
 } from '@conduitplatform/grpc-sdk';
 import {
+  ConfigController,
   GrpcServer,
   RequestHandlers,
   RoutingManager,
   SocketEventHandler,
 } from '@conduitplatform/module-tools';
-import { ConfigController } from '@conduitplatform/module-tools';
 
 import { Functions } from '../models/index.js';
 import { CronQueueController } from './cronQueue.controller.js';
@@ -33,8 +33,10 @@ type Middleware = {
   handler: RequestHandlers;
 };
 
+type FunctionRoute = Route | Socket | Middleware;
+
 export class FunctionController {
-  private functionRoutes: (Route | Socket | Middleware)[] = [];
+  private functionRoutes: FunctionRoute[] = [];
   private readonly compiledCronFunctions = new Map<string, CompiledUserFunction>();
 
   private _routingManager: RoutingManager;
@@ -54,77 +56,66 @@ export class FunctionController {
     });
   }
 
-  refreshRoutes() {
-    return Functions.getInstance()
-      .findMany({}, { readPreference: 'primary' })
-      .then(async r => {
-        if (!r || r.length == 0) {
-          ConduitGrpcSdk.Logger.log('No functions to register');
-        }
-        this.functionRoutes = [];
-        this.compiledCronFunctions.clear();
+  async refreshRoutes() {
+    try {
+      const functions = await Functions.getInstance().findMany(
+        {},
+        { readPreference: 'primary' },
+      );
+      if (!functions || functions.length === 0) {
+        ConduitGrpcSdk.Logger.log('No functions to register');
+      }
+      this.functionRoutes = [];
+      this.compiledCronFunctions.clear();
 
-        for (const func of r) {
-          try {
-            if (func.functionType === 'cron') {
-              try {
-                this.compiledCronFunctions.set(func._id, tryPrepareCronFunction(func));
-              } catch (err) {
-                ConduitGrpcSdk.Logger.error(
-                  `Failed to prepare cron function ${func.name} (${func._id})`,
-                );
-                ConduitGrpcSdk.Logger.error(err as Error);
-              }
-              continue;
-            }
-            const route = createFunctionRoute(func, this.grpcSdk);
-            if (route) {
-              this.functionRoutes.push(route as any);
-            }
-          } catch (err) {
-            ConduitGrpcSdk.Logger.error(
-              `Failed to process function ${func.name} (${func._id}); skipping`,
-            );
-            ConduitGrpcSdk.Logger.error(err as Error);
+      for (const func of functions) {
+        try {
+          if (func.functionType === 'cron') {
+            this.compiledCronFunctions.set(func._id, tryPrepareCronFunction(func));
+            continue;
           }
+          const route = createFunctionRoute(func, this.grpcSdk);
+          if (route) {
+            this.functionRoutes.push(route as FunctionRoute);
+          }
+        } catch (err) {
+          ConduitGrpcSdk.Logger.error(
+            `Failed to process function ${func.name} (${func._id}); skipping`,
+          );
+          ConduitGrpcSdk.Logger.error(err as Error);
         }
-        this._routingManager.clear();
-        this.functionRoutes.forEach(route => {
-          if ((route as Socket).events) {
-            this._routingManager.socket(
-              (route as Socket).input,
-              (route as Socket).events,
-            );
-          } else if (!(route as Middleware).hasOwnProperty('returnType')) {
-            this._routingManager.middleware(
-              (route as Middleware).input,
-              (route as Middleware).handler,
-            );
-          } else {
-            this._routingManager.route(
-              (route as Route).input,
-              (route as Route).returnType,
-              (route as Route).handler,
-            );
-          }
-        });
-        await this._routingManager.registerRoutes();
-        ConduitGrpcSdk.Logger.log('Refreshed routes');
-
-        if (ConfigController.getInstance().config.active) {
-          const cronQueue = CronQueueController.getInstance(this.grpcSdk);
-          cronQueue.setCompiledFunctions(this.compiledCronFunctions);
-          if (ConfigController.getInstance().config.active) {
-            await cronQueue.syncCronJobs();
-          }
+      }
+      this._routingManager.clear();
+      this.functionRoutes.forEach(route => {
+        if ((route as Socket).events) {
+          this._routingManager.socket((route as Socket).input, (route as Socket).events);
+        } else if (!(route as Middleware).hasOwnProperty('returnType')) {
+          this._routingManager.middleware(
+            (route as Middleware).input,
+            (route as Middleware).handler,
+          );
+        } else {
+          this._routingManager.route(
+            (route as Route).input,
+            (route as Route).returnType,
+            (route as Route).handler,
+          );
         }
-      })
-      .catch((err: Error) => {
-        ConduitGrpcSdk.Logger.error(
-          'Something went wrong when loading functions to the router',
-        );
-        ConduitGrpcSdk.Logger.error(err);
       });
+      await this._routingManager.registerRoutes();
+      ConduitGrpcSdk.Logger.log('Refreshed routes');
+
+      if (ConfigController.getInstance().config.active) {
+        const cronQueue = CronQueueController.getInstance(this.grpcSdk);
+        cronQueue.setCompiledFunctions(this.compiledCronFunctions);
+        await cronQueue.syncCronJobs();
+      }
+    } catch (err) {
+      ConduitGrpcSdk.Logger.error(
+        'Something went wrong when loading functions to the router',
+      );
+      ConduitGrpcSdk.Logger.error(err as Error);
+    }
   }
 
   refreshEndpoints(): void {

--- a/modules/functions/src/migrations/index.ts
+++ b/modules/functions/src/migrations/index.ts
@@ -3,7 +3,6 @@ import { Functions } from '../models/index.js';
 import { getCronPatternFromInputs } from '../controllers/cron.utils.js';
 
 export async function runMigrations(_grpcSdk: ConduitGrpcSdk) {
-  void _grpcSdk;
   const cronFunctions = await Functions.getInstance().findMany({
     functionType: 'cron',
   });

--- a/modules/functions/tsconfig.json
+++ b/modules/functions/tsconfig.json
@@ -67,5 +67,12 @@
     "forceConsistentCasingInFileNames": true /* Disallow inconsistently-cased references to the same file. */
   },
   "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist", "bundle", "tsup.config.ts", "src/**/*.test.ts"]
+  "exclude": [
+    "node_modules",
+    "dist",
+    "bundle",
+    "tsup.config.ts",
+    "src/**/*.test.ts",
+    "src/__tests__"
+  ]
 }

--- a/packages/core/src/admin/routes/ToggleTwoFa.route.ts
+++ b/packages/core/src/admin/routes/ToggleTwoFa.route.ts
@@ -37,7 +37,7 @@ export function toggleTwoFaRoute() {
           return '2FA already enabled';
         }
 
-        const secret = await generateSecret({
+        const secret = generateSecret({
           name: 'Conduit',
           account: admin.username,
         });

--- a/packages/core/src/admin/utils/auth.ts
+++ b/packages/core/src/admin/utils/auth.ts
@@ -51,6 +51,6 @@ export async function verify2Fa(admin: Admin, code: string) {
   return signToken({ id: admin._id }, tokenSecret, tokenExpirationTime);
 }
 
-export async function generateSecret(options?: { name: string; account: string }) {
+export function generateSecret(options?: { name: string; account: string }) {
   return twoFactor.generateSecret(options);
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -22,8 +22,6 @@ overrides:
 allowBuilds:
   '@apollo/protobufjs': true
   '@firebase/util': true
-  '@parcel/watcher': true
-  '@scarf/scarf': false
   bcrypt: true
   core-js: true
   esbuild: true


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

PR #1507’s cron scheduler works, but the new code was noisy: nested try/catch in `refreshRoutes`, a duplicate `config.active` check, tests sitting next to controllers, and unrelated 2FA / `pnpm-workspace` drive-bys.

## Summary

Cleanup only — scheduling, drain, and lock behavior are unchanged.

- Flatten `refreshRoutes` to one try per function; cron prep failures still skip that function
- Drop the inner `config.active` check and the discarded `CronQueueController.getInstance()` call
- Extract the BullMQ worker handler and count register/update only after `queue.add` succeeds
- Move unit tests to `modules/functions/src/__tests__/`
- Revert unrelated `generateSecret` / `allowBuilds` changes from the cron PR

**What kind of change does this PR introduce?**

- [ ] Bugfix
- [ ] Feature
- [x] Code style update
- [x] Refactor
- [ ] Build-related changes
- [ ] Other (please describe)

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

**The PR fulfills these requirements:**

- [ ] It's submitted to the `main` branch

This is a cleanup PR into `feat/functions-cron-scheduler` (#1507).

## Test plan

- [x] `pnpm --filter @conduitplatform/functions test` — 19/19 passed
- [x] `pnpm --filter @conduitplatform/functions exec tsc --noEmit`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b99b97f5-f179-4dda-ae3c-1c2e79a43a95?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b99b97f5-f179-4dda-ae3c-1c2e79a43a95&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

