### PR TITLE
feat(database): stream live document updates over admin sockets

### DIFF
--- a/docker/.env
+++ b/docker/.env
@@ -26,7 +26,7 @@ DB_TYPE="mongodb"
 DB_USER="conduit"
 DB_PASS="pass"
 DB_PORT="27017"
-DB_CONN_URI="mongodb://conduit:pass@conduit-mongo:27017/conduit?authSource=admin"  # profile: mongodb
+DB_CONN_URI="mongodb://conduit:pass@conduit-mongo:27017/conduit?authSource=admin&replicaSet=rs0"  # profile: mongodb
 #DB_CONN_URI="postgres://conduit:pass@conduit-postgres:5432/conduit"               # profile: postgres
 
 # Security

--- a/docker/docker-compose.standalone.yml
+++ b/docker/docker-compose.standalone.yml
@@ -38,7 +38,7 @@ services:
       ADMIN_SOCKET_PORT: '${ADMIN_SOCKET_PORT:-3031}'
       __DEFAULT_HOST_URL: '${ADMIN_DEFAULT_HOST_URL:-http://localhost:3030}'
       GRPC_KEY: '${GRPC_KEY}'
-      DB_CONN_URI: '${DB_CONN_URI:-mongodb://conduit:pass@conduit-mongo:27017/conduit?authSource=admin}'
+      DB_CONN_URI: '${DB_CONN_URI:-mongodb://conduit:pass@conduit-mongo:27017/conduit?authSource=admin&replicaSet=rs0}'
     networks:
       default:
         aliases:
@@ -74,12 +74,35 @@ services:
       MONGO_INITDB_DATABASE: 'conduit'
       MONGO_INITDB_ROOT_USERNAME: '${DB_USER:-conduit}'
       MONGO_INITDB_ROOT_PASSWORD: '${DB_PASS:-pass}'
+    entrypoint:
+      - bash
+      - -c
+      - |
+        cp /mongo-keyfile /tmp/keyfile
+        chmod 400 /tmp/keyfile
+        chown mongodb:mongodb /tmp/keyfile
+        exec docker-entrypoint.sh mongod --replSet rs0 --bind_ip_all --keyFile /tmp/keyfile
     networks:
       default:
         aliases:
           - conduit-mongo
     volumes:
       - mongo:/data/db
+      - ./mongo/keyfile:/mongo-keyfile:ro
+
+  mongo-init-replica:
+    container_name: 'conduit-mongo-init'
+    image: 'docker.io/library/mongo:4.4.15'
+    restart: on-failure
+    depends_on:
+      - mongodb
+    environment:
+      MONGO_HOST: 'conduit-mongo'
+      MONGO_INITDB_ROOT_USERNAME: '${DB_USER:-conduit}'
+      MONGO_INITDB_ROOT_PASSWORD: '${DB_PASS:-pass}'
+    volumes:
+      - ./mongo/init-replica.sh:/init-replica.sh:ro
+    command: ['bash', '/init-replica.sh']
 
 # Persistent Volumes
 volumes:

--- a/docker/docker-compose.standalone.yml
+++ b/docker/docker-compose.standalone.yml
@@ -15,8 +15,12 @@ services:
     image: 'docker.io/conduitplatform/conduit-standalone:${IMAGE_TAG}'
     restart: unless-stopped
     depends_on:
-      - redis
-      - mongodb
+      redis:
+        condition: service_started
+      mongodb:
+        condition: service_started
+      mongo-init-replica:
+        condition: service_completed_successfully
     ports:
       - '${CORE_GRPC_PORT:-55152}:55152'
       - '${DB_GRPC_PORT:-55160}:55160'

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -85,7 +85,7 @@ services:
       LOKI_URL: 'http://conduit-loki:3100'
       GRPC_KEY: '${GRPC_KEY}'
       DB_TYPE: '${DB_TYPE:-mongodb}'
-      DB_CONN_URI: '${DB_CONN_URI:-mongodb://conduit:pass@conduit-mongo:27017/conduit?authSource=admin}'
+      DB_CONN_URI: '${DB_CONN_URI:-mongodb://conduit:pass@conduit-mongo:27017/conduit?authSource=admin&replicaSet=rs0}'
     networks:
       default:
         aliases:
@@ -271,12 +271,40 @@ services:
       MONGO_INITDB_ROOT_USERNAME: '${DB_USER:-conduit}'
       MONGO_INITDB_ROOT_PASSWORD: '${DB_PASS:-pass}'
     profiles: ['mongodb']
+    entrypoint:
+      - bash
+      - -c
+      - |
+        cp /mongo-keyfile /tmp/keyfile
+        chmod 400 /tmp/keyfile
+        chown mongodb:mongodb /tmp/keyfile
+        exec docker-entrypoint.sh mongod --replSet rs0 --bind_ip_all --keyFile /tmp/keyfile
     networks:
       default:
         aliases:
           - conduit-mongo
     volumes:
       - mongo:/data/db
+      - ./mongo/keyfile:/mongo-keyfile:ro
+
+  mongo-init-replica:
+    container_name: 'conduit-mongo-init'
+    image: 'docker.io/library/mongo:4.4.15'
+    restart: on-failure
+    profiles: ['mongodb']
+    depends_on:
+      - mongodb
+    environment:
+      MONGO_HOST: 'conduit-mongo'
+      MONGO_INITDB_ROOT_USERNAME: '${DB_USER:-conduit}'
+      MONGO_INITDB_ROOT_PASSWORD: '${DB_PASS:-pass}'
+    volumes:
+      - ./mongo/init-replica.sh:/init-replica.sh:ro
+    command: ['bash', '/init-replica.sh']
+    networks:
+      default:
+        aliases:
+          - conduit-mongo-init
 
   postgres:
     container_name: 'conduit-postgres'

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -71,10 +71,21 @@ services:
     image: 'docker.io/conduitplatform/database:${IMAGE_TAG}'
     restart: unless-stopped
     depends_on:
-      - core
-      - ${DB_TYPE:-mongodb}
-      - prometheus
-      - loki
+      core:
+        condition: service_started
+      prometheus:
+        condition: service_started
+      loki:
+        condition: service_started
+      mongodb:
+        condition: service_started
+        required: false
+      postgres:
+        condition: service_started
+        required: false
+      mongo-init-replica:
+        condition: service_completed_successfully
+        required: false
     ports:
       - '${DB_GRPC_PORT:-55160}:${DB_GRPC_PORT:-55160}'
     environment:

--- a/docker/mongo/init-replica.sh
+++ b/docker/mongo/init-replica.sh
@@ -4,17 +4,31 @@ HOST="${MONGO_HOST:-conduit-mongo}"
 USER="${MONGO_INITDB_ROOT_USERNAME:-conduit}"
 PASS="${MONGO_INITDB_ROOT_PASSWORD:-pass}"
 
-until mongo --host "$HOST" -u "$USER" -p "$PASS" --authenticationDatabase admin --quiet --eval 'db.adminCommand({ ping: 1 })' >/dev/null 2>&1; do
+mongo_eval() {
+  mongo --host "$HOST" -u "$USER" -p "$PASS" --authenticationDatabase admin --quiet --eval "$1"
+}
+
+until mongo_eval 'db.adminCommand({ ping: 1 })' >/dev/null 2>&1; do
   sleep 2
 done
 
-mongo --host "$HOST" -u "$USER" -p "$PASS" --authenticationDatabase admin --quiet --eval '
-  try {
-    rs.status();
-  } catch (err) {
-    rs.initiate({
-      _id: "rs0",
-      members: [{ _id: 0, host: "'"$HOST"':27017" }]
-    });
+# rs.status() returns { ok: 0 } before initiate; it does not throw.
+mongo_eval '
+  var status = rs.status();
+  if (status.ok === 1) {
+    quit(0);
+  }
+  var result = rs.initiate({
+    _id: "rs0",
+    members: [{ _id: 0, host: "'"$HOST"':27017" }]
+  });
+  if (result.ok !== 1) {
+    printjson(result);
+    quit(1);
   }
 '
+
+# Mongoose with replicaSet=rs0 only selects a PRIMARY (myState === 1).
+until mongo_eval 'var s = rs.status(); if (s.ok === 1 && s.myState === 1) { quit(0); } quit(1);' >/dev/null 2>&1; do
+  sleep 1
+done

--- a/docker/mongo/init-replica.sh
+++ b/docker/mongo/init-replica.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+set -euo pipefail
+HOST="${MONGO_HOST:-conduit-mongo}"
+USER="${MONGO_INITDB_ROOT_USERNAME:-conduit}"
+PASS="${MONGO_INITDB_ROOT_PASSWORD:-pass}"
+
+until mongo --host "$HOST" -u "$USER" -p "$PASS" --authenticationDatabase admin --quiet --eval 'db.adminCommand({ ping: 1 })' >/dev/null 2>&1; do
+  sleep 2
+done
+
+mongo --host "$HOST" -u "$USER" -p "$PASS" --authenticationDatabase admin --quiet --eval '
+  try {
+    rs.status();
+  } catch (err) {
+    rs.initiate({
+      _id: "rs0",
+      members: [{ _id: 0, host: "'"$HOST"':27017" }]
+    });
+  }
+'

--- a/docker/mongo/keyfile
+++ b/docker/mongo/keyfile
@@ -1,0 +1,1 @@
+conduit-dev-mongo-replica-keyfile-do-not-use-in-production-replace-me-before-any-real-deployment-0123456789abcdefghijklmnopqrstuvwxyz

--- a/docker/mongo/keyfile
+++ b/docker/mongo/keyfile
@@ -1,1 +1,1 @@
-conduit-dev-mongo-replica-keyfile-do-not-use-in-production-replace-me-before-any-real-deployment-0123456789abcdefghijklmnopqrstuvwxyz
+ConduitLocalDevMongoReplicaSetKeyFileDoNotUseInProductionReplaceBeforeAnyRealDeployment0123456789abcdefghijklmnopqrstuvwxyz

--- a/libraries/grpc-sdk/src/interfaces/Model.ts
+++ b/libraries/grpc-sdk/src/interfaces/Model.ts
@@ -71,9 +71,7 @@ export interface ConduitArrayValidation {
 }
 
 export type ConduitValidationRules =
-  | ConduitStringValidation
-  | ConduitNumberValidation
-  | ConduitArrayValidation;
+  ConduitStringValidation | ConduitNumberValidation | ConduitArrayValidation;
 
 type BaseConduitModelField = {
   type?: TYPE | TYPE[] | ConduitModel | ArrayConduitModel[];
@@ -188,6 +186,9 @@ export interface ConduitSchemaOptions {
       canDelete: boolean;
     };
     authorization?: {
+      enabled: boolean;
+    };
+    realtime?: {
       enabled: boolean;
     };
     /** Mongoose read preference for this schema (ignored by SQL); per-query wins. */

--- a/libraries/grpc-sdk/src/modules/admin/index.ts
+++ b/libraries/grpc-sdk/src/modules/admin/index.ts
@@ -3,7 +3,8 @@ import {
   AdminDefinition,
   RegisterAdminRouteRequest,
   RegisterAdminRouteRequest_PathDefinition,
-} from '../../protoUtils/index.js';
+  SocketPushRequest,
+} from '../../protoUtils/core.js';
 import { ConduitRouteActions } from '../../interfaces/index.js';
 
 export class Admin extends ConduitModule<typeof AdminDefinition> {
@@ -26,6 +27,10 @@ export class Admin extends ConduitModule<typeof AdminDefinition> {
     };
 
     return this.client!.registerAdminRoute(request);
+  }
+
+  socketPush(data: SocketPushRequest) {
+    return this.client!.socketPush(data);
   }
 
   patchRouteMiddlewares(

--- a/libraries/hermes/package.json
+++ b/libraries/hermes/package.json
@@ -11,6 +11,7 @@
   "scripts": {
     "prepublish": "npm run build",
     "build": "rimraf dist && tsc",
+    "test": "tsc -p tsconfig.test.json && node --test dist-test/Socket/applySocketGlobalMiddlewares.test.js",
     "publish": "npm publish",
     "postbuild": "copyfiles -u 1 src/*.proto src/**/*.json ./dist/"
   },

--- a/libraries/hermes/src/Socket/Socket.ts
+++ b/libraries/hermes/src/Socket/Socket.ts
@@ -15,6 +15,7 @@ import {
 } from '../interfaces/index.js';
 import ObjectHash from 'object-hash';
 import { ConduitError, ConduitGrpcSdk } from '@conduitplatform/grpc-sdk';
+import { applySocketGlobalMiddlewares } from './applySocketGlobalMiddlewares.js';
 import { buildSocketMiddlewareParams } from './buildSocketMiddlewareParams.js';
 
 export class SocketController extends ConduitRouter {
@@ -57,9 +58,17 @@ export class SocketController extends ConduitRouter {
     };
     this.io = new IOServer(this.httpServer, this.options);
     this.redisClient = grpcSdk.redisManager.getClient();
+    // Admin (e.g. :3031) and Router (e.g. :3001) are separate Socket.IO
+    // servers that share Redis. The adapter defaults would put both on the
+    // same stream, so a database change pushed to admin *and* router is
+    // delivered twice to every socket in those rooms.
+    const adapterKey = `socket.io:${this.port}`;
     this.io.adapter(
       createAdapter(this.redisClient, {
         onlyPlaintext: true,
+        streamName: adapterKey,
+        channelPrefix: adapterKey,
+        sessionKeyPrefix: `sio:session:${this.port}:`,
       }),
     );
     this.httpServer.listen(this.port);
@@ -107,20 +116,18 @@ export class SocketController extends ConduitRouter {
     this._registeredNamespaces.set(namespace, conduitSocket);
 
     const self = this;
-    this.globalMiddlewares.forEach(middleware => {
-      self.io.engine.use((req: any, res: any, next: any) => {
-        req.path = namespace;
-        middleware(req, res, next);
-      });
-    });
     this.io.of(namespace).use((socket, next) => {
-      const context = buildSocketMiddlewareParams(socket);
-      self
-        .checkMiddlewares(context, conduitSocket.input.middlewares)
-        .then(r => {
-          Object.assign(context.context, r);
-          socket.data = context.context;
-          next();
+      applySocketGlobalMiddlewares(socket, self.globalMiddlewares)
+        .then(() => {
+          const context = buildSocketMiddlewareParams(socket);
+          Object.assign(context.context, socket.data);
+          return self
+            .checkMiddlewares(context, conduitSocket.input.middlewares)
+            .then(r => {
+              Object.assign(context.context, r);
+              socket.data = context.context;
+              next();
+            });
         })
         .catch((err: Error | ConduitError) => {
           next(err);

--- a/libraries/hermes/src/Socket/applySocketGlobalMiddlewares.test.ts
+++ b/libraries/hermes/src/Socket/applySocketGlobalMiddlewares.test.ts
@@ -1,0 +1,44 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import type { NextFunction, Request, Response } from 'express';
+import { applySocketGlobalMiddlewares } from './applySocketGlobalMiddlewares.js';
+
+function fakeSocket(auth?: Record<string, unknown>) {
+  return {
+    request: {
+      headers: {},
+      url: '/realtime/?EIO=4&transport=polling',
+    },
+    handshake: { auth: auth ?? {} },
+    data: {},
+  };
+}
+
+describe('applySocketGlobalMiddlewares', () => {
+  it('injects handshake.auth.token and copies conduit onto socket.data', async () => {
+    const socket = fakeSocket({ token: 'ticket-token' });
+    await applySocketGlobalMiddlewares(socket as never, [
+      (req: Request, _res: Response, next: NextFunction) => {
+        assert.equal(req.headers.authorization, 'Bearer ticket-token');
+        (req as Request & { conduit: { admin: string } }).conduit = {
+          admin: 'ok',
+        };
+        next();
+      },
+    ]);
+    assert.equal((socket.data as { admin?: string }).admin, 'ok');
+  });
+
+  it('rejects when Express middleware sends 401 json', async () => {
+    const socket = fakeSocket();
+    await assert.rejects(
+      () =>
+        applySocketGlobalMiddlewares(socket as never, [
+          (_req: Request, res: Response) => {
+            res.status(401).json({ error: 'No token provided' });
+          },
+        ]),
+      /No token provided/,
+    );
+  });
+});

--- a/libraries/hermes/src/Socket/applySocketGlobalMiddlewares.ts
+++ b/libraries/hermes/src/Socket/applySocketGlobalMiddlewares.ts
@@ -1,0 +1,66 @@
+import type { NextFunction, Request, Response } from 'express';
+import type { Socket } from 'socket.io';
+import { buildSocketMiddlewareParams } from './buildSocketMiddlewareParams.js';
+
+type ExpressMiddleware = (req: Request, res: Response, next: NextFunction) => void;
+
+type ConduitRequest = Request & { conduit?: Record<string, unknown> };
+
+export async function applySocketGlobalMiddlewares(
+  socket: Socket,
+  middlewares: ExpressMiddleware[],
+): Promise<void> {
+  const params = buildSocketMiddlewareParams(socket);
+  const req = Object.assign(socket.request, {
+    headers: params.headers,
+    path: '/realtime',
+    url: socket.request.url ?? '/realtime',
+    originalUrl: socket.request.url ?? '/realtime',
+    conduit: { ...params.context },
+  }) as ConduitRequest;
+
+  await new Promise<void>((resolve, reject) => {
+    let settled = false;
+    const res = {
+      statusCode: 200,
+      status(this: { statusCode: number }, code: number) {
+        this.statusCode = code;
+        return this;
+      },
+      json(this: unknown, body: { error?: string }) {
+        if (settled) return this;
+        settled = true;
+        reject(new Error(body?.error || 'Unauthorized'));
+        return this;
+      },
+      setHeader() {
+        return this;
+      },
+      removeHeader() {},
+    } as unknown as Response;
+
+    let index = 0;
+    const next = (err?: unknown) => {
+      if (settled) return;
+      if (err) {
+        settled = true;
+        reject(err instanceof Error ? err : new Error(String(err)));
+        return;
+      }
+      const middleware = middlewares[index++];
+      if (!middleware) {
+        settled = true;
+        socket.data = { ...socket.data, ...(req.conduit ?? {}) };
+        resolve();
+        return;
+      }
+      try {
+        middleware(req, res, next);
+      } catch (error) {
+        settled = true;
+        reject(error as Error);
+      }
+    };
+    next();
+  });
+}

--- a/libraries/hermes/src/index.ts
+++ b/libraries/hermes/src/index.ts
@@ -47,6 +47,15 @@ export class ConduitRoutingController {
   private _cleanupTimeout: NodeJS.Timeout | null = null;
   /** Routes registered before MCP starts; replayed in initMCP. */
   private readonly _conduitRoutesByKey: Map<string, ConduitRoute> = new Map();
+  /** Sockets registered before Socket.IO starts; replayed in initSockets. */
+  private readonly _conduitSocketsByPath: Map<string, ConduitSocket> = new Map();
+  private readonly _socketMiddlewares: Array<
+    (req: ConduitRequest, res: Response, next: NextFunction) => void
+  > = [];
+  private readonly _socketRouteMiddlewares: Array<{
+    middleware: ConduitMiddleware;
+    moduleUrl: string;
+  }> = [];
   private readonly routeTrie: RouteTrie = new RouteTrie();
   readonly expressApp: Express = express();
   readonly server = http.createServer(this.expressApp);
@@ -143,6 +152,15 @@ export class ConduitRoutingController {
       this.expressApp,
       this.metrics,
     );
+    for (const middleware of this._socketMiddlewares) {
+      this._socketRouter.registerGlobalMiddleware(middleware);
+    }
+    for (const { middleware, moduleUrl } of this._socketRouteMiddlewares) {
+      this._socketRouter.registerMiddleware(middleware, moduleUrl);
+    }
+    for (const socket of this._conduitSocketsByPath.values()) {
+      this._socketRouter.registerConduitSocket(socket);
+    }
   }
 
   initMCP(config?: {
@@ -231,6 +249,7 @@ export class ConduitRoutingController {
   ) {
     this._middlewareRouter.use(middleware);
     if (socketMiddleware) {
+      this._socketMiddlewares.push(middleware);
       this._socketRouter?.registerGlobalMiddleware(middleware);
     }
   }
@@ -238,6 +257,7 @@ export class ConduitRoutingController {
   registerRouteMiddleware(middleware: ConduitMiddleware, moduleUrl: string) {
     this._restRouter?.registerMiddleware(middleware, moduleUrl);
     this._graphQLRouter?.registerMiddleware(middleware, moduleUrl);
+    this._socketRouteMiddlewares.push({ middleware, moduleUrl });
     this._socketRouter?.registerMiddleware(middleware, moduleUrl);
     this._mcpRouter?.registerMiddleware(middleware, moduleUrl);
   }
@@ -286,6 +306,7 @@ export class ConduitRoutingController {
   }
 
   registerConduitSocket(socket: ConduitSocket) {
+    this._conduitSocketsByPath.set(socket.input.path, socket);
     this._socketRouter?.registerConduitSocket(socket);
   }
 

--- a/libraries/hermes/tsconfig.json
+++ b/libraries/hermes/tsconfig.json
@@ -65,5 +65,6 @@
 
     /* Advanced Options */
     "forceConsistentCasingInFileNames": true /* Disallow inconsistently-cased references to the same file. */
-  }
+  },
+  "exclude": ["node_modules", "dist", "**/*.test.ts"]
 }

--- a/libraries/hermes/tsconfig.test.json
+++ b/libraries/hermes/tsconfig.test.json
@@ -1,0 +1,16 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist-test",
+    "rootDir": "./src",
+    "declaration": false,
+    "sourceMap": false,
+    "types": ["node"]
+  },
+  "include": [
+    "src/Socket/applySocketGlobalMiddlewares.ts",
+    "src/Socket/applySocketGlobalMiddlewares.test.ts",
+    "src/Socket/buildSocketMiddlewareParams.ts"
+  ],
+  "exclude": ["node_modules", "dist"]
+}

--- a/modules/database/README.mdx
+++ b/modules/database/README.mdx
@@ -47,6 +47,23 @@ since the latter need to go through parsers that are otherwise unnecessary for M
 
 When using MongoDB with a replica set (e.g., MongoDB Atlas), the database module supports configuring read preference, write concern, and read concern through the admin panel at `PATCH /config/database`.
 
+Live document updates also require a replica set or sharded cluster. Local Compose files initialize a single-node replica set so change streams can be exercised.
+
+### Live updates
+
+Enable `realtime.enabled` in database module config, then opt a schema in with `modelOptions.conduit.realtime.enabled`. Clients connect to the `/database/` Socket.IO namespace (path `/realtime`) and emit:
+
+```
+subscribe({ schema: 'Order', documentId?: string })
+unsubscribe({ schema: 'Order', documentId?: string })
+```
+
+Events arrive as `change` with `{ version, operation, schema, documentId, occurredAt, resumeToken }` and contain no document fields. Consumers should refetch through their authorized REST or custom-endpoint path.
+
+Client subscribers must authenticate. Schemas with document-level authorization reject schema-wide subscriptions and require a document ID plus a `read` check. Admin consumers use `POST /realtime/ticket` for a 30-second handshake token; session JWTs and masterkeys must not be sent from browser code.
+
+Admin sockets must be enabled (`admin.transports.sockets`) and the Admin socket port (`ADMIN_SOCKET_PORT`, default 3031) reachable from the UI.
+
 ### Configuration Options
 
 |      Setting      | Values                                                                    | Default   | Description                                              |
@@ -54,6 +71,7 @@ When using MongoDB with a replica set (e.g., MongoDB Atlas), the database module
 | `readPreference`  | `primary`, `primaryPreferred`, `secondary`, `secondaryPreferred`, `nearest` | `primary` | Controls which replica set members receive read queries  |
 | `writeConcern`    | `1`, `majority`                                                           |    `1`    | How many members must acknowledge a write                |
 | `readConcern`     | `local`, `available`, `majority`, `linearizable`, `snapshot`              |  `local`  | Consistency level for read operations                    |
+| `realtime.enabled` | `true`, `false`                                                          |  `false`  | Enable MongoDB change-stream live updates for opted-in schemas |
 
 ### Recommended Production Settings
 

--- a/modules/database/src/Database.ts
+++ b/modules/database/src/Database.ts
@@ -64,6 +64,7 @@ import { QueueController } from './controllers/queue.controller.js';
 import AppConfigSchema, { Config } from './config/index.js';
 import { Empty } from './protoTypes/google/protobuf/empty.js';
 import { fileURLToPath } from 'node:url';
+import { RealtimeService } from './realtime/index.js';
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
@@ -107,6 +108,7 @@ export default class DatabaseModule extends ManagedModule<Config> {
   private customEndpointController?: CustomEndpointController;
   private _authorizationDefinitionsRegistered = false;
   private _databaseRouterWatchDispose: (() => void) | null = null;
+  private realtimeService?: RealtimeService;
 
   constructor(dbType: string, dbUri: string, peerManifestRoot?: string) {
     super('database', peerManifestRoot);
@@ -164,6 +166,7 @@ export default class DatabaseModule extends ManagedModule<Config> {
         readConcern: config.readConcern ?? 'local',
       });
     }
+    void this.realtimeService?.reconcile();
     if (!config.viewCleanup.enabled) {
       try {
         await QueueController.getInstance().drainViewCleanupQueue();
@@ -1015,13 +1018,16 @@ export default class DatabaseModule extends ManagedModule<Config> {
         this.grpcSdk,
         this._activeAdapter,
       );
+      this.realtimeService = new RealtimeService(this.grpcSdk, this._activeAdapter);
       this.adminRouter = new AdminHandlers(
         this.grpcServer,
         this.grpcSdk,
         this._activeAdapter,
         this.schemaController,
         this.customEndpointController,
+        this.realtimeService,
       );
+      void this.realtimeService.reconcile();
       this._databaseRouterWatchDispose?.();
       this._databaseRouterWatchDispose = this.grpcSdk.watchPeer(
         'router',
@@ -1031,6 +1037,7 @@ export default class DatabaseModule extends ManagedModule<Config> {
             this.grpcServer,
             this._activeAdapter,
             this.grpcSdk,
+            this.realtimeService,
           );
           this.schemaController?.setRouter(this.userRouter);
           this.customEndpointController?.setRouter(this.userRouter);

--- a/modules/database/src/admin/__tests__/schema.admin.put-patch.test.ts
+++ b/modules/database/src/admin/__tests__/schema.admin.put-patch.test.ts
@@ -185,6 +185,21 @@ describe('SchemaAdmin PUT/PATCH split', () => {
       warnSpy.mockRestore();
     });
 
+    it('persists realtime conduitOptions used by live document updates', async () => {
+      const requestedSchema = makeRequestedSchema();
+      const { admin, createSchema } = setup(requestedSchema);
+
+      await admin.patchSchema(
+        makeCall({
+          id: 'schema-1',
+          conduitOptions: { realtime: { enabled: true } },
+        }),
+      );
+
+      const [writtenSchema] = createSchema.mock.calls[0];
+      expect(writtenSchema.modelOptions.conduit.realtime.enabled).toBe(true);
+    });
+
     it('wipes existing documents when enabling authorization via conduitOptions', async () => {
       const requestedSchema = makeRequestedSchema();
       const { admin, deleteMany } = setup(requestedSchema);

--- a/modules/database/src/admin/index.ts
+++ b/modules/database/src/admin/index.ts
@@ -23,6 +23,7 @@ import { SchemaController } from '../controllers/cms/schema.controller.js';
 import { CustomEndpointController } from '../controllers/customEndpoints/customEndpoint.controller.js';
 import { CustomEndpoints, DeclaredSchema, PendingSchemas } from '../models/index.js';
 import { ConduitOptions, SchemaFieldsRequired } from '../interfaces/index.js';
+import type { RealtimeService } from '../realtime/index.js';
 
 export class AdminHandlers {
   private readonly schemaAdmin: SchemaAdmin;
@@ -36,6 +37,7 @@ export class AdminHandlers {
     private readonly _activeAdapter: DatabaseAdapter<MongooseSchema | SequelizeSchema>,
     private readonly schemaController: SchemaController,
     private readonly customEndpointController: CustomEndpointController,
+    private readonly realtimeService: RealtimeService,
   ) {
     this.schemaAdmin = new SchemaAdmin(
       this.grpcSdk,
@@ -686,6 +688,7 @@ export class AdminHandlers {
       new ConduitRouteReturnDefinition('getDatabaseType', 'String'),
       this.schemaAdmin.getDatabaseType.bind(this.schemaAdmin),
     );
+    this.realtimeService.registerAdmin(this.routingManager);
     this.routingManager.registerRoutes();
   }
 }

--- a/modules/database/src/admin/schema.admin.ts
+++ b/modules/database/src/admin/schema.admin.ts
@@ -250,6 +250,7 @@ export class SchemaAdmin {
       cms: call.request.params.conduitOptions?.cms,
       permissions: call.request.params.conduitOptions?.permissions,
       authorization: call.request.params.conduitOptions?.authorization,
+      realtime: call.request.params.conduitOptions?.realtime,
       readPreference: call.request.params.conduitOptions?.readPreference,
       timestamps: call.request.params.timestamps,
     });
@@ -343,6 +344,7 @@ export class SchemaAdmin {
       cms: conduitOptions?.cms,
       authorization: conduitOptions?.authorization,
       permissions: conduitOptions?.permissions,
+      realtime: conduitOptions?.realtime,
       readPreference: conduitOptions?.readPreference,
       existingModelOptions: requestedSchema.modelOptions,
     });

--- a/modules/database/src/config/index.ts
+++ b/modules/database/src/config/index.ts
@@ -47,6 +47,13 @@ const AppConfigSchema = {
       default: 0,
     },
   },
+  realtime: {
+    enabled: {
+      doc: 'Enable MongoDB change-stream live updates for opted-in schemas',
+      format: 'Boolean',
+      default: false,
+    },
+  },
 };
 
 const config = convict(AppConfigSchema);

--- a/modules/database/src/interfaces/ConduitOptions.ts
+++ b/modules/database/src/interfaces/ConduitOptions.ts
@@ -30,5 +30,8 @@ export const ConduitOptions = {
   authorization: {
     enabled: ConduitBoolean.Optional,
   },
+  realtime: {
+    enabled: ConduitBoolean.Optional,
+  },
   readPreference: ConduitString.Optional,
 };

--- a/modules/database/src/metrics/index.ts
+++ b/modules/database/src/metrics/index.ts
@@ -31,4 +31,19 @@ export default {
       help: 'Tracks the total number of custom endpoints',
     },
   },
+  realtimeEvents: {
+    type: MetricType.Counter,
+    config: {
+      name: 'database_realtime_events_total',
+      help: 'Tracks normalized database change-stream events',
+      labelNames: ['operation'],
+    },
+  },
+  realtimeStreamErrors: {
+    type: MetricType.Counter,
+    config: {
+      name: 'database_realtime_stream_errors_total',
+      help: 'Tracks change-stream errors',
+    },
+  },
 };

--- a/modules/database/src/realtime/MongoChangeStreamCoordinator.ts
+++ b/modules/database/src/realtime/MongoChangeStreamCoordinator.ts
@@ -40,7 +40,6 @@ export type CoordinatorOptions = {
   subscriptions: RealtimeSubscriptionTracker;
   enabled: () => boolean;
   engine: () => string;
-  socketsEnabled?: () => Promise<boolean>;
 };
 
 export class MongoChangeStreamCoordinator {
@@ -172,10 +171,10 @@ export class MongoChangeStreamCoordinator {
     this.ignoreClose = false;
     try {
       const resumeAfter = parseResumeToken(
-        (await this.options.grpcSdk.state!.getKey(RESUME_TOKEN_KEY)) ?? undefined,
+        await this.options.grpcSdk.state!.getKey(RESUME_TOKEN_KEY),
       );
       if (this.watching || this.closed) return;
-      const stream = this.options.watch({ resumeAfter: resumeAfter ?? undefined });
+      const stream = this.options.watch({ resumeAfter });
       this.stream = stream;
       this.watching = true;
       this.streamState = 'live';

--- a/modules/database/src/realtime/MongoChangeStreamCoordinator.ts
+++ b/modules/database/src/realtime/MongoChangeStreamCoordinator.ts
@@ -55,6 +55,7 @@ export class MongoChangeStreamCoordinator {
   private topology: TopologyResult = { supported: false };
   private retryAttempt = 0;
   private watching = false;
+  private opening = false;
   private ignoreClose = false;
 
   constructor(private readonly options: CoordinatorOptions) {}
@@ -90,6 +91,14 @@ export class MongoChangeStreamCoordinator {
       await this.releaseLeader();
       this.streamState = 'idle';
       this.lastError = this.topology.message;
+      // Hello can fail during startup before Mongo is ready. Keep retrying
+      // that case; a confirmed standalone topology will not recover.
+      if (
+        !this.topology.message ||
+        this.topology.message.includes('Unable to determine')
+      ) {
+        this.scheduleRetry();
+      }
       return;
     }
     if (this.options.getOptedInSchemas().length === 0) {
@@ -121,7 +130,11 @@ export class MongoChangeStreamCoordinator {
         LOCK_TTL_MS,
       );
       if (!acquired) {
+        // Another instance holds the lock, or a crashed holder has not
+        // expired yet. Without a retry, a standalone process stays idle
+        // forever after a restart races the previous TTL.
         this.streamState = 'idle';
+        this.scheduleRetry();
         return;
       }
       this.lock = acquired;
@@ -153,13 +166,15 @@ export class MongoChangeStreamCoordinator {
   }
 
   private async openStream() {
-    if (this.watching || this.closed) return;
+    if (this.watching || this.closed || this.opening) return;
+    this.opening = true;
     this.streamState = 'starting';
     this.ignoreClose = false;
-    const resumeAfter = parseResumeToken(
-      (await this.options.grpcSdk.state!.getKey(RESUME_TOKEN_KEY)) ?? undefined,
-    );
     try {
+      const resumeAfter = parseResumeToken(
+        (await this.options.grpcSdk.state!.getKey(RESUME_TOKEN_KEY)) ?? undefined,
+      );
+      if (this.watching || this.closed) return;
       const stream = this.options.watch({ resumeAfter: resumeAfter ?? undefined });
       this.stream = stream;
       this.watching = true;
@@ -180,6 +195,8 @@ export class MongoChangeStreamCoordinator {
     } catch (err) {
       this.watching = false;
       await this.handleStreamError(err);
+    } finally {
+      this.opening = false;
     }
   }
 

--- a/modules/database/src/realtime/MongoChangeStreamCoordinator.ts
+++ b/modules/database/src/realtime/MongoChangeStreamCoordinator.ts
@@ -1,0 +1,329 @@
+import { ConduitGrpcSdk } from '@conduitplatform/grpc-sdk';
+import {
+  normalizeChangeEvent,
+  parseResumeToken,
+  type RawChangeEvent,
+} from './normalize.js';
+import { authorizedDocumentRoom, roomsForPublicChange } from './rooms.js';
+import {
+  isResumeTokenUnusable,
+  topologyFromHello,
+  type TopologyResult,
+} from './topology.js';
+import type {
+  ChangeStreamLike,
+  DatabaseChangeEvent,
+  OptedInSchema,
+  RealtimeStatusCode,
+} from './types.js';
+import type { RealtimeSubscriptionTracker } from './subscriptions.js';
+import { canReadDocument, type AuthorizationSdk } from './authorize.js';
+
+const LEADER_LOCK = 'realtime:change-stream:leader';
+const RESUME_TOKEN_KEY = 'realtime:resumeToken';
+const LOCK_TTL_MS = 15_000;
+const LOCK_RENEW_MS = 5_000;
+const RETRY_BASE_MS = 1_000;
+const RETRY_MAX_MS = 30_000;
+
+type LeaderLock = NonNullable<
+  Awaited<ReturnType<NonNullable<ConduitGrpcSdk['state']>['tryAcquireLock']>>
+>;
+
+export type WatchFactory = (options: { resumeAfter?: unknown }) => ChangeStreamLike;
+
+export type CoordinatorOptions = {
+  grpcSdk: ConduitGrpcSdk;
+  watch: WatchFactory;
+  hello: () => Promise<{ setName?: string; msg?: string } | null>;
+  getOptedInSchemas: () => OptedInSchema[];
+  subscriptions: RealtimeSubscriptionTracker;
+  enabled: () => boolean;
+  engine: () => string;
+  socketsEnabled?: () => Promise<boolean>;
+};
+
+export class MongoChangeStreamCoordinator {
+  private lock: LeaderLock | null = null;
+  private stream: ChangeStreamLike | null = null;
+  private renewTimer: NodeJS.Timeout | null = null;
+  private retryTimer: NodeJS.Timeout | null = null;
+  private closed = false;
+  private streamState: RealtimeStatusCode = 'idle';
+  private lastEventAt?: string;
+  private lastError?: string;
+  private topology: TopologyResult = { supported: false };
+  private retryAttempt = 0;
+  private watching = false;
+  private ignoreClose = false;
+
+  constructor(private readonly options: CoordinatorOptions) {}
+
+  getState(): RealtimeStatusCode {
+    return this.streamState;
+  }
+
+  getLastEventAt(): string | undefined {
+    return this.lastEventAt;
+  }
+
+  getLastError(): string | undefined {
+    return this.lastError;
+  }
+
+  getTopology(): TopologyResult {
+    return this.topology;
+  }
+
+  async reconcile(): Promise<void> {
+    if (this.closed) return;
+    const engine = this.options.engine();
+    if (engine !== 'MongoDB' || !this.options.enabled()) {
+      await this.stopStream('idle');
+      await this.releaseLeader();
+      this.streamState = engine !== 'MongoDB' ? 'unsupported' : 'disabled';
+      return;
+    }
+    this.topology = topologyFromHello(await this.options.hello().catch(() => null));
+    if (!this.topology.supported) {
+      await this.stopStream('idle');
+      await this.releaseLeader();
+      this.streamState = 'idle';
+      this.lastError = this.topology.message;
+      return;
+    }
+    if (this.options.getOptedInSchemas().length === 0) {
+      await this.stopStream('idle');
+      await this.releaseLeader();
+      this.streamState = 'idle';
+      return;
+    }
+    await this.ensureLeader();
+  }
+
+  async shutdown(): Promise<void> {
+    this.closed = true;
+    this.clearTimers();
+    await this.stopStream('idle');
+    await this.releaseLeader();
+  }
+
+  private async ensureLeader(): Promise<void> {
+    if (this.lock) {
+      if (!this.watching) {
+        await this.openStream();
+      }
+      return;
+    }
+    try {
+      const acquired = await this.options.grpcSdk.state!.tryAcquireLock(
+        LEADER_LOCK,
+        LOCK_TTL_MS,
+      );
+      if (!acquired) {
+        this.streamState = 'idle';
+        return;
+      }
+      this.lock = acquired;
+      this.startRenewal();
+      await this.openStream();
+    } catch (err) {
+      this.lastError = err instanceof Error ? err.message : String(err);
+      this.streamState = 'degraded';
+      this.scheduleRetry();
+    }
+  }
+
+  private startRenewal() {
+    this.clearRenewTimer();
+    this.renewTimer = setInterval(() => {
+      void this.renewLock();
+    }, LOCK_RENEW_MS);
+  }
+
+  private async renewLock() {
+    if (!this.lock) return;
+    try {
+      this.lock = await this.lock.extend(LOCK_TTL_MS);
+    } catch {
+      this.lock = null;
+      await this.stopStream('idle');
+      this.scheduleRetry();
+    }
+  }
+
+  private async openStream() {
+    if (this.watching || this.closed) return;
+    this.streamState = 'starting';
+    this.ignoreClose = false;
+    const resumeAfter = parseResumeToken(
+      (await this.options.grpcSdk.state!.getKey(RESUME_TOKEN_KEY)) ?? undefined,
+    );
+    try {
+      const stream = this.options.watch({ resumeAfter: resumeAfter ?? undefined });
+      this.stream = stream;
+      this.watching = true;
+      this.streamState = 'live';
+      this.retryAttempt = 0;
+      stream.on('change', (change: unknown) => {
+        void this.handleChange(change as RawChangeEvent);
+      });
+      stream.on('error', (err: unknown) => {
+        void this.handleStreamError(err);
+      });
+      stream.on('close', () => {
+        this.watching = false;
+        if (!this.closed && !this.ignoreClose && this.lock) {
+          this.scheduleRetry();
+        }
+      });
+    } catch (err) {
+      this.watching = false;
+      await this.handleStreamError(err);
+    }
+  }
+
+  private async handleChange(change: RawChangeEvent) {
+    const schema = this.resolveSchema(change.ns?.coll);
+    if (!schema) return;
+    const event = normalizeChangeEvent(change, schema.name);
+    if (!event) return;
+    this.lastEventAt = event.occurredAt;
+    this.lastError = undefined;
+    await this.options.grpcSdk.state!.setKey(RESUME_TOKEN_KEY, event.resumeToken);
+    this.options.grpcSdk.bus?.publish(
+      `database:change:${schema.name}`,
+      JSON.stringify(event),
+    );
+    ConduitGrpcSdk.Metrics?.increment('database_realtime_events_total', 1, {
+      operation: event.operation,
+    });
+    await this.pushEvent(schema, event);
+  }
+
+  private async pushEvent(schema: OptedInSchema, event: DatabaseChangeEvent) {
+    const payload = JSON.stringify(event);
+    const adminRooms = roomsForPublicChange(schema.name, event.documentId);
+    await this.safePush('admin', adminRooms, payload);
+    if (!schema.authorizationEnabled) {
+      await this.safePush('router', adminRooms, payload);
+      return;
+    }
+    const userIds = await this.options.subscriptions.listUsers(
+      schema.name,
+      event.documentId,
+    );
+    const allowedRooms: string[] = [];
+    for (const userId of userIds) {
+      const allowed = await canReadDocument(
+        this.options.grpcSdk as unknown as AuthorizationSdk,
+        schema.name,
+        event.documentId,
+        userId,
+      );
+      if (!allowed) {
+        await this.options.subscriptions.removeUser(
+          schema.name,
+          event.documentId,
+          userId,
+        );
+        continue;
+      }
+      allowedRooms.push(authorizedDocumentRoom(schema.name, event.documentId, userId));
+    }
+    if (allowedRooms.length > 0) {
+      await this.safePush('router', allowedRooms, payload);
+    }
+  }
+
+  private async safePush(
+    target: 'admin' | 'router',
+    rooms: string[],
+    data: string,
+  ): Promise<void> {
+    const client =
+      target === 'admin' ? this.options.grpcSdk.admin : this.options.grpcSdk.router;
+    if (!client?.socketPush) return;
+    try {
+      await client.socketPush({
+        event: 'change',
+        data,
+        rooms,
+        receivers: [],
+      });
+    } catch (err) {
+      ConduitGrpcSdk.Logger.error(err as Error);
+    }
+  }
+
+  private resolveSchema(collectionName?: string): OptedInSchema | undefined {
+    if (!collectionName) return undefined;
+    return this.options
+      .getOptedInSchemas()
+      .find(schema => schema.collectionName === collectionName);
+  }
+
+  private async handleStreamError(err: unknown) {
+    this.watching = false;
+    this.lastError = err instanceof Error ? err.message : String(err);
+    this.streamState = 'degraded';
+    ConduitGrpcSdk.Metrics?.increment('database_realtime_stream_errors_total');
+    ConduitGrpcSdk.Logger.error(err as Error);
+    if (isResumeTokenUnusable(err)) {
+      await this.options.grpcSdk.state!.clearKey(RESUME_TOKEN_KEY);
+    }
+    await this.stopStream('degraded');
+    this.scheduleRetry();
+  }
+
+  private scheduleRetry() {
+    if (this.closed || this.retryTimer) return;
+    const delay = Math.min(RETRY_MAX_MS, RETRY_BASE_MS * 2 ** this.retryAttempt);
+    this.retryAttempt += 1;
+    this.retryTimer = setTimeout(() => {
+      this.retryTimer = null;
+      void this.reconcile();
+    }, delay);
+  }
+
+  private async stopStream(nextState: RealtimeStatusCode) {
+    const stream = this.stream;
+    this.stream = null;
+    this.watching = false;
+    this.streamState = nextState;
+    this.ignoreClose = true;
+    if (stream) {
+      try {
+        await stream.close();
+      } catch {
+        // already closed
+      }
+    }
+  }
+
+  private async releaseLeader() {
+    this.clearRenewTimer();
+    if (!this.lock) return;
+    try {
+      await this.options.grpcSdk.state!.releaseLock(this.lock);
+    } catch {
+      // lock may already have expired
+    }
+    this.lock = null;
+  }
+
+  private clearTimers() {
+    this.clearRenewTimer();
+    if (this.retryTimer) {
+      clearTimeout(this.retryTimer);
+      this.retryTimer = null;
+    }
+  }
+
+  private clearRenewTimer() {
+    if (this.renewTimer) {
+      clearInterval(this.renewTimer);
+      this.renewTimer = null;
+    }
+  }
+}

--- a/modules/database/src/realtime/RealtimeService.ts
+++ b/modules/database/src/realtime/RealtimeService.ts
@@ -1,0 +1,160 @@
+import {
+  ConduitGrpcSdk,
+  ConduitRouteActions,
+  ConduitRouteReturnDefinition,
+} from '@conduitplatform/grpc-sdk';
+import {
+  ConduitNumber,
+  ConduitString,
+  ConfigController,
+  RoutingManager,
+} from '@conduitplatform/module-tools';
+import { DatabaseAdapter } from '../adapters/DatabaseAdapter.js';
+import { MongooseAdapter } from '../adapters/mongoose-adapter/index.js';
+import { MongooseSchema } from '../adapters/mongoose-adapter/MongooseSchema.js';
+import { SequelizeSchema } from '../adapters/sequelize-adapter/SequelizeSchema.js';
+import { toOptedInSchema } from './authorize.js';
+import { MongoChangeStreamCoordinator } from './MongoChangeStreamCoordinator.js';
+import { registerDatabaseRealtimeSocket } from './sockets.js';
+import { buildRealtimeStatus } from './status.js';
+import { RealtimeSubscriptionTracker } from './subscriptions.js';
+import type { OptedInSchema, RealtimeStatus } from './types.js';
+import type { ChangeStreamLike } from './types.js';
+
+export class RealtimeService {
+  private readonly subscriptions: RealtimeSubscriptionTracker;
+  private coordinator?: MongoChangeStreamCoordinator;
+
+  constructor(
+    private readonly grpcSdk: ConduitGrpcSdk,
+    private readonly adapter: DatabaseAdapter<MongooseSchema | SequelizeSchema>,
+  ) {
+    this.subscriptions = new RealtimeSubscriptionTracker(
+      grpcSdk.redisManager.getClient(),
+    );
+    this.grpcSdk.bus?.subscribe('database:create:schema', () => {
+      void this.reconcile();
+    });
+    this.grpcSdk.bus?.subscribe('database:delete:schema', () => {
+      void this.reconcile();
+    });
+    if (adapter instanceof MongooseAdapter) {
+      this.coordinator = new MongoChangeStreamCoordinator({
+        grpcSdk,
+        watch: options => this.openWatch(adapter, options.resumeAfter),
+        hello: () => this.hello(adapter),
+        getOptedInSchemas: () => this.getOptedInSchemas(),
+        subscriptions: this.subscriptions,
+        enabled: () => this.isGloballyEnabled(),
+        engine: () => adapter.getDatabaseType(),
+        socketsEnabled: () => this.areAdminSocketsEnabled(),
+      });
+    }
+  }
+
+  registerAdmin(routingManager: RoutingManager) {
+    routingManager.route(
+      {
+        path: '/realtime/status',
+        action: ConduitRouteActions.GET,
+        description: `Returns live-update capability and runtime status for the database module.`,
+      },
+      new ConduitRouteReturnDefinition('DatabaseRealtimeStatus', {
+        status: ConduitString.Required,
+        engine: ConduitString.Required,
+        activeSchemaCount: ConduitNumber.Required,
+        lastEventAt: ConduitString.Optional,
+        message: ConduitString.Optional,
+      }),
+      async () => this.getStatus(),
+    );
+    registerDatabaseRealtimeSocket(routingManager, {
+      mode: 'admin',
+      grpcSdk: this.grpcSdk,
+      schemaLookup: this.adapter,
+      subscriptions: this.subscriptions,
+      isGloballyEnabled: () => this.isGloballyEnabled(),
+    });
+  }
+
+  registerClient(routingManager: RoutingManager) {
+    registerDatabaseRealtimeSocket(routingManager, {
+      mode: 'client',
+      grpcSdk: this.grpcSdk,
+      schemaLookup: this.adapter,
+      subscriptions: this.subscriptions,
+      isGloballyEnabled: () => this.isGloballyEnabled(),
+    });
+  }
+
+  async reconcile(): Promise<void> {
+    if (!this.coordinator) return;
+    await this.coordinator.reconcile();
+  }
+
+  async shutdown(): Promise<void> {
+    await this.coordinator?.shutdown();
+  }
+
+  async getStatus(): Promise<RealtimeStatus> {
+    const engine = this.adapter.getDatabaseType();
+    const optedIn = this.getOptedInSchemas();
+    return buildRealtimeStatus({
+      engine,
+      enabled: this.isGloballyEnabled(),
+      topologySupported: this.coordinator?.getTopology().supported ?? false,
+      topologyMessage: this.coordinator?.getTopology().message,
+      activeSchemaCount: optedIn.length,
+      streamState:
+        this.coordinator?.getState() ?? (engine === 'MongoDB' ? 'idle' : 'unsupported'),
+      lastEventAt: this.coordinator?.getLastEventAt(),
+      lastError: this.coordinator?.getLastError(),
+      socketsEnabled: await this.areAdminSocketsEnabled(),
+    });
+  }
+
+  private isGloballyEnabled(): boolean {
+    return ConfigController.getInstance().config?.realtime?.enabled === true;
+  }
+
+  private getOptedInSchemas(): OptedInSchema[] {
+    const schemas: OptedInSchema[] = [];
+    for (const schema of this.adapter.registeredSchemas.values()) {
+      const optedIn = toOptedInSchema({
+        name: schema.name,
+        collectionName: schema.collectionName,
+        modelOptions: schema.modelOptions,
+      });
+      if (optedIn) schemas.push(optedIn);
+    }
+    return schemas;
+  }
+
+  private openWatch(adapter: MongooseAdapter, resumeAfter?: unknown): ChangeStreamLike {
+    const db = adapter.mongoose.connection.db;
+    if (!db) {
+      throw new Error('MongoDB connection is not ready');
+    }
+    return db.watch(
+      [],
+      resumeAfter ? { resumeAfter: resumeAfter as never } : {},
+    ) as unknown as ChangeStreamLike;
+  }
+
+  private async hello(
+    adapter: MongooseAdapter,
+  ): Promise<{ setName?: string; msg?: string } | null> {
+    const db = adapter.mongoose.connection.db;
+    if (!db) return null;
+    return db.admin().command({ hello: 1 });
+  }
+
+  private async areAdminSocketsEnabled(): Promise<boolean> {
+    try {
+      const adminConfig = await this.grpcSdk.config.get('admin');
+      return adminConfig?.transports?.sockets === true;
+    } catch {
+      return true;
+    }
+  }
+}

--- a/modules/database/src/realtime/RealtimeService.ts
+++ b/modules/database/src/realtime/RealtimeService.ts
@@ -18,8 +18,7 @@ import { MongoChangeStreamCoordinator } from './MongoChangeStreamCoordinator.js'
 import { registerDatabaseRealtimeSocket } from './sockets.js';
 import { buildRealtimeStatus } from './status.js';
 import { RealtimeSubscriptionTracker } from './subscriptions.js';
-import type { OptedInSchema, RealtimeStatus } from './types.js';
-import type { ChangeStreamLike } from './types.js';
+import type { ChangeStreamLike, OptedInSchema, RealtimeStatus } from './types.js';
 
 export class RealtimeService {
   private readonly subscriptions: RealtimeSubscriptionTracker;
@@ -47,7 +46,6 @@ export class RealtimeService {
         subscriptions: this.subscriptions,
         enabled: () => this.isGloballyEnabled(),
         engine: () => adapter.getDatabaseType(),
-        socketsEnabled: () => this.areAdminSocketsEnabled(),
       });
     }
   }

--- a/modules/database/src/realtime/__tests__/authorize.test.ts
+++ b/modules/database/src/realtime/__tests__/authorize.test.ts
@@ -16,12 +16,9 @@ describe('realtime authorization helpers', () => {
     });
     expect(requireSchemaName('Order')).toBe('Order');
     expect(optionalDocumentId(undefined)).toBeUndefined();
-    try {
-      requireSchemaName('');
-      throw new Error('expected throw');
-    } catch (err: any) {
-      expect(err.code).toBe(status.INVALID_ARGUMENT);
-    }
+    expect(() => requireSchemaName('')).toThrow(
+      expect.objectContaining({ code: status.INVALID_ARGUMENT }),
+    );
   });
 
   it('rejects missing schemas, disabled realtime, and CMS-read for clients', () => {
@@ -43,24 +40,15 @@ describe('realtime authorization helpers', () => {
         };
       },
     };
-    try {
-      assertSchemaAvailable(lookup, 'Missing', true);
-      throw new Error('expected throw');
-    } catch (err: any) {
-      expect(err.code).toBe(status.NOT_FOUND);
-    }
-    try {
-      assertSchemaAvailable(lookup, 'Off', false);
-      throw new Error('expected throw');
-    } catch (err: any) {
-      expect(err.code).toBe(status.FAILED_PRECONDITION);
-    }
-    try {
-      assertSchemaAvailable(lookup, 'Order', true);
-      throw new Error('expected throw');
-    } catch (err: any) {
-      expect(err.code).toBe(status.PERMISSION_DENIED);
-    }
+    expect(() => assertSchemaAvailable(lookup, 'Missing', true)).toThrow(
+      expect.objectContaining({ code: status.NOT_FOUND }),
+    );
+    expect(() => assertSchemaAvailable(lookup, 'Off', false)).toThrow(
+      expect.objectContaining({ code: status.FAILED_PRECONDITION }),
+    );
+    expect(() => assertSchemaAvailable(lookup, 'Order', true)).toThrow(
+      expect.objectContaining({ code: status.PERMISSION_DENIED }),
+    );
     const admin = assertSchemaAvailable(lookup, 'Order', false);
     expect(admin.authorizationEnabled).toBe(true);
   });
@@ -71,12 +59,11 @@ describe('realtime authorization helpers', () => {
         throw new GrpcError(status.NOT_FOUND, 'Schema Missing not defined yet');
       },
     };
-    try {
-      assertSchemaAvailable(lookup, 'Missing', false);
-      throw new Error('expected throw');
-    } catch (err: any) {
-      expect(err.code).toBe(status.NOT_FOUND);
-      expect(err.message).toBe('Schema does not exist');
-    }
+    expect(() => assertSchemaAvailable(lookup, 'Missing', false)).toThrow(
+      expect.objectContaining({
+        code: status.NOT_FOUND,
+        message: 'Schema does not exist',
+      }),
+    );
   });
 });

--- a/modules/database/src/realtime/__tests__/authorize.test.ts
+++ b/modules/database/src/realtime/__tests__/authorize.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from '@jest/globals';
+import { status } from '@grpc/grpc-js';
+import { GrpcError } from '@conduitplatform/grpc-sdk';
+import {
+  assertSchemaAvailable,
+  optionalDocumentId,
+  parseSubscribeRequest,
+  requireSchemaName,
+} from '../authorize.js';
+
+describe('realtime authorization helpers', () => {
+  it('parses subscribe payloads and required schema names', () => {
+    expect(parseSubscribeRequest([{ schema: 'Order', documentId: '1' }])).toEqual({
+      schema: 'Order',
+      documentId: '1',
+    });
+    expect(requireSchemaName('Order')).toBe('Order');
+    expect(optionalDocumentId(undefined)).toBeUndefined();
+    try {
+      requireSchemaName('');
+      throw new Error('expected throw');
+    } catch (err: any) {
+      expect(err.code).toBe(status.INVALID_ARGUMENT);
+    }
+  });
+
+  it('rejects missing schemas, disabled realtime, and CMS-read for clients', () => {
+    const lookup = {
+      getSchema: (name: string) => {
+        if (name === 'Missing') return undefined;
+        if (name === 'Off') {
+          return { name, modelOptions: { conduit: { realtime: { enabled: false } } } };
+        }
+        return {
+          name,
+          modelOptions: {
+            conduit: {
+              realtime: { enabled: true },
+              cms: { crudOperations: { read: { enabled: false } } },
+              authorization: { enabled: true },
+            },
+          },
+        };
+      },
+    };
+    try {
+      assertSchemaAvailable(lookup, 'Missing', true);
+      throw new Error('expected throw');
+    } catch (err: any) {
+      expect(err.code).toBe(status.NOT_FOUND);
+    }
+    try {
+      assertSchemaAvailable(lookup, 'Off', false);
+      throw new Error('expected throw');
+    } catch (err: any) {
+      expect(err.code).toBe(status.FAILED_PRECONDITION);
+    }
+    try {
+      assertSchemaAvailable(lookup, 'Order', true);
+      throw new Error('expected throw');
+    } catch (err: any) {
+      expect(err.code).toBe(status.PERMISSION_DENIED);
+    }
+    const admin = assertSchemaAvailable(lookup, 'Order', false);
+    expect(admin.authorizationEnabled).toBe(true);
+  });
+
+  it('maps adapter NOT_FOUND throws to a subscription error', () => {
+    const lookup = {
+      getSchema: () => {
+        throw new GrpcError(status.NOT_FOUND, 'Schema Missing not defined yet');
+      },
+    };
+    try {
+      assertSchemaAvailable(lookup, 'Missing', false);
+      throw new Error('expected throw');
+    } catch (err: any) {
+      expect(err.code).toBe(status.NOT_FOUND);
+      expect(err.message).toBe('Schema does not exist');
+    }
+  });
+});

--- a/modules/database/src/realtime/__tests__/change-stream.integration.test.ts
+++ b/modules/database/src/realtime/__tests__/change-stream.integration.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from '@jest/globals';
+import { MongoClient, ObjectId } from 'mongodb';
+import { normalizeChangeEvent, type RawChangeEvent } from '../normalize.js';
+
+const replicaSetUri = process.env.DB_CONN_URI;
+const integrationEnabled = Boolean(replicaSetUri?.includes('replicaSet'));
+const describeIntegration = integrationEnabled ? describe : describe.skip;
+
+describeIntegration('MongoDB change stream contract', () => {
+  it('normalizes insert events from a replica-set watch without document fields', async () => {
+    const client = new MongoClient(replicaSetUri!);
+    await client.connect();
+    const dbName = `conduit_realtime_${Date.now()}`;
+    const db = client.db(dbName);
+    try {
+      const collection = db.collection('orders');
+      const stream = db.watch([]);
+      const change = await new Promise<RawChangeEvent>((resolve, reject) => {
+        const timer = setTimeout(
+          () => reject(new Error('timed out waiting for change')),
+          10_000,
+        );
+        stream.on('change', event => {
+          clearTimeout(timer);
+          resolve(event as RawChangeEvent);
+        });
+        stream.on('error', err => {
+          clearTimeout(timer);
+          reject(err);
+        });
+        void collection.insertOne({ _id: new ObjectId(), secret: 'do-not-leak' });
+      });
+      await stream.close();
+      const event = normalizeChangeEvent(change, 'Order');
+      expect(event).toMatchObject({
+        version: 1,
+        operation: 'insert',
+        schema: 'Order',
+      });
+      expect(event).not.toHaveProperty('fullDocument');
+      expect(JSON.stringify(event)).not.toContain('do-not-leak');
+    } finally {
+      await db.dropDatabase().catch(() => undefined);
+      await client.close();
+    }
+  });
+});

--- a/modules/database/src/realtime/__tests__/coordinator.test.ts
+++ b/modules/database/src/realtime/__tests__/coordinator.test.ts
@@ -29,6 +29,7 @@ class MemoryStore {
 function createCoordinator(overrides?: {
   allow?: boolean;
   schemas?: { name: string; collectionName: string; authorizationEnabled: boolean }[];
+  getKeyDelayMs?: number;
 }) {
   const stream = new EventEmitter() as EventEmitter & { close: () => Promise<void> };
   stream.close = async () => {
@@ -42,12 +43,18 @@ function createCoordinator(overrides?: {
   const routerPush = jest.fn(async () => undefined);
   const adminPush = jest.fn(async () => undefined);
   const publish = jest.fn();
+  const watch = jest.fn(() => stream as never);
   const subscriptions = new RealtimeSubscriptionTracker(new MemoryStore());
   const grpcSdk = {
     state: {
       tryAcquireLock: jest.fn(async () => lock),
       releaseLock: jest.fn(async () => undefined),
-      getKey: jest.fn(async (key: string) => state.get(key) ?? null),
+      getKey: jest.fn(async (key: string) => {
+        if (overrides?.getKeyDelayMs) {
+          await new Promise(resolve => setTimeout(resolve, overrides.getKeyDelayMs));
+        }
+        return state.get(key) ?? null;
+      }),
       setKey: jest.fn(async (key: string, value: string) => {
         state.set(key, value);
       }),
@@ -65,7 +72,7 @@ function createCoordinator(overrides?: {
   };
   const coordinator = new MongoChangeStreamCoordinator({
     grpcSdk: grpcSdk as never,
-    watch: () => stream as never,
+    watch,
     hello: async () => ({ setName: 'rs0' }),
     getOptedInSchemas: () =>
       overrides?.schemas ?? [
@@ -78,6 +85,7 @@ function createCoordinator(overrides?: {
   return {
     coordinator,
     stream,
+    watch,
     routerPush,
     adminPush,
     publish,
@@ -152,6 +160,25 @@ describe('MongoChangeStreamCoordinator', () => {
     expect(authorizedDocumentRoom('Order', '64b64c4c4c4c4c4c4c4c4c', 'user-1')).toContain(
       'user-1',
     );
+    await coordinator.shutdown();
+  });
+
+  it('retries later when the leader lock is held by another instance', async () => {
+    jest.useFakeTimers();
+    const { coordinator, grpcSdk, lock } = createCoordinator();
+    grpcSdk.state.tryAcquireLock.mockResolvedValueOnce(null).mockResolvedValue(lock);
+    await coordinator.reconcile();
+    expect(coordinator.getState()).toBe('idle');
+    await jest.advanceTimersByTimeAsync(1_000);
+    expect(coordinator.getState()).toBe('live');
+    await coordinator.shutdown();
+    jest.useRealTimers();
+  });
+
+  it('opens a single watch when reconcile runs concurrently', async () => {
+    const { coordinator, watch } = createCoordinator({ getKeyDelayMs: 40 });
+    await Promise.all([coordinator.reconcile(), coordinator.reconcile()]);
+    expect(watch).toHaveBeenCalledTimes(1);
     await coordinator.shutdown();
   });
 

--- a/modules/database/src/realtime/__tests__/coordinator.test.ts
+++ b/modules/database/src/realtime/__tests__/coordinator.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it, jest } from '@jest/globals';
 import { ObjectId } from 'bson';
 import { MongoChangeStreamCoordinator } from '../MongoChangeStreamCoordinator.js';
 import { RealtimeSubscriptionTracker } from '../subscriptions.js';
-import { authorizedDocumentRoom, roomsForPublicChange } from '../rooms.js';
+import { roomsForPublicChange } from '../rooms.js';
 
 class MemoryStore {
   private sets = new Map<string, Set<string>>();
@@ -157,9 +157,6 @@ describe('MongoChangeStreamCoordinator', () => {
     await new Promise(resolve => setImmediate(resolve));
     expect(routerPush).not.toHaveBeenCalled();
     expect(await subscriptions.listUsers('Order', '64b64c4c4c4c4c4c4c4c4c')).toEqual([]);
-    expect(authorizedDocumentRoom('Order', '64b64c4c4c4c4c4c4c4c4c', 'user-1')).toContain(
-      'user-1',
-    );
     await coordinator.shutdown();
   });
 

--- a/modules/database/src/realtime/__tests__/coordinator.test.ts
+++ b/modules/database/src/realtime/__tests__/coordinator.test.ts
@@ -1,0 +1,166 @@
+import { EventEmitter } from 'node:events';
+import { describe, expect, it, jest } from '@jest/globals';
+import { ObjectId } from 'bson';
+import { MongoChangeStreamCoordinator } from '../MongoChangeStreamCoordinator.js';
+import { RealtimeSubscriptionTracker } from '../subscriptions.js';
+import { authorizedDocumentRoom, roomsForPublicChange } from '../rooms.js';
+
+class MemoryStore {
+  private sets = new Map<string, Set<string>>();
+  async sadd(key: string, ...members: string[]) {
+    const set = this.sets.get(key) ?? new Set<string>();
+    members.forEach(member => set.add(member));
+    this.sets.set(key, set);
+  }
+  async srem(key: string, ...members: string[]) {
+    members.forEach(member => this.sets.get(key)?.delete(member));
+  }
+  async smembers(key: string) {
+    return [...(this.sets.get(key) ?? new Set())];
+  }
+  async scard(key: string) {
+    return this.sets.get(key)?.size ?? 0;
+  }
+  async del(...keys: string[]) {
+    keys.forEach(key => this.sets.delete(key));
+  }
+}
+
+function createCoordinator(overrides?: {
+  allow?: boolean;
+  schemas?: { name: string; collectionName: string; authorizationEnabled: boolean }[];
+}) {
+  const stream = new EventEmitter() as EventEmitter & { close: () => Promise<void> };
+  stream.close = async () => {
+    stream.emit('close');
+  };
+  const state = new Map<string, string>();
+  const lock = {
+    extend: jest.fn(async () => lock),
+    release: jest.fn(async () => undefined),
+  };
+  const routerPush = jest.fn(async () => undefined);
+  const adminPush = jest.fn(async () => undefined);
+  const publish = jest.fn();
+  const subscriptions = new RealtimeSubscriptionTracker(new MemoryStore());
+  const grpcSdk = {
+    state: {
+      tryAcquireLock: jest.fn(async () => lock),
+      releaseLock: jest.fn(async () => undefined),
+      getKey: jest.fn(async (key: string) => state.get(key) ?? null),
+      setKey: jest.fn(async (key: string, value: string) => {
+        state.set(key, value);
+      }),
+      clearKey: jest.fn(async (key: string) => {
+        state.delete(key);
+      }),
+    },
+    bus: { publish },
+    router: { socketPush: routerPush },
+    admin: { socketPush: adminPush },
+    isAvailable: () => true,
+    authorization: {
+      can: async () => ({ allow: overrides?.allow !== false }),
+    },
+  };
+  const coordinator = new MongoChangeStreamCoordinator({
+    grpcSdk: grpcSdk as never,
+    watch: () => stream as never,
+    hello: async () => ({ setName: 'rs0' }),
+    getOptedInSchemas: () =>
+      overrides?.schemas ?? [
+        { name: 'Order', collectionName: 'orders', authorizationEnabled: false },
+      ],
+    subscriptions,
+    enabled: () => true,
+    engine: () => 'MongoDB',
+  });
+  return {
+    coordinator,
+    stream,
+    routerPush,
+    adminPush,
+    publish,
+    subscriptions,
+    grpcSdk,
+    state,
+    lock,
+  };
+}
+
+describe('MongoChangeStreamCoordinator', () => {
+  it('emits one normalized event to public rooms and ignores other collections', async () => {
+    const { coordinator, stream, routerPush, adminPush, publish } = createCoordinator();
+    await coordinator.reconcile();
+    const resume = { _data: 'token' };
+    stream.emit('change', {
+      operationType: 'insert',
+      ns: { coll: 'orders' },
+      documentKey: { _id: new ObjectId('64b64c4c4c4c4c4c4c4c4c4c') },
+      fullDocument: { secret: 'nope' },
+      _id: resume,
+      wallTime: new Date('2026-01-02T00:00:00.000Z'),
+    });
+    stream.emit('change', {
+      operationType: 'insert',
+      ns: { coll: 'other' },
+      documentKey: { _id: new ObjectId('64b64c4c4c4c4c4c4c4c4c4d') },
+      _id: resume,
+    });
+    await new Promise(resolve => setImmediate(resolve));
+    expect(publish).toHaveBeenCalledTimes(1);
+    expect(publish.mock.calls[0][0]).toBe('database:change:Order');
+    const payload = JSON.parse(publish.mock.calls[0][1] as string);
+    expect(payload).toMatchObject({
+      operation: 'insert',
+      schema: 'Order',
+      documentId: '64b64c4c4c4c4c4c4c4c4c4c',
+    });
+    expect(payload).not.toHaveProperty('fullDocument');
+    expect(payload).not.toHaveProperty('secret');
+    const expectedRooms = roomsForPublicChange('Order', '64b64c4c4c4c4c4c4c4c4c4c');
+    expect(routerPush).toHaveBeenCalledWith(
+      expect.objectContaining({ event: 'change', rooms: expectedRooms }),
+    );
+    expect(adminPush).toHaveBeenCalledWith(
+      expect.objectContaining({ event: 'change', rooms: expectedRooms }),
+    );
+    await coordinator.shutdown();
+  });
+
+  it('re-checks ReBAC before emission and drops revoked users', async () => {
+    const { coordinator, stream, routerPush, subscriptions } = createCoordinator({
+      allow: false,
+      schemas: [{ name: 'Order', collectionName: 'orders', authorizationEnabled: true }],
+    });
+    await subscriptions.addAuthorizedDocument(
+      'sock-1',
+      'Order',
+      '64b64c4c4c4c4c4c4c4c4c4c',
+      'user-1',
+    );
+    await coordinator.reconcile();
+    stream.emit('change', {
+      operationType: 'update',
+      ns: { coll: 'orders' },
+      documentKey: { _id: new ObjectId('64b64c4c4c4c4c4c4c4c4c4c') },
+      _id: { _data: 'token' },
+    });
+    await new Promise(resolve => setImmediate(resolve));
+    expect(routerPush).not.toHaveBeenCalled();
+    expect(await subscriptions.listUsers('Order', '64b64c4c4c4c4c4c4c4c4c')).toEqual([]);
+    expect(authorizedDocumentRoom('Order', '64b64c4c4c4c4c4c4c4c4c', 'user-1')).toContain(
+      'user-1',
+    );
+    await coordinator.shutdown();
+  });
+
+  it('clears an unusable resume token and retries', async () => {
+    const { coordinator, stream, grpcSdk } = createCoordinator();
+    await coordinator.reconcile();
+    stream.emit('error', { code: 280, message: 'ChangeStreamHistoryLost' });
+    await new Promise(resolve => setImmediate(resolve));
+    expect(grpcSdk.state.clearKey).toHaveBeenCalled();
+    await coordinator.shutdown();
+  });
+});

--- a/modules/database/src/realtime/__tests__/normalize.test.ts
+++ b/modules/database/src/realtime/__tests__/normalize.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from '@jest/globals';
+import { ObjectId } from 'bson';
+import { normalizeChangeEvent, parseResumeToken } from '../normalize.js';
+
+describe('normalizeChangeEvent', () => {
+  it('normalizes insert/update/replace/delete into metadata-only events', () => {
+    const resume = { _data: 'token-1' };
+    const event = normalizeChangeEvent(
+      {
+        operationType: 'insert',
+        documentKey: { _id: new ObjectId('64b64c4c4c4c4c4c4c4c4c4c') },
+        wallTime: new Date('2026-01-01T00:00:00.000Z'),
+        _id: resume,
+      },
+      'Order',
+    );
+    expect(event).toMatchObject({
+      version: 1,
+      operation: 'insert',
+      schema: 'Order',
+      documentId: '64b64c4c4c4c4c4c4c4c4c4c',
+      occurredAt: '2026-01-01T00:00:00.000Z',
+    });
+    expect(event?.resumeToken).toEqual(
+      parseResumeToken(event!.resumeToken) ? event!.resumeToken : event?.resumeToken,
+    );
+    expect(JSON.parse(JSON.stringify(event))).not.toHaveProperty('fullDocument');
+  });
+
+  it('ignores drop/invalidate and missing document ids', () => {
+    expect(
+      normalizeChangeEvent({ operationType: 'drop', _id: { _data: 'x' } }, 'Order'),
+    ).toBeNull();
+    expect(
+      normalizeChangeEvent({ operationType: 'insert', _id: { _data: 'x' } }, 'Order'),
+    ).toBeNull();
+  });
+});

--- a/modules/database/src/realtime/__tests__/normalize.test.ts
+++ b/modules/database/src/realtime/__tests__/normalize.test.ts
@@ -9,6 +9,7 @@ describe('normalizeChangeEvent', () => {
       {
         operationType: 'insert',
         documentKey: { _id: new ObjectId('64b64c4c4c4c4c4c4c4c4c4c') },
+        fullDocument: { secret: 'nope' },
         wallTime: new Date('2026-01-01T00:00:00.000Z'),
         _id: resume,
       },
@@ -21,9 +22,7 @@ describe('normalizeChangeEvent', () => {
       documentId: '64b64c4c4c4c4c4c4c4c4c4c',
       occurredAt: '2026-01-01T00:00:00.000Z',
     });
-    expect(event?.resumeToken).toEqual(
-      parseResumeToken(event!.resumeToken) ? event!.resumeToken : event?.resumeToken,
-    );
+    expect(parseResumeToken(event!.resumeToken)).toEqual(resume);
     expect(JSON.parse(JSON.stringify(event))).not.toHaveProperty('fullDocument');
   });
 

--- a/modules/database/src/realtime/__tests__/rooms.test.ts
+++ b/modules/database/src/realtime/__tests__/rooms.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from '@jest/globals';
+import {
+  authorizedDocumentRoom,
+  documentRoom,
+  roomsForPublicChange,
+  schemaRoom,
+} from '../rooms.js';
+
+describe('realtime rooms', () => {
+  it('isolates schema, document, and per-user rooms', () => {
+    expect(schemaRoom('Order')).toBe('database:schema:Order');
+    expect(documentRoom('Order', 'abc')).toBe('database:doc:Order:abc');
+    expect(authorizedDocumentRoom('Order', 'abc', 'user-1')).toBe(
+      'database:doc:Order:abc:user:user-1',
+    );
+    expect(roomsForPublicChange('Order', 'abc')).toEqual([
+      'database:schema:Order',
+      'database:doc:Order:abc',
+    ]);
+    expect(schemaRoom('Order')).not.toBe(schemaRoom('Orders'));
+    expect(authorizedDocumentRoom('Order', 'abc', 'u1')).not.toBe(
+      authorizedDocumentRoom('Order', 'abc', 'u2'),
+    );
+  });
+
+  it('encodes reserved characters so rooms cannot collide', () => {
+    expect(schemaRoom('a/b')).toBe('database:schema:a%2Fb');
+    expect(documentRoom('Order', 'id:1')).toBe('database:doc:Order:id%3A1');
+  });
+});

--- a/modules/database/src/realtime/__tests__/status.test.ts
+++ b/modules/database/src/realtime/__tests__/status.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from '@jest/globals';
+import { buildRealtimeStatus } from '../status.js';
+
+describe('buildRealtimeStatus', () => {
+  it('reports unsupported, disabled, idle, live, and degraded states', () => {
+    expect(
+      buildRealtimeStatus({
+        engine: 'PostgreSQL',
+        enabled: true,
+        topologySupported: true,
+        activeSchemaCount: 1,
+        streamState: 'live',
+      }).status,
+    ).toBe('unsupported');
+    expect(
+      buildRealtimeStatus({
+        engine: 'MongoDB',
+        enabled: false,
+        topologySupported: true,
+        activeSchemaCount: 1,
+        streamState: 'live',
+      }).status,
+    ).toBe('disabled');
+    expect(
+      buildRealtimeStatus({
+        engine: 'MongoDB',
+        enabled: true,
+        topologySupported: false,
+        activeSchemaCount: 1,
+        streamState: 'idle',
+      }).message,
+    ).toMatch(/replica set/i);
+    expect(
+      buildRealtimeStatus({
+        engine: 'MongoDB',
+        enabled: true,
+        topologySupported: true,
+        activeSchemaCount: 2,
+        streamState: 'live',
+      }).status,
+    ).toBe('live');
+    expect(
+      buildRealtimeStatus({
+        engine: 'MongoDB',
+        enabled: true,
+        topologySupported: true,
+        activeSchemaCount: 1,
+        streamState: 'degraded',
+        lastError: 'boom',
+      }),
+    ).toMatchObject({ status: 'degraded', message: 'boom' });
+  });
+});

--- a/modules/database/src/realtime/__tests__/subscriptions.test.ts
+++ b/modules/database/src/realtime/__tests__/subscriptions.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from '@jest/globals';
+import { RealtimeSubscriptionTracker } from '../subscriptions.js';
+
+class MemoryStore {
+  private sets = new Map<string, Set<string>>();
+
+  async sadd(key: string, ...members: string[]) {
+    const set = this.sets.get(key) ?? new Set<string>();
+    members.forEach(member => set.add(member));
+    this.sets.set(key, set);
+    return members.length;
+  }
+
+  async srem(key: string, ...members: string[]) {
+    const set = this.sets.get(key);
+    if (!set) return 0;
+    members.forEach(member => set.delete(member));
+    return members.length;
+  }
+
+  async smembers(key: string) {
+    return [...(this.sets.get(key) ?? new Set())];
+  }
+
+  async scard(key: string) {
+    return this.sets.get(key)?.size ?? 0;
+  }
+
+  async del(...keys: string[]) {
+    keys.forEach(key => this.sets.delete(key));
+    return keys.length;
+  }
+}
+
+describe('RealtimeSubscriptionTracker', () => {
+  it('tracks users per document and cleans up on disconnect', async () => {
+    const tracker = new RealtimeSubscriptionTracker(new MemoryStore());
+    await tracker.addAuthorizedDocument('s1', 'Order', 'doc-1', 'user-1');
+    await tracker.addAuthorizedDocument('s2', 'Order', 'doc-1', 'user-1');
+    expect(await tracker.listUsers('Order', 'doc-1')).toEqual(['user-1']);
+
+    await tracker.disconnect('s1');
+    expect(await tracker.listUsers('Order', 'doc-1')).toEqual(['user-1']);
+
+    await tracker.disconnect('s2');
+    expect(await tracker.listUsers('Order', 'doc-1')).toEqual([]);
+  });
+
+  it('removes revoked users from the document set', async () => {
+    const tracker = new RealtimeSubscriptionTracker(new MemoryStore());
+    await tracker.addAuthorizedDocument('s1', 'Order', 'doc-1', 'user-1');
+    await tracker.removeUser('Order', 'doc-1', 'user-1');
+    expect(await tracker.listUsers('Order', 'doc-1')).toEqual([]);
+  });
+});

--- a/modules/database/src/realtime/__tests__/topology.test.ts
+++ b/modules/database/src/realtime/__tests__/topology.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from '@jest/globals';
+import { isResumeTokenUnusable, topologyFromHello } from '../topology.js';
+
+describe('topology helpers', () => {
+  it('accepts replica sets and mongos, rejects standalone', () => {
+    expect(topologyFromHello({ setName: 'rs0' })).toEqual({ supported: true });
+    expect(topologyFromHello({ msg: 'isdbgrid' })).toEqual({ supported: true });
+    expect(topologyFromHello({}).supported).toBe(false);
+  });
+
+  it('detects unusable resume tokens', () => {
+    expect(isResumeTokenUnusable({ code: 280 })).toBe(true);
+    expect(isResumeTokenUnusable(new Error('cannot resume'))).toBe(true);
+    expect(isResumeTokenUnusable(new Error('socket hang up'))).toBe(false);
+  });
+});

--- a/modules/database/src/realtime/authorize.ts
+++ b/modules/database/src/realtime/authorize.ts
@@ -1,0 +1,147 @@
+import { status } from '@grpc/grpc-js';
+import { GrpcError } from '@conduitplatform/grpc-sdk';
+import type { OptedInSchema, SubscribeRequest } from './types.js';
+
+export class RealtimeSubscriptionError extends GrpcError {
+  constructor(code: number, message: string) {
+    super(code, message);
+    this.name = 'RealtimeSubscriptionError';
+  }
+}
+
+export type AuthorizationSdk = {
+  isAvailable: (module: string) => boolean;
+  authorization?: {
+    can: (request: {
+      subject: string;
+      actions: string[];
+      resource: string;
+    }) => Promise<{ allow: boolean }>;
+  } | null;
+};
+
+export type SchemaLookup = {
+  getSchema(name: string):
+    | {
+        name: string;
+        modelOptions?: {
+          conduit?: {
+            realtime?: { enabled?: boolean };
+            cms?: { crudOperations?: { read?: { enabled?: boolean } } };
+            authorization?: { enabled?: boolean };
+          };
+        };
+      }
+    | undefined;
+};
+
+export type ResolvedSubscription = {
+  schema: string;
+  documentId?: string;
+  authorizationEnabled: boolean;
+  rooms: string[];
+};
+
+export function parseSubscribeRequest(params: unknown[]): SubscribeRequest {
+  const raw = params[0];
+  if (raw && typeof raw === 'object' && !Array.isArray(raw)) {
+    return raw as SubscribeRequest;
+  }
+  return {};
+}
+
+export function requireSchemaName(value: unknown): string {
+  if (typeof value !== 'string' || value.trim() === '') {
+    throw new RealtimeSubscriptionError(status.INVALID_ARGUMENT, 'schema is required');
+  }
+  return value.trim();
+}
+
+export function optionalDocumentId(value: unknown): string | undefined {
+  if (value === undefined || value === null || value === '') return undefined;
+  if (typeof value !== 'string') {
+    throw new RealtimeSubscriptionError(
+      status.INVALID_ARGUMENT,
+      'documentId must be a string',
+    );
+  }
+  return value;
+}
+
+export async function canReadDocument(
+  grpcSdk: AuthorizationSdk,
+  schema: string,
+  documentId: string,
+  userId: string,
+): Promise<boolean> {
+  if (!grpcSdk.authorization || !grpcSdk.isAvailable('authorization')) {
+    return false;
+  }
+  try {
+    const decision = await grpcSdk.authorization.can({
+      subject: `User:${userId}`,
+      actions: ['read'],
+      resource: `${schema}:${documentId}`,
+    });
+    return decision.allow === true;
+  } catch {
+    return false;
+  }
+}
+
+export function assertSchemaAvailable(
+  lookup: SchemaLookup,
+  schemaName: string,
+  requireCmsRead: boolean,
+): {
+  authorizationEnabled: boolean;
+  realtimeEnabled: boolean;
+} {
+  let schema: ReturnType<SchemaLookup['getSchema']>;
+  try {
+    schema = lookup.getSchema(schemaName);
+  } catch (err) {
+    if (err instanceof GrpcError && err.code === status.NOT_FOUND) {
+      throw new RealtimeSubscriptionError(status.NOT_FOUND, 'Schema does not exist');
+    }
+    throw err;
+  }
+  if (!schema) {
+    throw new RealtimeSubscriptionError(status.NOT_FOUND, 'Schema does not exist');
+  }
+  const conduit = schema.modelOptions?.conduit;
+  if (!conduit?.realtime?.enabled) {
+    throw new RealtimeSubscriptionError(
+      status.FAILED_PRECONDITION,
+      'Live updates are not enabled for this schema',
+    );
+  }
+  if (requireCmsRead && conduit.cms?.crudOperations?.read?.enabled !== true) {
+    throw new RealtimeSubscriptionError(
+      status.PERMISSION_DENIED,
+      'CMS read is not enabled for this schema',
+    );
+  }
+  return {
+    authorizationEnabled: conduit.authorization?.enabled === true,
+    realtimeEnabled: true,
+  };
+}
+
+export function toOptedInSchema(schema: {
+  name: string;
+  collectionName: string;
+  modelOptions?: {
+    conduit?: {
+      realtime?: { enabled?: boolean };
+      authorization?: { enabled?: boolean };
+    };
+  };
+}): OptedInSchema | null {
+  if (!schema.modelOptions?.conduit?.realtime?.enabled) return null;
+  return {
+    name: schema.name,
+    collectionName: schema.collectionName,
+    authorizationEnabled: schema.modelOptions.conduit.authorization?.enabled === true,
+  };
+}

--- a/modules/database/src/realtime/authorize.ts
+++ b/modules/database/src/realtime/authorize.ts
@@ -35,13 +35,6 @@ export type SchemaLookup = {
     | undefined;
 };
 
-export type ResolvedSubscription = {
-  schema: string;
-  documentId?: string;
-  authorizationEnabled: boolean;
-  rooms: string[];
-};
-
 export function parseSubscribeRequest(params: unknown[]): SubscribeRequest {
   const raw = params[0];
   if (raw && typeof raw === 'object' && !Array.isArray(raw)) {
@@ -93,10 +86,7 @@ export function assertSchemaAvailable(
   lookup: SchemaLookup,
   schemaName: string,
   requireCmsRead: boolean,
-): {
-  authorizationEnabled: boolean;
-  realtimeEnabled: boolean;
-} {
+): { authorizationEnabled: boolean } {
   let schema: ReturnType<SchemaLookup['getSchema']>;
   try {
     schema = lookup.getSchema(schemaName);
@@ -124,7 +114,6 @@ export function assertSchemaAvailable(
   }
   return {
     authorizationEnabled: conduit.authorization?.enabled === true,
-    realtimeEnabled: true,
   };
 }
 

--- a/modules/database/src/realtime/index.ts
+++ b/modules/database/src/realtime/index.ts
@@ -1,0 +1,11 @@
+export { RealtimeService } from './RealtimeService.js';
+export { buildRealtimeStatus } from './status.js';
+export { normalizeChangeEvent } from './normalize.js';
+export {
+  schemaRoom,
+  documentRoom,
+  authorizedDocumentRoom,
+  roomsForPublicChange,
+} from './rooms.js';
+export { RealtimeSubscriptionTracker } from './subscriptions.js';
+export type { RealtimeStatus, DatabaseChangeEvent } from './types.js';

--- a/modules/database/src/realtime/normalize.ts
+++ b/modules/database/src/realtime/normalize.ts
@@ -1,0 +1,70 @@
+import { EJSON } from 'bson';
+import {
+  DATABASE_CHANGE_EVENT_VERSION,
+  DATABASE_CHANGE_OPERATIONS,
+  type DatabaseChangeEvent,
+  type DatabaseChangeOperation,
+} from './types.js';
+
+const OPERATION_SET = new Set<string>(DATABASE_CHANGE_OPERATIONS);
+
+export type RawChangeEvent = {
+  operationType?: string;
+  ns?: { coll?: string };
+  documentKey?: { _id?: unknown };
+  wallTime?: Date;
+  clusterTime?: { toString?: () => string };
+  _id?: unknown;
+};
+
+export function normalizeChangeEvent(
+  change: RawChangeEvent,
+  schemaName: string,
+  occurredAt: Date = new Date(),
+): DatabaseChangeEvent | null {
+  const operation = change.operationType;
+  if (!operation || !OPERATION_SET.has(operation)) {
+    return null;
+  }
+  const documentId = extractDocumentId(change.documentKey?._id);
+  if (!documentId) {
+    return null;
+  }
+  if (!change._id) {
+    return null;
+  }
+  return {
+    version: DATABASE_CHANGE_EVENT_VERSION,
+    operation: operation as DatabaseChangeOperation,
+    schema: schemaName,
+    documentId,
+    occurredAt: (change.wallTime instanceof Date
+      ? change.wallTime
+      : occurredAt
+    ).toISOString(),
+    resumeToken: EJSON.stringify(change._id),
+  };
+}
+
+export function parseResumeToken(token: string | null | undefined): unknown | undefined {
+  if (!token) return undefined;
+  try {
+    return EJSON.parse(token);
+  } catch {
+    return undefined;
+  }
+}
+
+function extractDocumentId(id: unknown): string | null {
+  if (id === undefined || id === null) return null;
+  if (typeof id === 'string' || typeof id === 'number') return String(id);
+  if (typeof id === 'object' && id !== null && 'toHexString' in id) {
+    const hex = (id as { toHexString: () => string }).toHexString();
+    return typeof hex === 'string' && hex.length > 0 ? hex : null;
+  }
+  if (typeof id === 'object' && id !== null && 'toString' in id) {
+    const value = String(id);
+    return value && value !== '[object Object]' ? value : null;
+  }
+  return null;
+}

--- a/modules/database/src/realtime/rooms.ts
+++ b/modules/database/src/realtime/rooms.ts
@@ -1,0 +1,25 @@
+const ROOM_PREFIX = 'database';
+
+function encodeSegment(value: string): string {
+  return encodeURIComponent(value);
+}
+
+export function schemaRoom(schema: string): string {
+  return `${ROOM_PREFIX}:schema:${encodeSegment(schema)}`;
+}
+
+export function documentRoom(schema: string, documentId: string): string {
+  return `${ROOM_PREFIX}:doc:${encodeSegment(schema)}:${encodeSegment(documentId)}`;
+}
+
+export function authorizedDocumentRoom(
+  schema: string,
+  documentId: string,
+  userId: string,
+): string {
+  return `${ROOM_PREFIX}:doc:${encodeSegment(schema)}:${encodeSegment(documentId)}:user:${encodeSegment(userId)}`;
+}
+
+export function roomsForPublicChange(schema: string, documentId: string): string[] {
+  return [schemaRoom(schema), documentRoom(schema, documentId)];
+}

--- a/modules/database/src/realtime/sockets.ts
+++ b/modules/database/src/realtime/sockets.ts
@@ -1,0 +1,166 @@
+import {
+  ConduitGrpcSdk,
+  ConduitRouteReturnDefinition,
+  ParsedSocketRequest,
+  TYPE,
+  UnparsedSocketResponse,
+} from '@conduitplatform/grpc-sdk';
+import { status } from '@grpc/grpc-js';
+import { RoutingManager } from '@conduitplatform/module-tools';
+import {
+  assertSchemaAvailable,
+  canReadDocument,
+  optionalDocumentId,
+  parseSubscribeRequest,
+  RealtimeSubscriptionError,
+  requireSchemaName,
+  type AuthorizationSdk,
+  type SchemaLookup,
+} from './authorize.js';
+import { authorizedDocumentRoom, documentRoom, schemaRoom } from './rooms.js';
+import type { RealtimeSubscriptionTracker } from './subscriptions.js';
+
+type SocketMode = 'client' | 'admin';
+
+export function registerDatabaseRealtimeSocket(
+  routingManager: RoutingManager,
+  options: {
+    mode: SocketMode;
+    grpcSdk: ConduitGrpcSdk;
+    schemaLookup: SchemaLookup;
+    subscriptions: RealtimeSubscriptionTracker;
+    isGloballyEnabled: () => boolean;
+  },
+) {
+  const handlers = createSocketHandlers(options);
+  routingManager.socket(
+    {
+      path: '/',
+      middlewares: options.mode === 'client' ? ['authMiddleware'] : undefined,
+    },
+    {
+      connect: { handler: handlers.connect },
+      disconnect: { handler: handlers.disconnect },
+      subscribe: {
+        params: [TYPE.JSON],
+        handler: handlers.subscribe,
+        returnType: new ConduitRouteReturnDefinition('DatabaseRealtimeSubscribe', {
+          rooms: [TYPE.String],
+        }),
+      },
+      unsubscribe: {
+        params: [TYPE.JSON],
+        handler: handlers.unsubscribe,
+        returnType: new ConduitRouteReturnDefinition('DatabaseRealtimeUnsubscribe', {
+          rooms: [TYPE.String],
+        }),
+      },
+    },
+  );
+}
+
+function createSocketHandlers(options: {
+  mode: SocketMode;
+  grpcSdk: ConduitGrpcSdk;
+  schemaLookup: SchemaLookup;
+  subscriptions: RealtimeSubscriptionTracker;
+  isGloballyEnabled: () => boolean;
+}) {
+  return {
+    connect: async (): Promise<UnparsedSocketResponse> => {
+      return { event: 'connected', data: { ok: true } };
+    },
+    disconnect: async (call: ParsedSocketRequest): Promise<UnparsedSocketResponse> => {
+      await options.subscriptions.disconnect(call.request.socketId);
+      return { event: 'disconnected', data: { ok: true } };
+    },
+    subscribe: async (call: ParsedSocketRequest): Promise<UnparsedSocketResponse> => {
+      const rooms = await resolveSubscription(call, options, 'join');
+      return { event: 'join-room', rooms };
+    },
+    unsubscribe: async (call: ParsedSocketRequest): Promise<UnparsedSocketResponse> => {
+      const rooms = await resolveSubscription(call, options, 'leave');
+      return { event: 'leave-room', rooms };
+    },
+  };
+}
+
+async function resolveSubscription(
+  call: ParsedSocketRequest,
+  options: {
+    mode: SocketMode;
+    grpcSdk: ConduitGrpcSdk;
+    schemaLookup: SchemaLookup;
+    subscriptions: RealtimeSubscriptionTracker;
+    isGloballyEnabled: () => boolean;
+  },
+  action: 'join' | 'leave',
+): Promise<string[]> {
+  if (!options.isGloballyEnabled()) {
+    throw new RealtimeSubscriptionError(
+      status.FAILED_PRECONDITION,
+      'Live updates are disabled',
+    );
+  }
+  const payload = parseSubscribeRequest(call.request.params ?? []);
+  const schemaName = requireSchemaName(payload.schema);
+  const documentId = optionalDocumentId(payload.documentId);
+  const meta = assertSchemaAvailable(
+    options.schemaLookup,
+    schemaName,
+    options.mode === 'client',
+  );
+
+  if (options.mode === 'admin') {
+    if (documentId) return [documentRoom(schemaName, documentId)];
+    return [schemaRoom(schemaName)];
+  }
+
+  const userId = call.request.context?.user?._id;
+  if (!userId) {
+    throw new RealtimeSubscriptionError(
+      status.UNAUTHENTICATED,
+      'Authentication required',
+    );
+  }
+
+  if (meta.authorizationEnabled) {
+    if (!documentId) {
+      throw new RealtimeSubscriptionError(
+        status.PERMISSION_DENIED,
+        'Document ID is required for authorized schemas',
+      );
+    }
+    const allowed = await canReadDocument(
+      options.grpcSdk as unknown as AuthorizationSdk,
+      schemaName,
+      documentId,
+      userId,
+    );
+    if (!allowed) {
+      throw new RealtimeSubscriptionError(
+        status.PERMISSION_DENIED,
+        'Read permission denied',
+      );
+    }
+    if (action === 'join') {
+      await options.subscriptions.addAuthorizedDocument(
+        call.request.socketId,
+        schemaName,
+        documentId,
+        userId,
+      );
+    } else {
+      await options.subscriptions.removeAuthorizedDocument(
+        call.request.socketId,
+        schemaName,
+        documentId,
+        userId,
+      );
+    }
+    return [authorizedDocumentRoom(schemaName, documentId, userId)];
+  }
+
+  if (documentId) return [documentRoom(schemaName, documentId)];
+  return [schemaRoom(schemaName)];
+}

--- a/modules/database/src/realtime/sockets.ts
+++ b/modules/database/src/realtime/sockets.ts
@@ -22,15 +22,17 @@ import type { RealtimeSubscriptionTracker } from './subscriptions.js';
 
 type SocketMode = 'client' | 'admin';
 
+type RealtimeSocketOptions = {
+  mode: SocketMode;
+  grpcSdk: ConduitGrpcSdk;
+  schemaLookup: SchemaLookup;
+  subscriptions: RealtimeSubscriptionTracker;
+  isGloballyEnabled: () => boolean;
+};
+
 export function registerDatabaseRealtimeSocket(
   routingManager: RoutingManager,
-  options: {
-    mode: SocketMode;
-    grpcSdk: ConduitGrpcSdk;
-    schemaLookup: SchemaLookup;
-    subscriptions: RealtimeSubscriptionTracker;
-    isGloballyEnabled: () => boolean;
-  },
+  options: RealtimeSocketOptions,
 ) {
   const handlers = createSocketHandlers(options);
   routingManager.socket(
@@ -59,13 +61,7 @@ export function registerDatabaseRealtimeSocket(
   );
 }
 
-function createSocketHandlers(options: {
-  mode: SocketMode;
-  grpcSdk: ConduitGrpcSdk;
-  schemaLookup: SchemaLookup;
-  subscriptions: RealtimeSubscriptionTracker;
-  isGloballyEnabled: () => boolean;
-}) {
+function createSocketHandlers(options: RealtimeSocketOptions) {
   return {
     connect: async (): Promise<UnparsedSocketResponse> => {
       return { event: 'connected', data: { ok: true } };
@@ -87,13 +83,7 @@ function createSocketHandlers(options: {
 
 async function resolveSubscription(
   call: ParsedSocketRequest,
-  options: {
-    mode: SocketMode;
-    grpcSdk: ConduitGrpcSdk;
-    schemaLookup: SchemaLookup;
-    subscriptions: RealtimeSubscriptionTracker;
-    isGloballyEnabled: () => boolean;
-  },
+  options: RealtimeSocketOptions,
   action: 'join' | 'leave',
 ): Promise<string[]> {
   if (!options.isGloballyEnabled()) {

--- a/modules/database/src/realtime/status.ts
+++ b/modules/database/src/realtime/status.ts
@@ -1,0 +1,74 @@
+import type { RealtimeStatus, RealtimeStatusCode } from './types.js';
+
+export type RealtimeStatusInput = {
+  engine: string;
+  enabled: boolean;
+  topologySupported: boolean;
+  topologyMessage?: string;
+  activeSchemaCount: number;
+  streamState: RealtimeStatusCode;
+  lastEventAt?: string;
+  lastError?: string;
+  socketsEnabled?: boolean;
+};
+
+export function buildRealtimeStatus(input: RealtimeStatusInput): RealtimeStatus {
+  if (input.engine !== 'MongoDB') {
+    return {
+      status: 'unsupported',
+      engine: input.engine,
+      activeSchemaCount: 0,
+      message: 'Live updates require MongoDB',
+    };
+  }
+  if (!input.enabled) {
+    return {
+      status: 'disabled',
+      engine: input.engine,
+      activeSchemaCount: input.activeSchemaCount,
+    };
+  }
+  if (!input.topologySupported) {
+    return {
+      status: 'idle',
+      engine: input.engine,
+      activeSchemaCount: input.activeSchemaCount,
+      message:
+        input.topologyMessage ??
+        'A replica set or sharded MongoDB deployment is required for live updates',
+    };
+  }
+  if (input.socketsEnabled === false) {
+    return {
+      status: 'idle',
+      engine: input.engine,
+      activeSchemaCount: input.activeSchemaCount,
+      message:
+        'Enable Admin socket transport to consume live updates in the control panel',
+      lastEventAt: input.lastEventAt,
+    };
+  }
+  if (input.activeSchemaCount === 0) {
+    return {
+      status: 'idle',
+      engine: input.engine,
+      activeSchemaCount: 0,
+      message: 'No schemas have live updates enabled',
+    };
+  }
+  if (input.streamState === 'degraded') {
+    return {
+      status: 'degraded',
+      engine: input.engine,
+      activeSchemaCount: input.activeSchemaCount,
+      lastEventAt: input.lastEventAt,
+      message: input.lastError ?? 'Change stream is retrying after an error',
+    };
+  }
+  return {
+    status: input.streamState,
+    engine: input.engine,
+    activeSchemaCount: input.activeSchemaCount,
+    lastEventAt: input.lastEventAt,
+  };
+}

--- a/modules/database/src/realtime/subscriptions.ts
+++ b/modules/database/src/realtime/subscriptions.ts
@@ -1,0 +1,92 @@
+export type SubscriptionStore = {
+  sadd(key: string, ...members: string[]): Promise<unknown>;
+  srem(key: string, ...members: string[]): Promise<unknown>;
+  smembers(key: string): Promise<string[]>;
+  scard(key: string): Promise<number>;
+  del(...keys: string[]): Promise<unknown>;
+};
+
+function socketKey(socketId: string): string {
+  return `realtime:socket:${socketId}`;
+}
+
+function docUsersKey(schema: string, documentId: string): string {
+  return `realtime:doc:${schema}:${documentId}`;
+}
+
+function userDocSocketsKey(schema: string, documentId: string, userId: string): string {
+  return `realtime:userdoc:${schema}:${documentId}:${userId}`;
+}
+
+function subscriptionRecord(schema: string, documentId: string, userId: string): string {
+  return JSON.stringify({ schema, documentId, userId });
+}
+
+export class RealtimeSubscriptionTracker {
+  constructor(private readonly store: SubscriptionStore) {}
+
+  async addAuthorizedDocument(
+    socketId: string,
+    schema: string,
+    documentId: string,
+    userId: string,
+  ): Promise<void> {
+    await this.store.sadd(
+      socketKey(socketId),
+      subscriptionRecord(schema, documentId, userId),
+    );
+    await this.store.sadd(userDocSocketsKey(schema, documentId, userId), socketId);
+    await this.store.sadd(docUsersKey(schema, documentId), userId);
+  }
+
+  async removeAuthorizedDocument(
+    socketId: string,
+    schema: string,
+    documentId: string,
+    userId: string,
+  ): Promise<void> {
+    await this.store.srem(
+      socketKey(socketId),
+      subscriptionRecord(schema, documentId, userId),
+    );
+    await this.store.srem(userDocSocketsKey(schema, documentId, userId), socketId);
+    const remaining = await this.store.scard(
+      userDocSocketsKey(schema, documentId, userId),
+    );
+    if (remaining === 0) {
+      await this.store.srem(docUsersKey(schema, documentId), userId);
+      await this.store.del(userDocSocketsKey(schema, documentId, userId));
+    }
+  }
+
+  async listUsers(schema: string, documentId: string): Promise<string[]> {
+    return this.store.smembers(docUsersKey(schema, documentId));
+  }
+
+  async removeUser(schema: string, documentId: string, userId: string): Promise<void> {
+    await this.store.srem(docUsersKey(schema, documentId), userId);
+    await this.store.del(userDocSocketsKey(schema, documentId, userId));
+  }
+
+  async disconnect(socketId: string): Promise<void> {
+    const records = await this.store.smembers(socketKey(socketId));
+    for (const record of records) {
+      try {
+        const parsed = JSON.parse(record) as {
+          schema: string;
+          documentId: string;
+          userId: string;
+        };
+        await this.removeAuthorizedDocument(
+          socketId,
+          parsed.schema,
+          parsed.documentId,
+          parsed.userId,
+        );
+      } catch {
+        // ignore malformed records
+      }
+    }
+    await this.store.del(socketKey(socketId));
+  }
+}

--- a/modules/database/src/realtime/topology.ts
+++ b/modules/database/src/realtime/topology.ts
@@ -1,0 +1,49 @@
+const CHANGE_STREAM_ERROR_CODES = new Set([
+  136, // CappedPositionLost
+  237, // CursorKilled
+  280, // ChangeStreamHistoryLost
+  286, // ChangeStreamFatalError
+]);
+
+export type TopologyResult = {
+  supported: boolean;
+  message?: string;
+};
+
+export function topologyFromHello(
+  hello:
+    | {
+        setName?: string;
+        msg?: string;
+      }
+    | null
+    | undefined,
+): TopologyResult {
+  if (!hello) {
+    return { supported: false, message: 'Unable to determine MongoDB topology' };
+  }
+  if (hello.msg === 'isdbgrid' || Boolean(hello.setName)) {
+    return { supported: true };
+  }
+  return {
+    supported: false,
+    message: 'A replica set or sharded MongoDB deployment is required for live updates',
+  };
+}
+
+export function isResumeTokenUnusable(error: unknown): boolean {
+  const code = extractErrorCode(error);
+  if (code !== undefined && CHANGE_STREAM_ERROR_CODES.has(code)) {
+    return true;
+  }
+  const message = error instanceof Error ? error.message : String(error ?? '');
+  return /resume token|ChangeStreamHistoryLost|cannot resume/i.test(message);
+}
+
+function extractErrorCode(error: unknown): number | undefined {
+  if (!error || typeof error !== 'object') return undefined;
+  const candidate = error as { code?: unknown; errorCode?: unknown };
+  if (typeof candidate.code === 'number') return candidate.code;
+  if (typeof candidate.errorCode === 'number') return candidate.errorCode;
+  return undefined;
+}

--- a/modules/database/src/realtime/types.ts
+++ b/modules/database/src/realtime/types.ts
@@ -1,0 +1,49 @@
+export const DATABASE_CHANGE_EVENT_VERSION = 1 as const;
+
+export const DATABASE_CHANGE_OPERATIONS = [
+  'insert',
+  'update',
+  'replace',
+  'delete',
+] as const;
+
+export type DatabaseChangeOperation = (typeof DATABASE_CHANGE_OPERATIONS)[number];
+
+export type DatabaseChangeEvent = {
+  version: typeof DATABASE_CHANGE_EVENT_VERSION;
+  operation: DatabaseChangeOperation;
+  schema: string;
+  documentId: string;
+  occurredAt: string;
+  resumeToken: string;
+};
+
+export type RealtimeStatusCode =
+  'unsupported' | 'disabled' | 'idle' | 'starting' | 'live' | 'degraded';
+
+export type RealtimeStatus = {
+  status: RealtimeStatusCode;
+  engine: string;
+  activeSchemaCount: number;
+  lastEventAt?: string;
+  message?: string;
+};
+
+export type OptedInSchema = {
+  name: string;
+  collectionName: string;
+  authorizationEnabled: boolean;
+};
+
+export type SubscribeRequest = {
+  schema?: unknown;
+  documentId?: unknown;
+};
+
+export type ChangeStreamLike = {
+  on(
+    event: 'change' | 'error' | 'close' | 'end',
+    listener: (...args: unknown[]) => void,
+  ): void;
+  close(): Promise<void> | void;
+};

--- a/modules/database/src/routes/index.ts
+++ b/modules/database/src/routes/index.ts
@@ -13,6 +13,7 @@ import {
 import { DatabaseAdapter } from '../adapters/DatabaseAdapter.js';
 import { MongooseSchema } from '../adapters/mongoose-adapter/MongooseSchema.js';
 import { SequelizeSchema } from '../adapters/sequelize-adapter/SequelizeSchema.js';
+import type { RealtimeService } from '../realtime/index.js';
 
 export class DatabaseRoutes {
   private readonly handlers: CmsHandlers;
@@ -34,6 +35,7 @@ export class DatabaseRoutes {
     readonly server: GrpcServer,
     private readonly database: DatabaseAdapter<MongooseSchema | SequelizeSchema>,
     private readonly grpcSdk: ConduitGrpcSdk,
+    private readonly realtimeService?: RealtimeService,
   ) {
     this.handlers = new CmsHandlers(grpcSdk, database);
     this._routingManager = new RoutingManager(this.grpcSdk.router!, server);
@@ -55,7 +57,6 @@ export class DatabaseRoutes {
   }
 
   requestRefresh() {
-    if (this.crudRoutes.length === 0 && this.customRoutes.length === 0) return;
     this._scheduleTimeout();
   }
 
@@ -86,6 +87,7 @@ export class DatabaseRoutes {
     this.crudRoutes.concat(this.customRoutes).forEach(route => {
       this._routingManager.route(route.input, route.returnType, route.handler);
     });
+    this.realtimeService?.registerClient(this._routingManager);
     this._routingManager
       .registerRoutes()
       .then(() => {

--- a/modules/database/src/utils/SchemaConverter.ts
+++ b/modules/database/src/utils/SchemaConverter.ts
@@ -38,6 +38,9 @@ export namespace SchemaConverter {
     authorization?: {
       enabled?: boolean;
     };
+    realtime?: {
+      enabled?: boolean;
+    };
     permissions?: {
       extendable?: boolean;
       canCreate?: boolean;
@@ -129,6 +132,9 @@ export namespace SchemaConverter {
         existing?.authorization?.enabled ??
         defaults.conduit!.authorization?.enabled ??
         false,
+    };
+    modelOptions.conduit.realtime = {
+      enabled: opts.realtime?.enabled ?? existing?.realtime?.enabled ?? false,
     };
     modelOptions.conduit.permissions = {
       extendable:

--- a/modules/database/src/utils/__tests__/validate-model-options.test.ts
+++ b/modules/database/src/utils/__tests__/validate-model-options.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from '@jest/globals';
+import { validateSchemaInput } from '../utilities.js';
+
+const baseConduit = {
+  cms: { enabled: true },
+  authorization: { enabled: false },
+  permissions: {
+    extendable: true,
+    canCreate: true,
+    canModify: 'Everything' as const,
+    canDelete: true,
+  },
+};
+
+describe('validateSchemaInput modelOptions.conduit', () => {
+  it('allows conduit.realtime used by live document updates', () => {
+    expect(() =>
+      validateSchemaInput('TestSchema', undefined, {
+        conduit: {
+          ...baseConduit,
+          realtime: { enabled: true },
+        },
+      }),
+    ).not.toThrow();
+  });
+
+  it('rejects an unknown conduit field', () => {
+    expect(() =>
+      validateSchemaInput('TestSchema', undefined, {
+        conduit: {
+          ...baseConduit,
+          notARealField: true,
+        },
+      }),
+    ).toThrow(/fields allowed inside 'conduit' field/);
+  });
+});

--- a/modules/database/src/utils/utilities.ts
+++ b/modules/database/src/utils/utilities.ts
@@ -183,10 +183,11 @@ function validateModelOptions(modelOptions: ConduitSchemaOptions) {
           conduitKey !== 'cms' &&
           conduitKey !== 'permissions' &&
           conduitKey !== 'authorization' &&
-          conduitKey !== 'imported'
+          conduitKey !== 'imported' &&
+          conduitKey !== 'realtime'
         )
           throw new Error(
-            "Only 'cms', 'permissions', 'authorization', 'imported', and 'readPreference' fields allowed inside 'conduit' field",
+            "Only 'cms', 'permissions', 'authorization', 'imported', 'readPreference', and 'realtime' fields allowed inside 'conduit' field",
           );
         if (conduitKey === 'imported') {
           if (!isBoolean(modelOptions.conduit!.imported))

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -12,6 +12,7 @@
     "start": "node dist/bin/www.js",
     "start:bundle": "node bundle/index.js",
     "lint": "eslint src",
+    "test": "npx tsc -p tsconfig.test.json && node --test dist-test/admin/realtime/*.test.js",
     "prebuild": "npm run generateTypes",
     "build": "rimraf dist && tsc",
     "generateTypes": "sh build.sh",

--- a/packages/core/src/admin/AdminModule.ts
+++ b/packages/core/src/admin/AdminModule.ts
@@ -14,6 +14,7 @@ import {
   PatchRouteMiddlewaresRequest,
   RegisterAdminRouteRequest,
   RegisterAdminRouteRequest_PathDefinition,
+  SocketPushRequest,
 } from '../interfaces/index.js';
 import { hashPassword } from './utils/auth.js';
 import AdminConfigRawSchema from './config/index.js';
@@ -33,6 +34,7 @@ import {
   ConduitSocket,
   grpcToConduitRoute,
   RouteT,
+  SocketPush,
 } from '@conduitplatform/hermes';
 import convict from 'convict';
 import { NextFunction, Request, Response } from 'express';
@@ -48,6 +50,7 @@ import { getReadinessMiddleware } from '../health/readinessMiddleware.js';
 import { ReadinessService } from '../health/ReadinessService.js';
 import type { CoreHealthProvider } from '../health/types.js';
 import { stripUndeclaredConfigParams } from '../utils/stripUndeclaredConfigParams.js';
+import { adminSocketNamespace } from './realtime/namespace.js';
 
 export default class AdminModule {
   grpcSdk: ConduitGrpcSdk;
@@ -93,6 +96,7 @@ export default class AdminModule {
       adminRoutes.createApiTokenRoute(),
       adminRoutes.getApiTokensRoute(),
       adminRoutes.deleteApiTokenRoute(),
+      adminRoutes.getRealtimeTicketRoute(),
       configRoutes.getModulesRoute(),
       adminRoutes.getStateExportRoute(this),
       adminRoutes.getStateImportRoute(this),
@@ -131,6 +135,7 @@ export default class AdminModule {
       {
         registerAdminRoute: this.registerAdminRoute.bind(this),
         patchRouteMiddlewares: this.patchRouteMiddlewares.bind(this),
+        socketPush: this.socketPush.bind(this),
       },
     );
   }
@@ -238,6 +243,27 @@ export default class AdminModule {
     callback(null, {});
   }
 
+  async socketPush(
+    call: GrpcRequest<SocketPushRequest>,
+    callback: GrpcCallback<Record<string, never>>,
+  ) {
+    try {
+      const moduleName = call.metadata?.get('module-name')?.[0] as string | undefined;
+      const socketData: SocketPush = {
+        event: call.request.event,
+        data: call.request.data ? JSON.parse(call.request.data) : undefined,
+        receivers: call.request.receivers,
+        rooms: call.request.rooms,
+        namespace: adminSocketNamespace(moduleName),
+      };
+      await this._router.socketPush(socketData);
+    } catch (err) {
+      ConduitGrpcSdk.Logger.error(err as Error);
+      return callback({ code: status.INTERNAL, message: 'Well that failed :/' });
+    }
+    callback(null, {});
+  }
+
   registerRoute(route: ConduitRoute): void {
     this._sdkRoutes.push(route);
     this._router.registerConduitRoute(route);
@@ -288,6 +314,16 @@ export default class AdminModule {
           `New admin route registered: ${r.input.action} ${r.input.path} handler url: ${url}`,
         );
         this._router.registerConduitRoute(r);
+      } else if (r instanceof ConduitMiddleware) {
+        ConduitGrpcSdk.Logger.log(
+          `New admin middleware registered: ${r.input.path} handler url: ${url}`,
+        );
+        this._router.registerRouteMiddleware(r, url);
+      } else if (r instanceof ConduitSocket) {
+        ConduitGrpcSdk.Logger.log(
+          `New admin socket registered: ${r.input.path} handler url: ${url}`,
+        );
+        this._router.registerConduitSocket(r);
       }
     });
     // @ts-ignore

--- a/packages/core/src/admin/middleware/Admin.middleware.ts
+++ b/packages/core/src/admin/middleware/Admin.middleware.ts
@@ -4,6 +4,7 @@ import { isNil } from 'lodash-es';
 import { isDev } from '../utils/middleware.js';
 import { ConduitRequest } from '@conduitplatform/hermes';
 import { ConduitGrpcSdk } from '@conduitplatform/grpc-sdk';
+import { isSocketHandshake } from '../realtime/handshake.js';
 
 export function getAdminMiddleware(configManager: any) {
   return async function adminMiddleware(
@@ -28,9 +29,14 @@ export function getAdminMiddleware(configManager: any) {
     ) {
       return next();
     }
-    // Allow API tokens (cdt_*) to bypass masterkey; Auth.middleware will validate the token
+    // Allow API tokens (cdt_*) and Socket.IO handshakes with a Bearer token to
+    // skip masterkey. Auth.middleware still validates the credential.
     const authHeader = req.headers.authorization;
-    if (authHeader && authHeader.startsWith('Bearer cdt_')) {
+    if (
+      typeof authHeader === 'string' &&
+      authHeader.startsWith('Bearer ') &&
+      (authHeader.startsWith('Bearer cdt_') || isSocketHandshake(req))
+    ) {
       return next();
     }
     const masterKey = req.headers.masterkey;

--- a/packages/core/src/admin/middleware/Auth.middleware.ts
+++ b/packages/core/src/admin/middleware/Auth.middleware.ts
@@ -7,6 +7,8 @@ import { isDev } from '../utils/middleware.js';
 import { ConduitRequest } from '@conduitplatform/hermes';
 import { gql } from 'graphql-tag';
 import { ConfigController } from '@conduitplatform/module-tools';
+import { isSocketHandshake } from '../realtime/handshake.js';
+import { isRealtimeTicket } from '../realtime/ticket.js';
 
 const excludedRestRoutes = ['/ready', '/live', '/login', '/config/modules'];
 const excludedGqlOperations = [
@@ -113,6 +115,10 @@ async function handleJwtToken(
   }
 
   const { id } = decoded;
+  if (isRealtimeTicket(decoded) && !isSocketHandshake(req)) {
+    res.status(401).json({ error: 'Realtime ticket cannot be used for HTTP requests' });
+    return;
+  }
   if (decoded.twoFaRequired && req.path !== '/verify-twofa') {
     res.status(401).json({ error: 'Two FA required' });
     return;

--- a/packages/core/src/admin/realtime/handshake.test.ts
+++ b/packages/core/src/admin/realtime/handshake.test.ts
@@ -1,0 +1,12 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { isSocketHandshake } from './handshake.js';
+
+describe('isSocketHandshake', () => {
+  it('detects Socket.IO engine requests', () => {
+    assert.equal(isSocketHandshake({ url: '/realtime/?EIO=4&transport=polling' }), true);
+    assert.equal(isSocketHandshake({ originalUrl: '/realtime' }), true);
+    assert.equal(isSocketHandshake({ path: '/login' }), false);
+    assert.equal(isSocketHandshake({ url: '/graphql' }), false);
+  });
+});

--- a/packages/core/src/admin/realtime/handshake.ts
+++ b/packages/core/src/admin/realtime/handshake.ts
@@ -1,0 +1,14 @@
+export function isSocketHandshake(req: {
+  url?: string;
+  originalUrl?: string;
+  path?: string;
+}): boolean {
+  const parts = [req.url, req.originalUrl, req.path].filter((value): value is string =>
+    Boolean(value),
+  );
+  return parts.some(part => part.includes('EIO=') || isRealtimePath(part));
+}
+
+function isRealtimePath(value: string): boolean {
+  return /(?:^|[/?])realtime(?:[/?]|$)/.test(value);
+}

--- a/packages/core/src/admin/realtime/namespace.test.ts
+++ b/packages/core/src/admin/realtime/namespace.test.ts
@@ -1,0 +1,11 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { adminSocketNamespace } from './namespace.js';
+
+describe('adminSocketNamespace', () => {
+  it('mirrors the Router module namespace contract', () => {
+    assert.equal(adminSocketNamespace('database'), '/database/');
+    assert.throws(() => adminSocketNamespace(''), /module-name/);
+    assert.throws(() => adminSocketNamespace(undefined), /module-name/);
+  });
+});

--- a/packages/core/src/admin/realtime/namespace.ts
+++ b/packages/core/src/admin/realtime/namespace.ts
@@ -1,0 +1,7 @@
+export function adminSocketNamespace(moduleName: string | undefined | null): string {
+  const name = typeof moduleName === 'string' ? moduleName.trim() : '';
+  if (!name) {
+    throw new Error('module-name metadata is required for Admin socket push');
+  }
+  return `/${name}/`;
+}

--- a/packages/core/src/admin/realtime/ticket.test.ts
+++ b/packages/core/src/admin/realtime/ticket.test.ts
@@ -1,0 +1,26 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import {
+  ADMIN_REALTIME_AUDIENCE,
+  buildRealtimeTicketClaims,
+  isRealtimeTicket,
+} from './ticket.js';
+
+describe('admin realtime tickets', () => {
+  it('scopes claims to the realtime audience', () => {
+    const claims = buildRealtimeTicketClaims('admin-1');
+    assert.equal(claims.id, 'admin-1');
+    assert.equal(claims.aud, ADMIN_REALTIME_AUDIENCE);
+    assert.equal(isRealtimeTicket(claims), true);
+  });
+
+  it('rejects ordinary admin JWTs and missing payloads', () => {
+    assert.equal(isRealtimeTicket({ id: 'admin-1' }), false);
+    assert.equal(isRealtimeTicket({ id: 'admin-1', aud: 'other' }), false);
+    assert.equal(isRealtimeTicket(null), false);
+    assert.equal(
+      isRealtimeTicket({ id: 'admin-1', aud: [ADMIN_REALTIME_AUDIENCE, 'extra'] }),
+      true,
+    );
+  });
+});

--- a/packages/core/src/admin/realtime/ticket.ts
+++ b/packages/core/src/admin/realtime/ticket.ts
@@ -1,0 +1,26 @@
+export const ADMIN_REALTIME_AUDIENCE = 'admin-realtime';
+export const ADMIN_REALTIME_TICKET_TTL_SECONDS = 30;
+
+export type RealtimeTicketClaims = {
+  id: string;
+  aud?: string | string[];
+  twoFaRequired?: boolean;
+};
+
+export function buildRealtimeTicketClaims(adminId: string): RealtimeTicketClaims {
+  return {
+    id: adminId,
+    aud: ADMIN_REALTIME_AUDIENCE,
+  };
+}
+
+export function isRealtimeTicket(
+  decoded: RealtimeTicketClaims | null | undefined,
+): boolean {
+  if (!decoded) return false;
+  const audience = decoded.aud;
+  if (Array.isArray(audience)) {
+    return audience.includes(ADMIN_REALTIME_AUDIENCE);
+  }
+  return audience === ADMIN_REALTIME_AUDIENCE;
+}

--- a/packages/core/src/admin/routes/RealtimeTicket.route.ts
+++ b/packages/core/src/admin/routes/RealtimeTicket.route.ts
@@ -1,0 +1,51 @@
+import { isNil } from 'lodash-es';
+import { ConduitRoute } from '@conduitplatform/hermes';
+import {
+  ConduitError,
+  ConduitRouteActions,
+  ConduitRouteParameters,
+  ConduitRouteReturnDefinition,
+} from '@conduitplatform/grpc-sdk';
+import {
+  ConduitNumber,
+  ConduitString,
+  ConfigController,
+} from '@conduitplatform/module-tools';
+import { signToken } from '../utils/auth.js';
+import {
+  ADMIN_REALTIME_TICKET_TTL_SECONDS,
+  buildRealtimeTicketClaims,
+} from '../realtime/ticket.js';
+
+export function getRealtimeTicketRoute() {
+  return new ConduitRoute(
+    {
+      path: '/realtime/ticket',
+      action: ConduitRouteActions.POST,
+      mcp: false,
+      description:
+        'Issue a short-lived token for Admin Socket.IO handshakes. The token cannot be used for REST or GraphQL.',
+    },
+    new ConduitRouteReturnDefinition('RealtimeTicket', {
+      token: ConduitString.Required,
+      expiresIn: ConduitNumber.Required,
+    }),
+    async (req: ConduitRouteParameters) => {
+      const admin = req.context?.admin;
+      if (isNil(admin) || isNil(admin._id)) {
+        throw new ConduitError('UNAUTHORIZED', 401, 'Authentication required');
+      }
+      const adminId = admin._id.toString();
+      const authConfig = ConfigController.getInstance().config.auth;
+      const token = signToken(
+        buildRealtimeTicketClaims(adminId),
+        authConfig.tokenSecret,
+        ADMIN_REALTIME_TICKET_TTL_SECONDS,
+      );
+      return {
+        token,
+        expiresIn: ADMIN_REALTIME_TICKET_TTL_SECONDS,
+      };
+    },
+  );
+}

--- a/packages/core/src/admin/routes/index.ts
+++ b/packages/core/src/admin/routes/index.ts
@@ -20,3 +20,4 @@ export * from './ToggleTwoFa.route.js';
 export * from './VerifyQrCode.route.js';
 export * from './VerifyTwoFa.route.js';
 export * from './ApiTokens.route.js';
+export * from './RealtimeTicket.route.js';

--- a/packages/core/src/core.proto
+++ b/packages/core/src/core.proto
@@ -21,6 +21,14 @@ service Config {
 service Admin {
   rpc RegisterAdminRoute (RegisterAdminRouteRequest) returns (google.protobuf.Empty);
   rpc PatchRouteMiddlewares(PatchRouteMiddlewaresRequest) returns (google.protobuf.Empty);
+  rpc SocketPush (SocketPushRequest) returns (google.protobuf.Empty);
+}
+
+message SocketPushRequest {
+  string event = 1;
+  optional string data = 2;
+  repeated string receivers = 3;
+  repeated string rooms = 4;
 }
 
 message RegisterAdminRouteRequest {

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -67,5 +67,5 @@
     "forceConsistentCasingInFileNames": true /* Disallow inconsistently-cased references to the same file. */
   },
   "include": ["src/**/*"],
-  "exclude": ["tests", "node_modules", "dist", "bundle", "tsup.config.ts"]
+  "exclude": ["tests", "node_modules", "dist", "bundle", "tsup.config.ts", "**/*.test.ts"]
 }

--- a/packages/core/tsconfig.test.json
+++ b/packages/core/tsconfig.test.json
@@ -1,0 +1,17 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist-test",
+    "rootDir": "./src",
+    "declaration": false,
+    "sourceMap": false,
+    "types": ["node"]
+  },
+  "include": [
+    "src/admin/realtime/ticket.ts",
+    "src/admin/realtime/handshake.ts",
+    "src/admin/realtime/namespace.ts",
+    "src/admin/realtime/*.test.ts"
+  ],
+  "exclude": ["node_modules", "dist", "bundle"]
+}


### PR DESCRIPTION
**What kind of change does this PR introduce?**

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other (please describe)

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

Local Compose Mongo now runs as a single-node replica set (`rs0`) so change streams work. Existing deployments are unchanged; local `DB_CONN_URI` must include `replicaSet=rs0`.

**The PR fulfills these requirements:**

- [x] It's submitted to the `main` branch
- [ ] When resolving a specific issue, it's referenced in the PR's description  (e.g. `fix #xxx`, where "xxx" is the issue number)

If adding a **new feature**, the PR's description includes:

- [x] A convincing reason for adding this feature

**Other information:**

Split from #1594 (2/3). Stacked on #1600 (event relays). SQL live updates follow in a stacked PR.

Schemas can opt in to live document updates via `realtime.enabled` plus `modelOptions.conduit.realtime.enabled`. MongoDB change streams require a replica set, so local Compose initializes a single-node `rs0`. Events are `change` metadata only (no document fields); consumers refetch through authorized REST. Admin clients use `POST /realtime/ticket` for a 30-second handshake token so session JWTs / masterkey are not sent from the browser.

Hermes isolates Redis adapter streams by port so admin and router Socket.IO servers do not deliver the same change twice, and handshake auth runs on connect.

### Test plan

- [x] Database realtime unit tests (`modules/database/src/realtime/__tests__/`, excluding integration): coordinator, authorize, topology, subscriptions, rooms, normalize, status
- [x] Core admin realtime tests (`packages/core/src/admin/realtime/*.test.ts`): ticket, handshake, namespace
- [x] Hermes `applySocketGlobalMiddlewares` tests
- [ ] `docker compose --profile mongodb up`: Mongo becomes replica set `rs0`; `DB_CONN_URI` includes `replicaSet=rs0`
- [ ] Enable `realtime.enabled`, opt a schema in, subscribe on `/database/`, mutate a document, confirm a `change` event with no document payload
- [ ] Admin socket via `POST /realtime/ticket` (session JWT / masterkey not sent from the browser)
