### PR TITLE
fix(router): Event Relays interventions (EventBus, Hermes, relay manager)

### DIFF
--- a/libraries/grpc-sdk/package.json
+++ b/libraries/grpc-sdk/package.json
@@ -25,7 +25,8 @@
     "prepublish": "npm run build",
     "prebuild": "npm run protoc",
     "build": "rimraf dist && tsup",
-    "protoc": "sh build.sh"
+    "protoc": "sh build.sh",
+    "test": "npx tsc -p tsconfig.test.json && node --test dist-test/utilities/EventBus.test.js"
   },
   "license": "MIT",
   "dependencies": {

--- a/libraries/grpc-sdk/src/utilities/EventBus.test.ts
+++ b/libraries/grpc-sdk/src/utilities/EventBus.test.ts
@@ -1,0 +1,94 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { EventBus } from './EventBus.js';
+
+type Listener = (channel: string, message: string) => void;
+
+class FakeRedis {
+  handlers: Record<string, Listener[]> = {};
+  subscribed = new Set<string>();
+
+  on(event: string, listener: Listener) {
+    this.handlers[event] = this.handlers[event] ?? [];
+    this.handlers[event].push(listener);
+  }
+
+  subscribe(channel: string, cb?: (err?: Error | null) => void) {
+    this.subscribed.add(channel);
+    cb?.(null);
+  }
+
+  unsubscribe(_channel: string, cb?: () => void) {
+    cb?.();
+  }
+
+  publish(_channel: string, _message: string) {}
+
+  quit() {}
+
+  emitMessage(channel: string, message: string) {
+    for (const listener of this.handlers.message ?? []) {
+      listener(channel, message);
+    }
+  }
+}
+
+function createBus() {
+  const sub = new FakeRedis();
+  const pub = new FakeRedis();
+  const manager = {
+    getClient: () => sub,
+  };
+  const bus = new EventBus(manager as never);
+  (bus as unknown as { _clientSubscriber: FakeRedis })._clientSubscriber = sub;
+  (bus as unknown as { _clientPublisher: FakeRedis })._clientPublisher = pub;
+  return { bus, sub };
+}
+
+describe('EventBus', () => {
+  it('fires once after deactivate/reactivate on the same channel', () => {
+    const { bus, sub } = createBus();
+    let count = 0;
+    bus.subscribe(
+      'database:update:Order',
+      () => {
+        count += 1;
+      },
+      'relay-a',
+    );
+    bus.unsubscribe('relay-a');
+    bus.subscribe(
+      'database:update:Order',
+      () => {
+        count += 1;
+      },
+      'relay-a',
+    );
+    sub.emitMessage('database:update:Order', '{"ok":true}');
+    assert.equal(count, 1);
+  });
+
+  it('keeps the second subscriber when the first is removed', () => {
+    const { bus, sub } = createBus();
+    let first = 0;
+    let second = 0;
+    bus.subscribe(
+      'chan',
+      () => {
+        first += 1;
+      },
+      'one',
+    );
+    bus.subscribe(
+      'chan',
+      () => {
+        second += 1;
+      },
+      'two',
+    );
+    bus.unsubscribe('one');
+    sub.emitMessage('chan', 'x');
+    assert.equal(first, 0);
+    assert.equal(second, 1);
+  });
+});

--- a/libraries/grpc-sdk/src/utilities/EventBus.test.ts
+++ b/libraries/grpc-sdk/src/utilities/EventBus.test.ts
@@ -7,6 +7,7 @@ type Listener = (channel: string, message: string) => void;
 class FakeRedis {
   handlers: Record<string, Listener[]> = {};
   subscribed = new Set<string>();
+  failNext = new Set<string>();
 
   on(event: string, listener: Listener) {
     this.handlers[event] = this.handlers[event] ?? [];
@@ -14,6 +15,11 @@ class FakeRedis {
   }
 
   subscribe(channel: string, cb?: (err?: Error | null) => void) {
+    if (this.failNext.has(channel)) {
+      this.failNext.delete(channel);
+      cb?.(new Error('subscribe failed'));
+      return;
+    }
     this.subscribed.add(channel);
     cb?.(null);
   }
@@ -90,5 +96,26 @@ describe('EventBus', () => {
     sub.emitMessage('chan', 'x');
     assert.equal(first, 0);
     assert.equal(second, 1);
+  });
+
+  it('subscribeAck rejects when Redis subscribe fails', async () => {
+    const { bus, sub } = createBus();
+    sub.failNext.add('chan');
+    await assert.rejects(
+      () =>
+        bus.subscribeAck(
+          'chan',
+          () => {},
+          'relay-a',
+        ),
+      /subscribe failed/,
+    );
+    sub.failNext.delete('chan');
+    let count = 0;
+    await bus.subscribeAck('chan', () => {
+      count += 1;
+    }, 'relay-a');
+    sub.emitMessage('chan', 'x');
+    assert.equal(count, 1);
   });
 });

--- a/libraries/grpc-sdk/src/utilities/EventBus.ts
+++ b/libraries/grpc-sdk/src/utilities/EventBus.ts
@@ -14,6 +14,7 @@ export class EventBus {
   private _subscriberChannels: Map<string, string>;
   /** channels with a successful Redis SUBSCRIBE */
   private _redisSubscribedChannels: Set<string>;
+  private _subscribeInFlight = new Map<string, Promise<void>>();
   private _signature: string;
   private _anonymousSubscriberSeq = 0;
   private _shuttingDown = false;
@@ -31,12 +32,9 @@ export class EventBus {
     this._clientSubscriber.on('message', (channel: string, message: string) => {
       this.dispatch(channel, message);
     });
-    const shutdown = () => {
+    process.on('exit', () => {
       this.quit();
-    };
-    process.on('exit', shutdown);
-    process.on('SIGTERM', shutdown);
-    process.on('SIGINT', shutdown);
+    });
   }
 
   quit(): void {
@@ -67,6 +65,20 @@ export class EventBus {
     callback: (message: string) => void,
     subscriberId?: string,
   ): void {
+    void this.subscribeAck(channelName, callback, subscriberId).catch(err => {
+      getLogger().error(
+        `EventBus subscribe failed for ${channelName}: ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      );
+    });
+  }
+
+  async subscribeAck(
+    channelName: string,
+    callback: (message: string) => void,
+    subscriberId?: string,
+  ): Promise<void> {
     if (this._shuttingDown) {
       return;
     }
@@ -89,27 +101,48 @@ export class EventBus {
       return;
     }
 
-    this._clientSubscriber.subscribe(channelName, err => {
-      if (err) {
-        getLogger().error(
-          `EventBus failed to subscribe to ${channelName}: ${err.message}`,
-        );
-        const pending = this._channelCallbacks.get(channelName);
-        if (pending) {
-          for (const subId of pending.keys()) {
-            this._subscriberChannels.delete(subId);
+    let inFlight = this._subscribeInFlight.get(channelName);
+    if (!inFlight) {
+      inFlight = new Promise<void>((resolve, reject) => {
+        this._clientSubscriber.subscribe(channelName, err => {
+          if (err) {
+            reject(err);
+            return;
           }
-          this._channelCallbacks.delete(channelName);
-        }
-        return;
+          this._redisSubscribedChannels.add(channelName);
+          resolve();
+        });
+      }).finally(() => {
+        this._subscribeInFlight.delete(channelName);
+      });
+      this._subscribeInFlight.set(channelName, inFlight);
+    }
+
+    try {
+      await inFlight;
+    } catch (err) {
+      if (!this._redisSubscribedChannels.has(channelName)) {
+        this.removeChannelCallbacks(channelName);
       }
-      this._redisSubscribedChannels.add(channelName);
-    });
+      this.unsubscribe(id);
+      throw err;
+    }
   }
 
   publish(channelName: string, message: string) {
     message = message + `CND_Signature:${this._signature}`;
     this._clientPublisher.publish(channelName, message);
+  }
+
+  private removeChannelCallbacks(channelName: string): void {
+    const callbacks = this._channelCallbacks.get(channelName);
+    if (!callbacks) {
+      return;
+    }
+    for (const subId of callbacks.keys()) {
+      this._subscriberChannels.delete(subId);
+    }
+    this._channelCallbacks.delete(channelName);
   }
 
   private dispatch(channel: string, message: string): void {

--- a/libraries/grpc-sdk/src/utilities/EventBus.ts
+++ b/libraries/grpc-sdk/src/utilities/EventBus.ts
@@ -3,35 +3,60 @@ import { Cluster, Redis } from 'ioredis';
 import crypto from 'crypto';
 import { getLogger } from './GrpcSdkContext.js';
 
+type ChannelCallbacks = Map<string, (message: string) => void>;
+
 export class EventBus {
   private _clientSubscriber: Redis | Cluster;
   private _clientPublisher: Redis | Cluster;
-  private _subscribedChannels: { [listener: string]: ((message: string) => void)[] };
-  private _subscribers: { [listener: string]: [string, number] };
+  /** channelName -> subscriberId -> callback */
+  private _channelCallbacks: Map<string, ChannelCallbacks>;
+  /** subscriberId -> channelName */
+  private _subscriberChannels: Map<string, string>;
+  /** channels with a successful Redis SUBSCRIBE */
+  private _redisSubscribedChannels: Set<string>;
   private _signature: string;
+  private _anonymousSubscriberSeq = 0;
+  private _shuttingDown = false;
 
   constructor(redisManager: RedisManager) {
-    this._subscribedChannels = {};
-    this._subscribers = {};
+    this._channelCallbacks = new Map();
+    this._subscriberChannels = new Map();
+    this._redisSubscribedChannels = new Set();
     this._clientSubscriber = redisManager.getClient({ keyPrefix: 'bus_' });
     this._clientPublisher = redisManager.getClient({ keyPrefix: 'bus_' });
     this._signature = crypto.randomBytes(20).toString('hex');
     this._clientSubscriber.on('ready', () => {
       getLogger().log('The Bus is in the station...hehe');
     });
-    process.on('exit', () => {
-      this._clientSubscriber.quit();
-      this._clientPublisher.quit();
+    this._clientSubscriber.on('message', (channel: string, message: string) => {
+      this.dispatch(channel, message);
     });
+    const shutdown = () => {
+      this.quit();
+    };
+    process.on('exit', shutdown);
+    process.on('SIGTERM', shutdown);
+    process.on('SIGINT', shutdown);
+  }
+
+  quit(): void {
+    if (this._shuttingDown) return;
+    this._shuttingDown = true;
+    void this._clientSubscriber.quit();
+    void this._clientPublisher.quit();
   }
 
   unsubscribe(subscriberId: string): void {
-    if (this._subscribers[subscriberId]) {
-      const [channelName, index] = this._subscribers[subscriberId];
-      this._subscribedChannels[channelName].splice(index, 1);
-      delete this._subscribers[subscriberId];
-      if (this._subscribedChannels[channelName].length === 0) {
-        delete this._subscribedChannels[channelName];
+    const channelName = this._subscriberChannels.get(subscriberId);
+    if (!channelName) {
+      return;
+    }
+    const callbacks = this._channelCallbacks.get(channelName);
+    callbacks?.delete(subscriberId);
+    this._subscriberChannels.delete(subscriberId);
+    if (callbacks && callbacks.size === 0) {
+      this._channelCallbacks.delete(channelName);
+      if (this._redisSubscribedChannels.delete(channelName)) {
         this._clientSubscriber.unsubscribe(channelName, () => {});
       }
     }
@@ -42,43 +67,65 @@ export class EventBus {
     callback: (message: string) => void,
     subscriberId?: string,
   ): void {
-    if (subscriberId) {
-      // if subscriberId is provided, and it is already subscribed, unsubscribe it first
-      this.unsubscribe(subscriberId);
-    }
-    if (this._subscribedChannels[channelName]) {
-      this._subscribedChannels[channelName].push(callback);
-      if (subscriberId) {
-        this._subscribers[subscriberId] = [
-          channelName,
-          this._subscribedChannels[channelName].length - 1,
-        ];
-      }
+    if (this._shuttingDown) {
       return;
     }
-    this._subscribedChannels[channelName] = [callback];
-    this._clientSubscriber.subscribe(channelName, () => {});
-    const self = this;
-    this._clientSubscriber.on('message', (channel: string, message: string) => {
-      if (channel !== channelName) return;
-      // if the message supports the signature
-      if (message.indexOf('CND_Signature') !== -1) {
-        // if the message does not contain this module's signature
-        if (message.indexOf(self._signature) === -1) {
-          self._subscribedChannels[channelName].forEach(fn => {
-            fn(message.split('CND_Signature:')[0]);
-          });
+    const id =
+      subscriberId ??
+      `anon:${channelName}:${++this._anonymousSubscriberSeq}:${crypto.randomBytes(4).toString('hex')}`;
+    if (subscriberId) {
+      this.unsubscribe(subscriberId);
+    }
+
+    let callbacks = this._channelCallbacks.get(channelName);
+    if (!callbacks) {
+      callbacks = new Map();
+      this._channelCallbacks.set(channelName, callbacks);
+    }
+    callbacks.set(id, callback);
+    this._subscriberChannels.set(id, channelName);
+
+    if (this._redisSubscribedChannels.has(channelName)) {
+      return;
+    }
+
+    this._clientSubscriber.subscribe(channelName, err => {
+      if (err) {
+        getLogger().error(
+          `EventBus failed to subscribe to ${channelName}: ${err.message}`,
+        );
+        const pending = this._channelCallbacks.get(channelName);
+        if (pending) {
+          for (const subId of pending.keys()) {
+            this._subscriberChannels.delete(subId);
+          }
+          this._channelCallbacks.delete(channelName);
         }
-      } else {
-        self._subscribedChannels[channelName].forEach(fn => {
-          fn(message);
-        });
+        return;
       }
+      this._redisSubscribedChannels.add(channelName);
     });
   }
 
   publish(channelName: string, message: string) {
     message = message + `CND_Signature:${this._signature}`;
     this._clientPublisher.publish(channelName, message);
+  }
+
+  private dispatch(channel: string, message: string): void {
+    const callbacks = this._channelCallbacks.get(channel);
+    if (!callbacks || callbacks.size === 0) {
+      return;
+    }
+    let payload = message;
+    if (message.indexOf('CND_Signature') !== -1) {
+      if (message.indexOf(this._signature) !== -1) {
+        return;
+      }
+      payload = message.split('CND_Signature:')[0];
+    }
+    for (const fn of callbacks.values()) {
+      fn(payload);
+    }
   }
 }

--- a/libraries/grpc-sdk/tsconfig.test.json
+++ b/libraries/grpc-sdk/tsconfig.test.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist-test",
+    "rootDir": "./src",
+    "declaration": false,
+    "sourceMap": false,
+    "types": ["node"]
+  },
+  "include": ["src/utilities/EventBus.ts", "src/utilities/EventBus.test.ts"]
+}

--- a/libraries/hermes/package.json
+++ b/libraries/hermes/package.json
@@ -11,7 +11,7 @@
   "scripts": {
     "prepublish": "npm run build",
     "build": "rimraf dist && tsc",
-    "test": "npx tsc -p tsconfig.test.json && node --test dist-test/Socket/isSocketHandshake.test.js",
+    "test": "npx tsc -p tsconfig.test.json && node --test dist-test/Socket/*.test.js",
     "publish": "npm publish",
     "postbuild": "copyfiles -u 1 src/*.proto src/**/*.json ./dist/"
   },

--- a/libraries/hermes/package.json
+++ b/libraries/hermes/package.json
@@ -11,6 +11,7 @@
   "scripts": {
     "prepublish": "npm run build",
     "build": "rimraf dist && tsc",
+    "test": "npx tsc -p tsconfig.test.json && node --test dist-test/Socket/isSocketHandshake.test.js",
     "publish": "npm publish",
     "postbuild": "copyfiles -u 1 src/*.proto src/**/*.json ./dist/"
   },

--- a/libraries/hermes/src/Socket/Socket.ts
+++ b/libraries/hermes/src/Socket/Socket.ts
@@ -18,7 +18,6 @@ import { ConduitError, ConduitGrpcSdk } from '@conduitplatform/grpc-sdk';
 import { buildSocketMiddlewareParams } from './buildSocketMiddlewareParams.js';
 import { resolveEngineNamespacePath } from './resolveEngineNamespacePath.js';
 
-const EMIT_TIMEOUT_MS = 250;
 const SEND_BUFFER_HIGH_WATER_MARK = 512 * 1024;
 
 export class SocketController extends ConduitRouter {
@@ -256,21 +255,31 @@ export class SocketController extends ConduitRouter {
         }
       }
       if (push.receivers.length !== 0) {
+        const nsp = this.io.of(push.namespace);
         const filteredSockets = await this.findAndFilterSockets(
           push.receivers,
           push.namespace,
           localOnly,
         );
-        for (const socket of filteredSockets) {
-          if (push.boundedEmit && this.isSocketBackpressured(socket)) {
+        if (push.skipEmptyRooms && filteredSockets.length === 0) {
+          return false;
+        }
+        for (const remote of filteredSockets) {
+          const local = localOnly ? nsp.sockets.get(remote.id) : undefined;
+          if (
+            push.boundedEmit &&
+            localOnly &&
+            local &&
+            this.isLocalSocketBackpressured(local)
+          ) {
             ConduitGrpcSdk.Metrics?.increment('event_relays_emit_dropped_total');
-            socket.disconnect(true);
+            local.disconnect(true);
             continue;
           }
           ConduitGrpcSdk.Logger.debug(
-            `Emitting event: ${push.event} to socket: ${socket.id} in namespace: ${push.namespace}`,
+            `Emitting event: ${push.event} to socket: ${remote.id} in namespace: ${push.namespace}`,
           );
-          socket.emit(push.event, push.data);
+          remote.emit(push.event, push.data);
         }
       }
       return true;
@@ -301,24 +310,20 @@ export class SocketController extends ConduitRouter {
 
   private async emitEventToRooms(push: SocketPush, localOnly: boolean): Promise<boolean> {
     const nsp = this.io.of(push.namespace);
+    const localSockets = localOnly
+      ? this.localSocketsInRooms(nsp, push.rooms)
+      : [];
     if (push.skipEmptyRooms || push.boundedEmit) {
-      let memberCount = 0;
-      for (const room of push.rooms) {
-        const sockets = localOnly
-          ? await nsp.in(room).local.fetchSockets()
-          : await nsp.in(room).fetchSockets();
-        memberCount += sockets.length;
-        if (push.boundedEmit) {
-          for (const socket of sockets) {
-            if (this.isSocketBackpressured(socket)) {
-              ConduitGrpcSdk.Metrics?.increment('event_relays_emit_dropped_total');
-              socket.disconnect(true);
-            }
+      if (localOnly && localSockets.length === 0) {
+        return false;
+      }
+      if (push.boundedEmit && localOnly) {
+        for (const socket of localSockets) {
+          if (this.isLocalSocketBackpressured(socket)) {
+            ConduitGrpcSdk.Metrics?.increment('event_relays_emit_dropped_total');
+            socket.disconnect(true);
           }
         }
-      }
-      if (memberCount === 0) {
-        return false;
       }
     }
 
@@ -329,32 +334,25 @@ export class SocketController extends ConduitRouter {
     );
     const target = nsp.to(push.rooms);
     if (localOnly) {
-      if (push.boundedEmit) {
-        await Promise.race([
-          new Promise<void>(resolve => {
-            target.local.emit(push.event, push.data, () => resolve());
-          }),
-          new Promise<void>(resolve => setTimeout(resolve, EMIT_TIMEOUT_MS)),
-        ]);
-      } else {
-        target.local.emit(push.event, push.data);
-      }
-    } else if (push.boundedEmit) {
-      await Promise.race([
-        new Promise<void>(resolve => {
-          target.emit(push.event, push.data, () => resolve());
-        }),
-        new Promise<void>(resolve => setTimeout(resolve, EMIT_TIMEOUT_MS)),
-      ]);
+      target.local.emit(push.event, push.data);
     } else {
       target.emit(push.event, push.data);
     }
     return true;
   }
 
-  private isSocketBackpressured(socket: RemoteSocket<any, any> | Socket): boolean {
-    const conn = (socket as Socket).conn ?? (socket as RemoteSocket<any, any>).conn;
-    const transport = conn?.transport as { writableLength?: number } | undefined;
+  private localSocketsInRooms(nsp: ReturnType<IOServer['of']>, rooms: string[]): Socket[] {
+    const sockets: Socket[] = [];
+    for (const socket of nsp.sockets.values()) {
+      if (rooms.some(room => socket.rooms.has(room))) {
+        sockets.push(socket);
+      }
+    }
+    return sockets;
+  }
+
+  private isLocalSocketBackpressured(socket: Socket): boolean {
+    const transport = socket.conn?.transport as { writableLength?: number } | undefined;
     const buffered =
       typeof transport?.writableLength === 'number' ? transport.writableLength : 0;
     return buffered > SEND_BUFFER_HIGH_WATER_MARK;

--- a/libraries/hermes/src/Socket/Socket.ts
+++ b/libraries/hermes/src/Socket/Socket.ts
@@ -82,10 +82,10 @@ export class SocketController extends ConduitRouter {
       );
     });
 
-    this.io.engine.use((req: any, res: any, next: any) => {
+    this.io.engine.use((req: any, res: any, next: NextFunction) => {
       req.path = resolveEngineNamespacePath(req);
       let index = 0;
-      const run = (err?: Error) => {
+      const run: NextFunction = err => {
         if (err) {
           return next(err);
         }
@@ -142,7 +142,7 @@ export class SocketController extends ConduitRouter {
 
     this.io.of(namespace).on('connect', socket => {
       if (socket.recovered) {
-        ConduitGrpcSdk.Logger.debug(
+        ConduitGrpcSdk.Logger.info(
           `Socket recovered: ${socket.id} to namespace: ${namespace}`,
         );
         const recovered = conduitSocket.executeRecovered({
@@ -159,7 +159,7 @@ export class SocketController extends ConduitRouter {
             });
         }
       } else {
-        ConduitGrpcSdk.Logger.debug(
+        ConduitGrpcSdk.Logger.info(
           `Socket connected: ${socket.id} to namespace: ${namespace}`,
         );
         conduitSocket
@@ -176,7 +176,7 @@ export class SocketController extends ConduitRouter {
       }
 
       socket.onAny((event, ...args) => {
-        ConduitGrpcSdk.Logger.debug(`Socket event: ${event} from socket: ${socket.id}`);
+        ConduitGrpcSdk.Logger.info(`Socket event: ${event} from socket: ${socket.id}`);
         conduitSocket
           .executeRequest({
             event,
@@ -192,7 +192,7 @@ export class SocketController extends ConduitRouter {
       });
 
       socket.on('disconnect', () => {
-        ConduitGrpcSdk.Logger.debug(
+        ConduitGrpcSdk.Logger.info(
           `Socket disconnected: ${socket.id} from namespace: ${namespace}`,
         );
         conduitSocket
@@ -220,7 +220,7 @@ export class SocketController extends ConduitRouter {
         localOnly,
       );
       for (const socket of filteredSockets) {
-        ConduitGrpcSdk.Logger.debug(
+        ConduitGrpcSdk.Logger.info(
           `Socket ${socket.id} joining rooms: ${push.rooms.join(', ')} in namespace: ${
             push.namespace
           }`,
@@ -233,7 +233,7 @@ export class SocketController extends ConduitRouter {
         const filteredSockets = await this.socketsForRoomPush(push, localOnly);
         for (const socket of filteredSockets) {
           for (const room of push.rooms) {
-            ConduitGrpcSdk.Logger.debug(
+            ConduitGrpcSdk.Logger.info(
               `Socket ${socket.id} leaving room: ${room} in namespace: ${push.namespace}`,
             );
             socket.leave(room);
@@ -276,7 +276,7 @@ export class SocketController extends ConduitRouter {
             local.disconnect(true);
             continue;
           }
-          ConduitGrpcSdk.Logger.debug(
+          ConduitGrpcSdk.Logger.info(
             `Emitting event: ${push.event} to socket: ${remote.id} in namespace: ${push.namespace}`,
           );
           remote.emit(push.event, push.data);
@@ -310,9 +310,7 @@ export class SocketController extends ConduitRouter {
 
   private async emitEventToRooms(push: SocketPush, localOnly: boolean): Promise<boolean> {
     const nsp = this.io.of(push.namespace);
-    const localSockets = localOnly
-      ? this.localSocketsInRooms(nsp, push.rooms)
-      : [];
+    const localSockets = localOnly ? this.localSocketsInRooms(nsp, push.rooms) : [];
     if (push.skipEmptyRooms || push.boundedEmit) {
       if (localOnly && localSockets.length === 0) {
         return false;
@@ -327,7 +325,7 @@ export class SocketController extends ConduitRouter {
       }
     }
 
-    ConduitGrpcSdk.Logger.debug(
+    ConduitGrpcSdk.Logger.info(
       `Emitting event: ${push.event} to rooms: ${push.rooms.join(
         ', ',
       )} in namespace: ${push.namespace}`,
@@ -341,7 +339,10 @@ export class SocketController extends ConduitRouter {
     return true;
   }
 
-  private localSocketsInRooms(nsp: ReturnType<IOServer['of']>, rooms: string[]): Socket[] {
+  private localSocketsInRooms(
+    nsp: ReturnType<IOServer['of']>,
+    rooms: string[],
+  ): Socket[] {
     const sockets: Socket[] = [];
     for (const socket of nsp.sockets.values()) {
       if (rooms.some(room => socket.rooms.has(room))) {
@@ -389,7 +390,7 @@ export class SocketController extends ConduitRouter {
   ) {
     if (res.event === 'join-room') {
       if (res.rooms && res.rooms.length !== 0) {
-        ConduitGrpcSdk.Logger.debug(
+        ConduitGrpcSdk.Logger.info(
           `Socket ${socket.id} joining rooms: ${res.rooms.join(
             ', ',
           )} in namespace: ${namespace}`,
@@ -399,7 +400,7 @@ export class SocketController extends ConduitRouter {
     } else if (res.event === 'leave-room') {
       if (res.rooms && res.rooms.length !== 0) {
         for (const room of res.rooms) {
-          ConduitGrpcSdk.Logger.debug(
+          ConduitGrpcSdk.Logger.info(
             `Socket ${socket.id} leaving room: ${room} in namespace: ${namespace}`,
           );
           socket.leave(room);
@@ -410,13 +411,13 @@ export class SocketController extends ConduitRouter {
         (!res.receivers || res.receivers.length === 0) &&
         (!res.rooms || res.rooms.length === 0)
       ) {
-        ConduitGrpcSdk.Logger.debug(
+        ConduitGrpcSdk.Logger.info(
           `Emitting event: ${res.event} to all sockets in namespace: ${namespace}`,
         );
         socket.emit(res.event, JSON.parse(res.data));
       } else {
         if (res.rooms && res.rooms.length !== 0) {
-          ConduitGrpcSdk.Logger.debug(
+          ConduitGrpcSdk.Logger.info(
             `Emitting event: ${res.event} to rooms: ${res.rooms.join(
               ', ',
             )} in namespace: ${namespace}`,
@@ -429,7 +430,7 @@ export class SocketController extends ConduitRouter {
             namespace,
           );
           for (const socket of filteredSockets) {
-            ConduitGrpcSdk.Logger.debug(
+            ConduitGrpcSdk.Logger.info(
               `Emitting event: ${res.event} to socket: ${socket.id} in namespace: ${namespace}`,
             );
             socket.emit(res.event, JSON.parse(res.data));

--- a/libraries/hermes/src/Socket/Socket.ts
+++ b/libraries/hermes/src/Socket/Socket.ts
@@ -17,8 +17,10 @@ import ObjectHash from 'object-hash';
 import { ConduitError, ConduitGrpcSdk } from '@conduitplatform/grpc-sdk';
 import { buildSocketMiddlewareParams } from './buildSocketMiddlewareParams.js';
 import { resolveEngineNamespacePath } from './resolveEngineNamespacePath.js';
-
-const WRITE_BUFFER_PACKET_HIGH_WATER = 64;
+import {
+  filterRemoteSocketsByUserAndRooms,
+  isEngineSocketBackpressured,
+} from './socketPushUtils.js';
 
 export class SocketController extends ConduitRouter {
   private readonly httpServer: httpServer;
@@ -330,15 +332,9 @@ export class SocketController extends ConduitRouter {
   }
 
   private isLocalSocketBackpressured(socket: Socket): boolean {
-    const conn = socket.conn as unknown as {
-      writeBuffer?: unknown[];
-      transport?: { writable?: boolean };
-    };
-    if (conn.transport?.writable === false) {
-      return true;
-    }
-    const pending = conn.writeBuffer?.length ?? 0;
-    return pending > WRITE_BUFFER_PACKET_HIGH_WATER;
+    return isEngineSocketBackpressured(
+      socket.conn as unknown as { writeBuffer?: unknown[] },
+    );
   }
 
   private async socketsForRoomPush(
@@ -411,20 +407,15 @@ export class SocketController extends ConduitRouter {
   ): Promise<RemoteSocket<any, any>[]> {
     const nsp = this.io.of(namespace);
     const sockets = localOnly ? await nsp.local.fetchSockets() : await nsp.fetchSockets();
-    const userIdSet = new Set(userIds);
-    const roomSet = rooms.length > 0 ? new Set(rooms) : null;
-    return sockets.filter(socket => {
-      if (!socket.data?.user) {
-        return false;
-      }
-      if (!userIdSet.has(socket.data.user._id)) {
-        return false;
-      }
-      if (roomSet) {
-        return [...roomSet].some(room => socket.rooms.has(room));
-      }
-      return true;
-    });
+    return filterRemoteSocketsByUserAndRooms(
+      sockets.map(socket => ({
+        id: socket.id,
+        data: socket.data,
+        rooms: socket.rooms,
+      })),
+      userIds,
+      rooms,
+    ).map(filtered => sockets.find(s => s.id === filtered.id)!);
   }
 
   protected _refreshRouter(): void {

--- a/libraries/hermes/src/Socket/Socket.ts
+++ b/libraries/hermes/src/Socket/Socket.ts
@@ -18,7 +18,7 @@ import { ConduitError, ConduitGrpcSdk } from '@conduitplatform/grpc-sdk';
 import { buildSocketMiddlewareParams } from './buildSocketMiddlewareParams.js';
 import { resolveEngineNamespacePath } from './resolveEngineNamespacePath.js';
 
-const SEND_BUFFER_HIGH_WATER_MARK = 512 * 1024;
+const WRITE_BUFFER_PACKET_HIGH_WATER = 64;
 
 export class SocketController extends ConduitRouter {
   private readonly httpServer: httpServer;
@@ -142,13 +142,11 @@ export class SocketController extends ConduitRouter {
 
     this.io.of(namespace).on('connect', socket => {
       if (socket.recovered) {
-        ConduitGrpcSdk.Logger.info(
-          `Socket recovered: ${socket.id} to namespace: ${namespace}`,
-        );
         const recovered = conduitSocket.executeRecovered({
           event: 'recovered',
           socketId: socket.id,
           context: socket.data,
+          recoveredRooms: [...socket.rooms].filter(room => room.startsWith('er:')),
         });
         if (recovered) {
           recovered
@@ -159,9 +157,6 @@ export class SocketController extends ConduitRouter {
             });
         }
       } else {
-        ConduitGrpcSdk.Logger.info(
-          `Socket connected: ${socket.id} to namespace: ${namespace}`,
-        );
         conduitSocket
           .executeRequest({
             event: 'connect',
@@ -176,7 +171,6 @@ export class SocketController extends ConduitRouter {
       }
 
       socket.onAny((event, ...args) => {
-        ConduitGrpcSdk.Logger.info(`Socket event: ${event} from socket: ${socket.id}`);
         conduitSocket
           .executeRequest({
             event,
@@ -192,9 +186,6 @@ export class SocketController extends ConduitRouter {
       });
 
       socket.on('disconnect', () => {
-        ConduitGrpcSdk.Logger.info(
-          `Socket disconnected: ${socket.id} from namespace: ${namespace}`,
-        );
         conduitSocket
           .executeRequest({
             event: 'disconnect',
@@ -220,11 +211,6 @@ export class SocketController extends ConduitRouter {
         localOnly,
       );
       for (const socket of filteredSockets) {
-        ConduitGrpcSdk.Logger.info(
-          `Socket ${socket.id} joining rooms: ${push.rooms.join(', ')} in namespace: ${
-            push.namespace
-          }`,
-        );
         socket.join(push.rooms);
       }
       return true;
@@ -233,9 +219,6 @@ export class SocketController extends ConduitRouter {
         const filteredSockets = await this.socketsForRoomPush(push, localOnly);
         for (const socket of filteredSockets) {
           for (const room of push.rooms) {
-            ConduitGrpcSdk.Logger.info(
-              `Socket ${socket.id} leaving room: ${room} in namespace: ${push.namespace}`,
-            );
             socket.leave(room);
           }
         }
@@ -248,18 +231,13 @@ export class SocketController extends ConduitRouter {
       ) {
         return false;
       }
-      if (push.rooms.length !== 0) {
-        const emitted = await this.emitEventToRooms(push, localOnly);
-        if (!emitted) {
-          return false;
-        }
-      }
       if (push.receivers.length !== 0) {
         const nsp = this.io.of(push.namespace);
         const filteredSockets = await this.findAndFilterSockets(
           push.receivers,
           push.namespace,
           localOnly,
+          push.rooms,
         );
         if (push.skipEmptyRooms && filteredSockets.length === 0) {
           return false;
@@ -276,10 +254,14 @@ export class SocketController extends ConduitRouter {
             local.disconnect(true);
             continue;
           }
-          ConduitGrpcSdk.Logger.info(
-            `Emitting event: ${push.event} to socket: ${remote.id} in namespace: ${push.namespace}`,
-          );
           remote.emit(push.event, push.data);
+        }
+        return true;
+      }
+      if (push.rooms.length !== 0) {
+        const emitted = await this.emitEventToRooms(push, localOnly);
+        if (!emitted) {
+          return false;
         }
       }
       return true;
@@ -325,11 +307,6 @@ export class SocketController extends ConduitRouter {
       }
     }
 
-    ConduitGrpcSdk.Logger.info(
-      `Emitting event: ${push.event} to rooms: ${push.rooms.join(
-        ', ',
-      )} in namespace: ${push.namespace}`,
-    );
     const target = nsp.to(push.rooms);
     if (localOnly) {
       target.local.emit(push.event, push.data);
@@ -353,10 +330,15 @@ export class SocketController extends ConduitRouter {
   }
 
   private isLocalSocketBackpressured(socket: Socket): boolean {
-    const transport = socket.conn?.transport as { writableLength?: number } | undefined;
-    const buffered =
-      typeof transport?.writableLength === 'number' ? transport.writableLength : 0;
-    return buffered > SEND_BUFFER_HIGH_WATER_MARK;
+    const conn = socket.conn as unknown as {
+      writeBuffer?: unknown[];
+      transport?: { writable?: boolean };
+    };
+    if (conn.transport?.writable === false) {
+      return true;
+    }
+    const pending = conn.writeBuffer?.length ?? 0;
+    return pending > WRITE_BUFFER_PACKET_HIGH_WATER;
   }
 
   private async socketsForRoomPush(
@@ -390,19 +372,11 @@ export class SocketController extends ConduitRouter {
   ) {
     if (res.event === 'join-room') {
       if (res.rooms && res.rooms.length !== 0) {
-        ConduitGrpcSdk.Logger.info(
-          `Socket ${socket.id} joining rooms: ${res.rooms.join(
-            ', ',
-          )} in namespace: ${namespace}`,
-        );
         socket.join(res.rooms);
       }
     } else if (res.event === 'leave-room') {
       if (res.rooms && res.rooms.length !== 0) {
         for (const room of res.rooms) {
-          ConduitGrpcSdk.Logger.info(
-            `Socket ${socket.id} leaving room: ${room} in namespace: ${namespace}`,
-          );
           socket.leave(room);
         }
       }
@@ -411,17 +385,9 @@ export class SocketController extends ConduitRouter {
         (!res.receivers || res.receivers.length === 0) &&
         (!res.rooms || res.rooms.length === 0)
       ) {
-        ConduitGrpcSdk.Logger.info(
-          `Emitting event: ${res.event} to all sockets in namespace: ${namespace}`,
-        );
         socket.emit(res.event, JSON.parse(res.data));
       } else {
         if (res.rooms && res.rooms.length !== 0) {
-          ConduitGrpcSdk.Logger.info(
-            `Emitting event: ${res.event} to rooms: ${res.rooms.join(
-              ', ',
-            )} in namespace: ${namespace}`,
-          );
           this.io.of(namespace).to(res.rooms).emit(res.event, JSON.parse(res.data));
         }
         if (res.receivers && res.receivers.length !== 0) {
@@ -430,9 +396,6 @@ export class SocketController extends ConduitRouter {
             namespace,
           );
           for (const socket of filteredSockets) {
-            ConduitGrpcSdk.Logger.info(
-              `Emitting event: ${res.event} to socket: ${socket.id} in namespace: ${namespace}`,
-            );
             socket.emit(res.event, JSON.parse(res.data));
           }
         }
@@ -444,14 +407,23 @@ export class SocketController extends ConduitRouter {
     userIds: string[],
     namespace: string,
     localOnly: boolean = false,
+    rooms: string[] = [],
   ): Promise<RemoteSocket<any, any>[]> {
     const nsp = this.io.of(namespace);
     const sockets = localOnly ? await nsp.local.fetchSockets() : await nsp.fetchSockets();
     const userIdSet = new Set(userIds);
+    const roomSet = rooms.length > 0 ? new Set(rooms) : null;
     return sockets.filter(socket => {
-      if (socket.data && socket.data.user) {
-        return userIdSet.has(socket.data.user._id);
+      if (!socket.data?.user) {
+        return false;
       }
+      if (!userIdSet.has(socket.data.user._id)) {
+        return false;
+      }
+      if (roomSet) {
+        return [...roomSet].some(room => socket.rooms.has(room));
+      }
+      return true;
     });
   }
 

--- a/libraries/hermes/src/Socket/Socket.ts
+++ b/libraries/hermes/src/Socket/Socket.ts
@@ -16,6 +16,10 @@ import {
 import ObjectHash from 'object-hash';
 import { ConduitError, ConduitGrpcSdk } from '@conduitplatform/grpc-sdk';
 import { buildSocketMiddlewareParams } from './buildSocketMiddlewareParams.js';
+import { resolveEngineNamespacePath } from './resolveEngineNamespacePath.js';
+
+const EMIT_TIMEOUT_MS = 250;
+const SEND_BUFFER_HIGH_WATER_MARK = 512 * 1024;
 
 export class SocketController extends ConduitRouter {
   private readonly httpServer: httpServer;
@@ -78,6 +82,22 @@ export class SocketController extends ConduitRouter {
         `Socket connection error, context: ${err?.context ?? 'N/A'}`,
       );
     });
+
+    this.io.engine.use((req: any, res: any, next: any) => {
+      req.path = resolveEngineNamespacePath(req);
+      let index = 0;
+      const run = (err?: Error) => {
+        if (err) {
+          return next(err);
+        }
+        const middleware = this.globalMiddlewares[index++];
+        if (!middleware) {
+          return next();
+        }
+        middleware(req, res, run);
+      };
+      run();
+    });
   }
 
   registerGlobalMiddleware(
@@ -107,12 +127,6 @@ export class SocketController extends ConduitRouter {
     this._registeredNamespaces.set(namespace, conduitSocket);
 
     const self = this;
-    this.globalMiddlewares.forEach(middleware => {
-      self.io.engine.use((req: any, res: any, next: any) => {
-        req.path = namespace;
-        middleware(req, res, next);
-      });
-    });
     this.io.of(namespace).use((socket, next) => {
       const context = buildSocketMiddlewareParams(socket);
       self
@@ -129,11 +143,24 @@ export class SocketController extends ConduitRouter {
 
     this.io.of(namespace).on('connect', socket => {
       if (socket.recovered) {
-        ConduitGrpcSdk.Logger.info(
+        ConduitGrpcSdk.Logger.debug(
           `Socket recovered: ${socket.id} to namespace: ${namespace}`,
         );
+        const recovered = conduitSocket.executeRecovered({
+          event: 'recovered',
+          socketId: socket.id,
+          context: socket.data,
+        });
+        if (recovered) {
+          recovered
+            .then(res => this.handleResponse(res, socket, namespace))
+            .catch(e => {
+              ConduitGrpcSdk.Logger.error(e);
+              socket.emit('conduit_error', e);
+            });
+        }
       } else {
-        ConduitGrpcSdk.Logger.info(
+        ConduitGrpcSdk.Logger.debug(
           `Socket connected: ${socket.id} to namespace: ${namespace}`,
         );
         conduitSocket
@@ -150,7 +177,7 @@ export class SocketController extends ConduitRouter {
       }
 
       socket.onAny((event, ...args) => {
-        ConduitGrpcSdk.Logger.info(`Socket event: ${event} from socket: ${socket.id}`);
+        ConduitGrpcSdk.Logger.debug(`Socket event: ${event} from socket: ${socket.id}`);
         conduitSocket
           .executeRequest({
             event,
@@ -166,7 +193,7 @@ export class SocketController extends ConduitRouter {
       });
 
       socket.on('disconnect', () => {
-        ConduitGrpcSdk.Logger.info(
+        ConduitGrpcSdk.Logger.debug(
           `Socket disconnected: ${socket.id} from namespace: ${namespace}`,
         );
         conduitSocket
@@ -184,82 +211,177 @@ export class SocketController extends ConduitRouter {
     });
   }
 
-  async handleSocketPush(push: SocketPush) {
+  async handleSocketPush(push: SocketPush): Promise<boolean> {
     const localOnly = push.localOnly === true;
     if (push.event === 'join-room') {
-      if (push.rooms.length === 0) return;
+      if (push.rooms.length === 0) return false;
       const filteredSockets = await this.findAndFilterSockets(
         push.receivers,
         push.namespace,
         localOnly,
       );
       for (const socket of filteredSockets) {
-        ConduitGrpcSdk.Logger.info(
+        ConduitGrpcSdk.Logger.debug(
           `Socket ${socket.id} joining rooms: ${push.rooms.join(', ')} in namespace: ${
             push.namespace
           }`,
         );
         socket.join(push.rooms);
       }
+      return true;
     } else if (push.event === 'leave-room') {
       if (push.rooms && push.rooms.length !== 0) {
-        const filteredSockets = await this.findAndFilterSockets(
-          push.receivers,
-          push.namespace,
-          localOnly,
-        );
+        const filteredSockets = await this.socketsForRoomPush(push, localOnly);
         for (const socket of filteredSockets) {
           for (const room of push.rooms) {
-            ConduitGrpcSdk.Logger.info(
+            ConduitGrpcSdk.Logger.debug(
               `Socket ${socket.id} leaving room: ${room} in namespace: ${push.namespace}`,
             );
             socket.leave(room);
           }
         }
       }
+      return true;
     } else if (isInstanceOfEventResponse(push)) {
       if (
         (isNil(push.receivers) || push.receivers.length === 0) &&
         push.rooms.length === 0
       ) {
-        ConduitGrpcSdk.Logger.info(
-          `Emitting event: ${push.event} to all sockets in namespace: ${push.namespace}`,
+        return false;
+      }
+      if (push.rooms.length !== 0) {
+        const emitted = await this.emitEventToRooms(push, localOnly);
+        if (!emitted) {
+          return false;
+        }
+      }
+      if (push.receivers.length !== 0) {
+        const filteredSockets = await this.findAndFilterSockets(
+          push.receivers,
+          push.namespace,
+          localOnly,
         );
-        const nsp = this.io.of(push.namespace);
-        if (localOnly) {
-          nsp.local.emit(push.event, push.data);
-        } else {
-          nsp.emit(push.event, push.data);
-        }
-      } else {
-        if (push.rooms.length !== 0) {
-          ConduitGrpcSdk.Logger.info(
-            `Emitting event: ${push.event} to rooms: ${push.rooms.join(
-              ', ',
-            )} in namespace: ${push.namespace}`,
-          );
-          const target = this.io.of(push.namespace).to(push.rooms);
-          if (localOnly) {
-            target.local.emit(push.event, push.data);
-          } else {
-            target.emit(push.event, push.data);
+        for (const socket of filteredSockets) {
+          if (push.boundedEmit && this.isSocketBackpressured(socket)) {
+            ConduitGrpcSdk.Metrics?.increment('event_relays_emit_dropped_total');
+            socket.disconnect(true);
+            continue;
           }
-        }
-        if (push.receivers.length !== 0) {
-          const filteredSockets = await this.findAndFilterSockets(
-            push.receivers,
-            push.namespace,
-            localOnly,
+          ConduitGrpcSdk.Logger.debug(
+            `Emitting event: ${push.event} to socket: ${socket.id} in namespace: ${push.namespace}`,
           );
-          for (const socket of filteredSockets) {
-            ConduitGrpcSdk.Logger.info(
-              `Emitting event: ${push.event} to socket: ${socket.id} in namespace: ${push.namespace}`,
-            );
-            socket.emit(push.event, push.data);
+          socket.emit(push.event, push.data);
+        }
+      }
+      return true;
+    }
+    return false;
+  }
+
+  async getLocalRoomUserIds(namespace: string, room: string): Promise<string[]> {
+    const sockets = await this.io.of(namespace).in(room).local.fetchSockets();
+    const userIds = new Set<string>();
+    for (const socket of sockets) {
+      const userId = socket.data?.user?._id;
+      if (typeof userId === 'string' && userId.length > 0) {
+        userIds.add(userId);
+      }
+    }
+    return [...userIds];
+  }
+
+  async getLocalRoomsWithPrefix(namespace: string, prefix: string): Promise<string[]> {
+    const adapter = this.io.of(namespace).adapter as { rooms?: Map<string, unknown> };
+    const rooms = adapter.rooms;
+    if (!rooms) {
+      return [];
+    }
+    return [...rooms.keys()].filter(room => room.startsWith(prefix));
+  }
+
+  private async emitEventToRooms(push: SocketPush, localOnly: boolean): Promise<boolean> {
+    const nsp = this.io.of(push.namespace);
+    if (push.skipEmptyRooms || push.boundedEmit) {
+      let memberCount = 0;
+      for (const room of push.rooms) {
+        const sockets = localOnly
+          ? await nsp.in(room).local.fetchSockets()
+          : await nsp.in(room).fetchSockets();
+        memberCount += sockets.length;
+        if (push.boundedEmit) {
+          for (const socket of sockets) {
+            if (this.isSocketBackpressured(socket)) {
+              ConduitGrpcSdk.Metrics?.increment('event_relays_emit_dropped_total');
+              socket.disconnect(true);
+            }
           }
         }
       }
+      if (memberCount === 0) {
+        return false;
+      }
     }
+
+    ConduitGrpcSdk.Logger.debug(
+      `Emitting event: ${push.event} to rooms: ${push.rooms.join(
+        ', ',
+      )} in namespace: ${push.namespace}`,
+    );
+    const target = nsp.to(push.rooms);
+    if (localOnly) {
+      if (push.boundedEmit) {
+        await Promise.race([
+          new Promise<void>(resolve => {
+            target.local.emit(push.event, push.data, () => resolve());
+          }),
+          new Promise<void>(resolve => setTimeout(resolve, EMIT_TIMEOUT_MS)),
+        ]);
+      } else {
+        target.local.emit(push.event, push.data);
+      }
+    } else if (push.boundedEmit) {
+      await Promise.race([
+        new Promise<void>(resolve => {
+          target.emit(push.event, push.data, () => resolve());
+        }),
+        new Promise<void>(resolve => setTimeout(resolve, EMIT_TIMEOUT_MS)),
+      ]);
+    } else {
+      target.emit(push.event, push.data);
+    }
+    return true;
+  }
+
+  private isSocketBackpressured(socket: RemoteSocket<any, any> | Socket): boolean {
+    const conn = (socket as Socket).conn ?? (socket as RemoteSocket<any, any>).conn;
+    const transport = conn?.transport as { writableLength?: number } | undefined;
+    const buffered =
+      typeof transport?.writableLength === 'number' ? transport.writableLength : 0;
+    return buffered > SEND_BUFFER_HIGH_WATER_MARK;
+  }
+
+  private async socketsForRoomPush(
+    push: SocketPush,
+    localOnly: boolean,
+  ): Promise<RemoteSocket<any, any>[]> {
+    if (push.receivers.length > 0) {
+      return this.findAndFilterSockets(push.receivers, push.namespace, localOnly);
+    }
+    const nsp = this.io.of(push.namespace);
+    const seen = new Set<string>();
+    const sockets: RemoteSocket<any, any>[] = [];
+    for (const room of push.rooms) {
+      const inRoom = localOnly
+        ? await nsp.in(room).local.fetchSockets()
+        : await nsp.in(room).fetchSockets();
+      for (const socket of inRoom) {
+        if (!seen.has(socket.id)) {
+          seen.add(socket.id);
+          sockets.push(socket);
+        }
+      }
+    }
+    return sockets;
   }
 
   private async handleResponse(
@@ -269,7 +391,7 @@ export class SocketController extends ConduitRouter {
   ) {
     if (res.event === 'join-room') {
       if (res.rooms && res.rooms.length !== 0) {
-        ConduitGrpcSdk.Logger.info(
+        ConduitGrpcSdk.Logger.debug(
           `Socket ${socket.id} joining rooms: ${res.rooms.join(
             ', ',
           )} in namespace: ${namespace}`,
@@ -279,7 +401,7 @@ export class SocketController extends ConduitRouter {
     } else if (res.event === 'leave-room') {
       if (res.rooms && res.rooms.length !== 0) {
         for (const room of res.rooms) {
-          ConduitGrpcSdk.Logger.info(
+          ConduitGrpcSdk.Logger.debug(
             `Socket ${socket.id} leaving room: ${room} in namespace: ${namespace}`,
           );
           socket.leave(room);
@@ -290,13 +412,13 @@ export class SocketController extends ConduitRouter {
         (!res.receivers || res.receivers.length === 0) &&
         (!res.rooms || res.rooms.length === 0)
       ) {
-        ConduitGrpcSdk.Logger.info(
+        ConduitGrpcSdk.Logger.debug(
           `Emitting event: ${res.event} to all sockets in namespace: ${namespace}`,
         );
         socket.emit(res.event, JSON.parse(res.data));
       } else {
         if (res.rooms && res.rooms.length !== 0) {
-          ConduitGrpcSdk.Logger.info(
+          ConduitGrpcSdk.Logger.debug(
             `Emitting event: ${res.event} to rooms: ${res.rooms.join(
               ', ',
             )} in namespace: ${namespace}`,
@@ -309,7 +431,7 @@ export class SocketController extends ConduitRouter {
             namespace,
           );
           for (const socket of filteredSockets) {
-            ConduitGrpcSdk.Logger.info(
+            ConduitGrpcSdk.Logger.debug(
               `Emitting event: ${res.event} to socket: ${socket.id} in namespace: ${namespace}`,
             );
             socket.emit(res.event, JSON.parse(res.data));

--- a/libraries/hermes/src/Socket/isSocketHandshake.test.ts
+++ b/libraries/hermes/src/Socket/isSocketHandshake.test.ts
@@ -8,15 +8,19 @@ describe('isSocketHandshake', () => {
       isSocketHandshake({ url: '/events/?EIO=4&transport=polling&t=abc' }),
       true,
     );
-    assert.equal(
-      isSocketHandshake({ url: '/realtime/?EIO=4&transport=websocket' }),
-      true,
-    );
+    assert.equal(isSocketHandshake({ url: '/realtime/?EIO=4&transport=websocket' }), true);
   });
 
-  it('rejects HTTP routes that merely mention realtime', () => {
-    assert.equal(isSocketHandshake({ url: '/realtime/ticket' }), false);
+  it('rejects HTTP routes that merely mention realtime or established sessions', () => {
+    assert.equal(
+      isSocketHandshake({ url: '/realtime/ticket?EIO=4&transport=polling' }),
+      false,
+    );
     assert.equal(isSocketHandshake({ originalUrl: '/realtime' }), false);
-    assert.equal(isSocketHandshake({ url: '/graphql?EIO=4' }), false);
+    assert.equal(isSocketHandshake({ url: '/graphql?EIO=4&transport=polling' }), false);
+    assert.equal(
+      isSocketHandshake({ url: '/events/?EIO=4&transport=polling&sid=abc' }),
+      false,
+    );
   });
 });

--- a/libraries/hermes/src/Socket/isSocketHandshake.test.ts
+++ b/libraries/hermes/src/Socket/isSocketHandshake.test.ts
@@ -1,0 +1,22 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { isSocketHandshake } from './isSocketHandshake.js';
+
+describe('isSocketHandshake', () => {
+  it('matches Engine.IO handshake query params only', () => {
+    assert.equal(
+      isSocketHandshake({ url: '/events/?EIO=4&transport=polling&t=abc' }),
+      true,
+    );
+    assert.equal(
+      isSocketHandshake({ url: '/realtime/?EIO=4&transport=websocket' }),
+      true,
+    );
+  });
+
+  it('rejects HTTP routes that merely mention realtime', () => {
+    assert.equal(isSocketHandshake({ url: '/realtime/ticket' }), false);
+    assert.equal(isSocketHandshake({ originalUrl: '/realtime' }), false);
+    assert.equal(isSocketHandshake({ url: '/graphql?EIO=4' }), false);
+  });
+});

--- a/libraries/hermes/src/Socket/isSocketHandshake.ts
+++ b/libraries/hermes/src/Socket/isSocketHandshake.ts
@@ -1,16 +1,30 @@
 /**
- * True only for Engine.IO handshake requests (polling/WebSocket upgrade),
- * not for arbitrary HTTP routes under /realtime.
+ * True only for the initial Engine.IO handshake (polling/WebSocket upgrade),
+ * not for arbitrary HTTP routes or established sessions (`sid` present).
  */
 export function isSocketHandshake(req: { url?: string; originalUrl?: string }): boolean {
   const raw = req.url ?? req.originalUrl ?? '';
   if (!raw) {
     return false;
   }
-  const query = raw.includes('?') ? raw.slice(raw.indexOf('?') + 1) : '';
+  const queryIndex = raw.indexOf('?');
+  const pathname = queryIndex === -1 ? raw : raw.slice(0, queryIndex);
+  if (pathname.includes('ticket')) {
+    return false;
+  }
+  const query = queryIndex === -1 ? '' : raw.slice(queryIndex + 1);
   if (!query) {
     return false;
   }
   const params = new URLSearchParams(query);
-  return params.has('EIO') && params.has('transport');
+  if (!params.has('EIO') || !params.has('transport')) {
+    return false;
+  }
+  if (params.has('sid')) {
+    return false;
+  }
+  if (pathname !== '/' && !pathname.endsWith('/')) {
+    return false;
+  }
+  return true;
 }

--- a/libraries/hermes/src/Socket/isSocketHandshake.ts
+++ b/libraries/hermes/src/Socket/isSocketHandshake.ts
@@ -1,0 +1,16 @@
+/**
+ * True only for Engine.IO handshake requests (polling/WebSocket upgrade),
+ * not for arbitrary HTTP routes under /realtime.
+ */
+export function isSocketHandshake(req: { url?: string; originalUrl?: string }): boolean {
+  const raw = req.url ?? req.originalUrl ?? '';
+  if (!raw) {
+    return false;
+  }
+  const query = raw.includes('?') ? raw.slice(raw.indexOf('?') + 1) : '';
+  if (!query) {
+    return false;
+  }
+  const params = new URLSearchParams(query);
+  return params.has('EIO') && params.has('transport');
+}

--- a/libraries/hermes/src/Socket/isSocketHandshake.ts
+++ b/libraries/hermes/src/Socket/isSocketHandshake.ts
@@ -1,7 +1,3 @@
-/**
- * True only for the initial Engine.IO handshake (polling/WebSocket upgrade),
- * not for arbitrary HTTP routes or established sessions (`sid` present).
- */
 export function isSocketHandshake(req: { url?: string; originalUrl?: string }): boolean {
   const raw = req.url ?? req.originalUrl ?? '';
   if (!raw) {

--- a/libraries/hermes/src/Socket/resolveEngineNamespacePath.ts
+++ b/libraries/hermes/src/Socket/resolveEngineNamespacePath.ts
@@ -1,0 +1,11 @@
+/**
+ * Derive the Socket.IO namespace path from an Engine.IO handshake request URL.
+ */
+export function resolveEngineNamespacePath(req: { url?: string }): string {
+  const url = req.url ?? '/';
+  const pathname = url.split('?')[0] ?? '/';
+  if (pathname === '/' || pathname === '') {
+    return '/';
+  }
+  return pathname.endsWith('/') ? pathname : `${pathname}/`;
+}

--- a/libraries/hermes/src/Socket/socketPushUtils.test.ts
+++ b/libraries/hermes/src/Socket/socketPushUtils.test.ts
@@ -1,0 +1,69 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+import {
+  filterRemoteSocketsByUserAndRooms,
+  isEngineSocketBackpressured,
+  WRITE_BUFFER_PACKET_HIGH_WATER,
+} from './socketPushUtils.js';
+
+describe('filterRemoteSocketsByUserAndRooms', () => {
+  const roomA = 'er:relay-1:aaa';
+  const roomB = 'er:relay-1:bbb';
+
+  it('emits only to sockets in the target room for the same user', () => {
+    const sockets = [
+      {
+        id: 'tab-a',
+        data: { user: { _id: 'user-1' } },
+        rooms: new Set([roomA]),
+      },
+      {
+        id: 'tab-b',
+        data: { user: { _id: 'user-1' } },
+        rooms: new Set([roomB]),
+      },
+    ];
+
+    const filtered = filterRemoteSocketsByUserAndRooms(sockets, ['user-1'], [roomA]);
+    assert.deepEqual(
+      filtered.map(s => s.id),
+      ['tab-a'],
+    );
+  });
+});
+
+describe('isEngineSocketBackpressured', () => {
+  it('uses writeBuffer queue depth only', () => {
+    assert.equal(isEngineSocketBackpressured(undefined), false);
+    assert.equal(
+      isEngineSocketBackpressured({ writeBuffer: new Array(WRITE_BUFFER_PACKET_HIGH_WATER) }),
+      false,
+    );
+    assert.equal(
+      isEngineSocketBackpressured({
+        writeBuffer: new Array(WRITE_BUFFER_PACKET_HIGH_WATER + 1),
+      }),
+      true,
+    );
+    assert.equal(
+      isEngineSocketBackpressured({
+        writeBuffer: [],
+      }),
+      false,
+    );
+  });
+});
+
+describe('SocketController relay emit', () => {
+  it('does not reference writableLength or client emit ack callbacks', () => {
+    const socketSource = readFileSync(
+      path.join(path.dirname(fileURLToPath(import.meta.url)), '../../src/Socket/Socket.ts'),
+      'utf8',
+    );
+    assert.doesNotMatch(socketSource, /writableLength/);
+    assert.doesNotMatch(socketSource, /\.emit\([^)]*,\s*[^,)]+,\s*\(\)\s*=>/);
+  });
+});

--- a/libraries/hermes/src/Socket/socketPushUtils.ts
+++ b/libraries/hermes/src/Socket/socketPushUtils.ts
@@ -1,0 +1,36 @@
+export const WRITE_BUFFER_PACKET_HIGH_WATER = 64;
+
+type SocketLike = {
+  id: string;
+  data?: { user?: { _id?: string } };
+  rooms: Set<string>;
+};
+
+export function filterRemoteSocketsByUserAndRooms(
+  sockets: SocketLike[],
+  userIds: string[],
+  rooms: string[],
+): SocketLike[] {
+  const userIdSet = new Set(userIds);
+  const roomSet = rooms.length > 0 ? new Set(rooms) : null;
+  return sockets.filter(socket => {
+    if (!socket.data?.user?._id) {
+      return false;
+    }
+    if (!userIdSet.has(socket.data.user._id)) {
+      return false;
+    }
+    if (roomSet) {
+      return [...roomSet].some(room => socket.rooms.has(room));
+    }
+    return true;
+  });
+}
+
+export function isEngineSocketBackpressured(
+  conn: { writeBuffer?: unknown[] } | undefined,
+  highWater = WRITE_BUFFER_PACKET_HIGH_WATER,
+): boolean {
+  const pending = conn?.writeBuffer?.length ?? 0;
+  return pending > highWater;
+}

--- a/libraries/hermes/src/index.ts
+++ b/libraries/hermes/src/index.ts
@@ -235,6 +235,12 @@ export class ConduitRoutingController {
     }
   }
 
+  registerSocketGlobalMiddleware(
+    middleware: (req: ConduitRequest, res: Response, next: NextFunction) => void,
+  ) {
+    this._socketRouter?.registerGlobalMiddleware(middleware);
+  }
+
   registerRouteMiddleware(middleware: ConduitMiddleware, moduleUrl: string) {
     this._restRouter?.registerMiddleware(middleware, moduleUrl);
     this._graphQLRouter?.registerMiddleware(middleware, moduleUrl);
@@ -322,7 +328,20 @@ export class ConduitRoutingController {
   }
 
   async socketPush(data: SocketPush) {
-    await this._socketRouter?.handleSocketPush(data);
+    return (await this._socketRouter?.handleSocketPush(data)) ?? false;
+  }
+
+  getLocalRoomUserIds(namespace: string, room: string): Promise<string[]> {
+    return (
+      this._socketRouter?.getLocalRoomUserIds(namespace, room) ?? Promise.resolve([])
+    );
+  }
+
+  getLocalRoomsWithPrefix(namespace: string, prefix: string): Promise<string[]> {
+    return (
+      this._socketRouter?.getLocalRoomsWithPrefix(namespace, prefix) ??
+      Promise.resolve([])
+    );
   }
 
   /** True if any enabled transport would change this route (new or definition changed). */
@@ -451,6 +470,8 @@ export class ConduitRoutingController {
   }
 }
 
+export { isSocketHandshake } from './Socket/isSocketHandshake.js';
+export { resolveEngineNamespacePath } from './Socket/resolveEngineNamespacePath.js';
 export * from './interfaces/index.js';
 export * from './types/index.js';
 export * from './classes/index.js';

--- a/libraries/hermes/src/interfaces/Socket.ts
+++ b/libraries/hermes/src/interfaces/Socket.ts
@@ -10,6 +10,7 @@ export interface ConduitSocketParameters {
   socketId: string;
   params?: UntypedArray;
   context?: Indexable;
+  recoveredRooms?: string[];
 }
 
 export type ConduitSocketParamTypes = (TYPE | ConduitSocketParamTypes)[];

--- a/libraries/hermes/src/interfaces/Socket.ts
+++ b/libraries/hermes/src/interfaces/Socket.ts
@@ -19,6 +19,7 @@ export interface ConduitSocketOptions {
   name?: string;
   description?: string;
   middlewares?: string[];
+  onRecovered?: ConduitSocketEventHandler;
 }
 
 export type EventResponse = {
@@ -84,6 +85,15 @@ export class ConduitSocket {
       return this._events.get('any')!.handler(request);
     }
     return Promise.reject('no such event registered');
+  }
+
+  executeRecovered(
+    request: ConduitSocketParameters,
+  ): ConduitSocketHandlerResponse | null {
+    if (!this._input.onRecovered) {
+      return null;
+    }
+    return this._input.onRecovered(request);
   }
 }
 

--- a/libraries/hermes/src/interfaces/SocketPush.ts
+++ b/libraries/hermes/src/interfaces/SocketPush.ts
@@ -5,4 +5,8 @@ export interface SocketPush {
   rooms: string[];
   namespace: string;
   localOnly?: boolean;
+  /** Skip emit when the local room has no connected sockets. */
+  skipEmptyRooms?: boolean;
+  /** Drop or disconnect slow clients instead of blocking the caller. */
+  boundedEmit?: boolean;
 }

--- a/libraries/hermes/tsconfig.json
+++ b/libraries/hermes/tsconfig.json
@@ -65,5 +65,6 @@
 
     /* Advanced Options */
     "forceConsistentCasingInFileNames": true /* Disallow inconsistently-cased references to the same file. */
-  }
+  },
+  "exclude": ["src/**/*.test.ts"]
 }

--- a/libraries/hermes/tsconfig.test.json
+++ b/libraries/hermes/tsconfig.test.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist-test",
+    "rootDir": "./src",
+    "declaration": false,
+    "sourceMap": false,
+    "types": ["node"]
+  },
+  "include": ["src/Socket/isSocketHandshake.ts", "src/Socket/isSocketHandshake.test.ts"]
+}

--- a/libraries/hermes/tsconfig.test.json
+++ b/libraries/hermes/tsconfig.test.json
@@ -7,5 +7,11 @@
     "sourceMap": false,
     "types": ["node"]
   },
-  "include": ["src/Socket/isSocketHandshake.ts", "src/Socket/isSocketHandshake.test.ts"]
+  "include": [
+    "src/Socket/isSocketHandshake.ts",
+    "src/Socket/isSocketHandshake.test.ts",
+    "src/Socket/socketPushUtils.ts",
+    "src/Socket/socketPushUtils.test.ts"
+  ],
+  "exclude": []
 }

--- a/modules/router/README.mdx
+++ b/modules/router/README.mdx
@@ -92,12 +92,12 @@ import { io } from 'socket.io-client';
 
 const socket = io(`${SOCKET_BASE_URL}/events/`, {
   path: '/realtime',
-  extraHeaders: {
-    authorization: `Bearer ${accessToken}`,
-  },
+  auth: { token: accessToken },
 });
 
-socket.emit('subscribe', relayId, resourceId);
+socket.on('connect', () => {
+  socket.emit('subscribe', relayId, resourceId);
+});
 socket.on('order-updated', payload => {
   // payload is the rendered JSON template
 });
@@ -120,18 +120,7 @@ socket.emit('unsubscribe', relayId, resourceId);
 
 **Dual delivery warning:** Database `/database/` `change` events and a relay on overlapping bus channels (for example `database:change:*` or CRUD `database:update:*`) can duplicate notifications. CRUD bus payloads include **full documents** — prefer change-stream style payloads when both paths are enabled.
 
-Use preview to validate templates: `POST /router/event-relays/preview` with `messageTemplate` and `samplePayload` (same renderer as runtime).
-
-```javascript
-const socket = io(`${SOCKET_BASE_URL}/events/`, {
-  path: '/realtime',
-  auth: { token: accessToken },
-});
-
-socket.on('connect', () => {
-  socket.emit('subscribe', relayId, resourceId);
-});
-```
+Use preview to validate templates: `POST /router/event-relays/preview` with `messageTemplate` and `samplePayload` (same renderer as runtime; sample JSON is capped at 256 KiB like inbound bus payloads).
 
 ### Admin API
 

--- a/modules/router/README.mdx
+++ b/modules/router/README.mdx
@@ -108,6 +108,31 @@ socket.emit('unsubscribe', relayId, resourceId);
 - The outbound event name is the relay `socketEvent`.
 - Placeholders in `messageTemplate` use `{{payload.path}}` against the bus JSON payload.
 
+**Subscribe-only.** Clients cannot publish on `/events/`; modules publish to the Redis bus and relays forward matching messages to subscribed rooms.
+
+**Authentication and Authorization** are required (`authMiddleware` on subscribe). Authorization is re-checked on a short TTL during delivery; revoked access triggers `leave-room`.
+
+**Rooms** are server-assigned: `er:<relayId>:<sha256(resourceId)>`. Conduit has no tenant model and **team ids are not part of room names** — isolation is ReBAC on `User` × `permission` × `resourceType:resourceId`.
+
+**HA / `localOnly`:** every Router replica subscribes to the bus and emits with `localOnly`, so clients spread across replicas still receive one copy without sticky sessions for delivery. Engine.IO **polling** transport still benefits from sticky sessions or WebSocket-only clients.
+
+**EventBus self-publish:** the bus ignores this process’s own publishes (signature filter). A relay on a channel the Router publishes will not deliver to local clients for those self-originated messages (typical for module-originated events).
+
+**Dual delivery warning:** Database `/database/` `change` events and a relay on overlapping bus channels (for example `database:change:*` or CRUD `database:update:*`) can duplicate notifications. CRUD bus payloads include **full documents** — prefer change-stream style payloads when both paths are enabled.
+
+Use preview to validate templates: `POST /router/event-relays/preview` with `messageTemplate` and `samplePayload` (same renderer as runtime).
+
+```javascript
+const socket = io(`${SOCKET_BASE_URL}/events/`, {
+  path: '/realtime',
+  auth: { token: accessToken },
+});
+
+socket.on('connect', () => {
+  socket.emit('subscribe', relayId, resourceId);
+});
+```
+
 ### Admin API
 
 | Method | Path | Description |
@@ -115,5 +140,6 @@ socket.emit('unsubscribe', relayId, resourceId);
 | `GET` | `/router/event-relays` | Paginated list (`skip`, `limit`, `search`) |
 | `GET` | `/router/event-relays/:id` | Single relay |
 | `POST` | `/router/event-relays` | Create |
-| `PATCH` | `/router/event-relays/:id` | Update |
+| `POST` | `/router/event-relays/preview` | Render template against sample JSON |
+| `PATCH` | `/router/event-relays/:id` | Update (deactivating evicts rooms) |
 | `DELETE` | `/router/event-relays/:id` | Delete |

--- a/modules/router/src/Router.ts
+++ b/modules/router/src/Router.ts
@@ -361,7 +361,7 @@ export default class ConduitDefaultRouter extends ManagedModule<Config> {
 
   registerGlobalMiddleware(
     name: string,
-    middleware: any,
+    middleware: (req: ConduitRequest, res: Response, next: NextFunction) => void,
     socketMiddleware: boolean = false,
   ) {
     this._globalMiddlewares.push(name);
@@ -375,6 +375,13 @@ export default class ConduitDefaultRouter extends ManagedModule<Config> {
     for (const middleware of this._socketGlobalMiddlewareHandlers) {
       this._internalRouter.registerSocketGlobalMiddleware(middleware);
     }
+  }
+
+  async shutdown(): Promise<void> {
+    if (this.eventRelayManager) {
+      await this.eventRelayManager.stop();
+    }
+    this.grpcSdk.bus?.quit();
   }
 
   getRegisteredRoutes() {

--- a/modules/router/src/Router.ts
+++ b/modules/router/src/Router.ts
@@ -66,6 +66,11 @@ export default class ConduitDefaultRouter extends ManagedModule<Config> {
   private adminRouter: AdminHandlers;
   private readonly _routes: string[];
   private readonly _globalMiddlewares: string[];
+  private readonly _socketGlobalMiddlewareHandlers: ((
+    req: ConduitRequest,
+    res: Response,
+    next: NextFunction,
+  ) => void)[];
   private _grpcRoutes: {
     [field: string]: RouteT[];
   } = {};
@@ -76,12 +81,14 @@ export default class ConduitDefaultRouter extends ManagedModule<Config> {
   private _haInitialized = false;
   private eventRelayManager: EventRelayManager;
   private eventsSocket?: ConduitSocket;
+  private socketsPreviouslyStopped = false;
 
   constructor(peerManifestRoot?: string) {
     super('router', peerManifestRoot);
     this.updateHealth(HealthCheckStatus.UNKNOWN, true);
     this._routes = [];
     this._globalMiddlewares = [];
+    this._socketGlobalMiddlewareHandlers = [];
   }
 
   async onServerStart() {
@@ -112,6 +119,12 @@ export default class ConduitDefaultRouter extends ManagedModule<Config> {
     this.eventRelayManager = new EventRelayManager(
       this.grpcSdk,
       createEventRelayPusher(data => this._internalRouter.socketPush(data)),
+      {
+        getLocalRoomUserIds: (room: string) =>
+          this._internalRouter.getLocalRoomUserIds('/events/', room),
+        getLocalRoomsWithPrefix: (prefix: string) =>
+          this._internalRouter.getLocalRoomsWithPrefix('/events/', prefix),
+      },
     );
     this.adminRouter = new AdminHandlers(
       this.grpcServer,
@@ -148,16 +161,23 @@ export default class ConduitDefaultRouter extends ManagedModule<Config> {
     }
     if (config.transports.sockets) {
       this._internalRouter.initSockets();
-      this.registerEventsNamespace();
       await this.eventRelayManager.start();
       atLeastOne = true;
     } else {
       await this.eventRelayManager?.stop();
       this._internalRouter.stopSockets();
+      this.socketsPreviouslyStopped = true;
     }
 
     if (atLeastOne) {
       this._security.setupMiddlewares();
+    }
+    if (config.transports.sockets) {
+      if (this.socketsPreviouslyStopped) {
+        this.rebindSocketGlobalMiddlewares();
+        this.socketsPreviouslyStopped = false;
+      }
+      this.registerEventsNamespace();
     }
     if (!this._sdkRoutes.some(r => r.path === '/ready')) {
       this.registerRoute(adminRoutes.getReadyRoute());
@@ -339,7 +359,16 @@ export default class ConduitDefaultRouter extends ManagedModule<Config> {
     socketMiddleware: boolean = false,
   ) {
     this._globalMiddlewares.push(name);
+    if (socketMiddleware) {
+      this._socketGlobalMiddlewareHandlers.push(middleware);
+    }
     this._internalRouter.registerMiddleware(middleware, socketMiddleware);
+  }
+
+  private rebindSocketGlobalMiddlewares() {
+    for (const middleware of this._socketGlobalMiddlewareHandlers) {
+      this._internalRouter.registerSocketGlobalMiddleware(middleware);
+    }
   }
 
   getRegisteredRoutes() {

--- a/modules/router/src/Router.ts
+++ b/modules/router/src/Router.ts
@@ -1,4 +1,4 @@
-import { NextFunction } from 'express';
+import { NextFunction, Response } from 'express';
 import { status } from '@grpc/grpc-js';
 import {
   ConduitGrpcSdk,

--- a/modules/router/src/Router.ts
+++ b/modules/router/src/Router.ts
@@ -82,6 +82,7 @@ export default class ConduitDefaultRouter extends ManagedModule<Config> {
   private eventRelayManager: EventRelayManager;
   private eventsSocket?: ConduitSocket;
   private socketsPreviouslyStopped = false;
+  private securityMiddlewareInitialized = false;
 
   constructor(peerManifestRoot?: string) {
     super('router', peerManifestRoot);
@@ -146,6 +147,10 @@ export default class ConduitDefaultRouter extends ManagedModule<Config> {
 
   async onConfig() {
     const config = ConfigController.getInstance().config;
+    const shouldRebindSocketGlobals =
+      config.transports.sockets &&
+      this.socketsPreviouslyStopped &&
+      this.securityMiddlewareInitialized;
     let atLeastOne = false;
     if (config.transports.graphql) {
       this._internalRouter.initGraphQL();
@@ -169,14 +174,15 @@ export default class ConduitDefaultRouter extends ManagedModule<Config> {
       this.socketsPreviouslyStopped = true;
     }
 
-    if (atLeastOne) {
+    if (atLeastOne && !this.securityMiddlewareInitialized) {
       this._security.setupMiddlewares();
+      this.securityMiddlewareInitialized = true;
     }
     if (config.transports.sockets) {
-      if (this.socketsPreviouslyStopped) {
+      if (shouldRebindSocketGlobals) {
         this.rebindSocketGlobalMiddlewares();
-        this.socketsPreviouslyStopped = false;
       }
+      this.socketsPreviouslyStopped = false;
       this.registerEventsNamespace();
     }
     if (!this._sdkRoutes.some(r => r.path === '/ready')) {

--- a/modules/router/src/admin/event-relays.ts
+++ b/modules/router/src/admin/event-relays.ts
@@ -12,6 +12,7 @@ import { EventRelayInput, validateEventRelayInput } from '../event-relays/valida
 import { EventRelayValidationError } from '../event-relays/validationError.js';
 import { renderMessageTemplate } from '../event-relays/template.js';
 import { buildSearchQuery, parsePagination } from '../event-relays/search.js';
+import { assertJsonPayloadSize } from '../event-relays/process.js';
 
 export class EventRelayAdmin {
   constructor(private readonly manager: EventRelayManager) {}
@@ -59,6 +60,7 @@ export class EventRelayAdmin {
       samplePayload: unknown;
     };
     try {
+      assertJsonPayloadSize(samplePayload);
       const rendered = renderMessageTemplate(messageTemplate, samplePayload);
       return { rendered };
     } catch (err) {

--- a/modules/router/src/admin/event-relays.ts
+++ b/modules/router/src/admin/event-relays.ts
@@ -10,6 +10,7 @@ import { EventRelay } from '../models/index.js';
 import { EventRelayManager } from '../event-relays/EventRelayManager.js';
 import { EventRelayInput, validateEventRelayInput } from '../event-relays/validation.js';
 import { EventRelayValidationError } from '../event-relays/validationError.js';
+import { renderMessageTemplate } from '../event-relays/template.js';
 import { buildSearchQuery, parsePagination } from '../event-relays/search.js';
 
 export class EventRelayAdmin {
@@ -52,6 +53,22 @@ export class EventRelayAdmin {
     return relay;
   }
 
+  async previewEventRelay(call: ParsedRouterRequest): Promise<UnparsedRouterResponse> {
+    const { messageTemplate, samplePayload } = call.request.params as {
+      messageTemplate: unknown;
+      samplePayload: unknown;
+    };
+    try {
+      const rendered = renderMessageTemplate(messageTemplate, samplePayload);
+      return { rendered };
+    } catch (err) {
+      if (err instanceof EventRelayValidationError) {
+        throw new GrpcError(status.INVALID_ARGUMENT, err.message);
+      }
+      throw err;
+    }
+  }
+
   async patchEventRelay(call: ParsedRouterRequest): Promise<UnparsedRouterResponse> {
     const existing = await EventRelay.getInstance().findOne({
       _id: call.request.params.id,
@@ -89,7 +106,18 @@ export class EventRelayAdmin {
       ...input,
       messageTemplate: input.messageTemplate as EventRelay['messageTemplate'],
     });
-    await this.manager.notifyChanged();
+    const evictRelayIds: string[] = [];
+    if (!input.active) {
+      evictRelayIds.push(existing._id);
+    } else if (
+      input.permission !== existing.permission ||
+      input.resourceType !== existing.resourceType
+    ) {
+      evictRelayIds.push(existing._id);
+    }
+    await this.manager.notifyChanged({
+      evictRelayIds: evictRelayIds.length ? evictRelayIds : undefined,
+    });
     return updated!;
   }
 
@@ -101,7 +129,7 @@ export class EventRelayAdmin {
       throw new GrpcError(status.NOT_FOUND, 'Event relay not found');
     }
     await EventRelay.getInstance().deleteOne({ _id: existing._id });
-    await this.manager.notifyChanged();
+    await this.manager.notifyChanged({ evictRelayIds: [existing._id] });
     return { message: 'Event relay deleted' };
   }
 }

--- a/modules/router/src/admin/index.ts
+++ b/modules/router/src/admin/index.ts
@@ -242,6 +242,21 @@ export class AdminHandlers {
       }),
       this.eventRelayAdmin.deleteEventRelay.bind(this.eventRelayAdmin),
     );
+    this.routingManager.route(
+      {
+        path: '/event-relays/preview',
+        action: ConduitRouteActions.POST,
+        description: `Renders a relay message template against sample bus JSON (same engine as runtime).`,
+        bodyParams: {
+          messageTemplate: ConduitJson.Required,
+          samplePayload: ConduitJson.Required,
+        },
+      },
+      new ConduitRouteReturnDefinition('PreviewEventRelay', {
+        rendered: ConduitJson.Required,
+      }),
+      this.eventRelayAdmin.previewEventRelay.bind(this.eventRelayAdmin),
+    );
     this.routingManager.registerRoutes();
   }
 }

--- a/modules/router/src/event-relays/EventRelayManager.ts
+++ b/modules/router/src/event-relays/EventRelayManager.ts
@@ -280,7 +280,7 @@ export class EventRelayManager {
     }
 
     try {
-      const emitted = await this.push(relay.socketEvent, data, [], allowedUsers);
+      const emitted = await this.push(relay.socketEvent, data, [room], allowedUsers);
       if (emitted) {
         ConduitGrpcSdk.Metrics?.increment('event_relays_emitted_total');
       } else {

--- a/modules/router/src/event-relays/EventRelayManager.ts
+++ b/modules/router/src/event-relays/EventRelayManager.ts
@@ -10,8 +10,9 @@ import { groupRelaysByChannel, planChannelSubscriptions } from './channels.js';
 import { parseBusPayload } from './process.js';
 import { EventRelayPusher } from './push.js';
 import { compileRelay, CompiledRelay } from './compile.js';
-import { RelayRebacCache } from './rebacCache.js';
+import { checkRebacBatch, RelayRebacCache } from './rebacCache.js';
 import { eventRelayRoomPrefix } from './rooms.js';
+import { removeSubscriptionsForRelay } from './subscriptions.js';
 
 export type { EventRelayPusher } from './push.js';
 export { createEventRelayPusher } from './push.js';
@@ -19,6 +20,10 @@ export { createEventRelayPusher } from './push.js';
 export type EventRelaySocketAccess = {
   getLocalRoomUserIds: (room: string) => Promise<string[]>;
   getLocalRoomsWithPrefix: (prefix: string) => Promise<string[]>;
+};
+
+type RefreshPayload = {
+  evictRelayIds?: string[];
 };
 
 export class EventRelayManager {
@@ -41,8 +46,8 @@ export class EventRelayManager {
     if (!this.started) {
       this.grpcSdk.bus?.subscribe(
         EVENT_RELAY_REFRESH_CHANNEL,
-        () => {
-          void this.reconcile();
+        message => {
+          void this.onRefreshMessage(message);
         },
         'router-event-relays-refresh',
       );
@@ -83,20 +88,42 @@ export class EventRelayManager {
     if (this.started) {
       await this.reconcile();
     }
-    this.grpcSdk.bus?.publish(EVENT_RELAY_REFRESH_CHANNEL, '');
+    const payload: RefreshPayload = {
+      evictRelayIds: options?.evictRelayIds ?? [],
+    };
+    this.grpcSdk.bus?.publish(EVENT_RELAY_REFRESH_CHANNEL, JSON.stringify(payload));
   }
 
   async evictRelayRooms(relayId: string): Promise<void> {
     const prefix = eventRelayRoomPrefix(relayId);
     const rooms = await this.sockets.getLocalRoomsWithPrefix(prefix);
     if (rooms.length === 0) {
+      removeSubscriptionsForRelay(relayId);
       return;
     }
     await this.push('leave-room', undefined, rooms);
+    removeSubscriptionsForRelay(relayId);
   }
 
   getActiveRelay(id: string): EventRelay | undefined {
     return this.relaysById.get(id);
+  }
+
+  private async onRefreshMessage(raw: string): Promise<void> {
+    let payload: RefreshPayload = {};
+    if (raw.trim()) {
+      try {
+        payload = JSON.parse(raw) as RefreshPayload;
+      } catch {
+        payload = {};
+      }
+    }
+    if (payload.evictRelayIds?.length) {
+      for (const relayId of payload.evictRelayIds) {
+        await this.evictRelayRooms(relayId);
+      }
+    }
+    await this.reconcile();
   }
 
   async reconcile(): Promise<void> {
@@ -148,12 +175,20 @@ export class EventRelayManager {
     }
 
     for (const channel of toSubscribe) {
-      this.grpcSdk.bus?.subscribe(
-        channel,
-        message => this.onBusMessage(channel, message),
-        `${EVENT_RELAY_SUBSCRIBER_PREFIX}${channel}`,
-      );
-      this.subscribedChannels.add(channel);
+      try {
+        await this.grpcSdk.bus?.subscribeAck(
+          channel,
+          message => this.onBusMessage(channel, message),
+          `${EVENT_RELAY_SUBSCRIBER_PREFIX}${channel}`,
+        );
+        this.subscribedChannels.add(channel);
+      } catch (err) {
+        ConduitGrpcSdk.Logger.error(
+          `Event relay failed to subscribe to bus channel ${channel}: ${
+            err instanceof Error ? err.message : String(err)
+          }`,
+        );
+      }
     }
 
     ConduitGrpcSdk.Metrics?.set('event_relays_active_total', this.relaysById.size);
@@ -220,18 +255,21 @@ export class EventRelayManager {
       return;
     }
 
+    const decisions = await checkRebacBatch(
+      this.rebacCache,
+      this.grpcSdk,
+      userIds,
+      relay.permission,
+      relay.resourceType,
+      resourceId,
+    );
+
     const allowedUsers: string[] = [];
     for (const userId of userIds) {
-      const allowed = await this.rebacCache.can(
-        this.grpcSdk,
-        userId,
-        relay.permission,
-        relay.resourceType,
-        resourceId,
-      );
-      if (allowed) {
+      const decision = decisions.get(userId) ?? 'unavailable';
+      if (decision === 'allow') {
         allowedUsers.push(userId);
-      } else {
+      } else if (decision === 'deny') {
         await this.push('leave-room', undefined, [room], [userId]);
         ConduitGrpcSdk.Metrics?.increment('event_relay_subscriptions_denied_total');
       }
@@ -242,7 +280,7 @@ export class EventRelayManager {
     }
 
     try {
-      const emitted = await this.push(relay.socketEvent, data, [room]);
+      const emitted = await this.push(relay.socketEvent, data, [], allowedUsers);
       if (emitted) {
         ConduitGrpcSdk.Metrics?.increment('event_relays_emitted_total');
       } else {

--- a/modules/router/src/event-relays/EventRelayManager.ts
+++ b/modules/router/src/event-relays/EventRelayManager.ts
@@ -3,22 +3,38 @@ import { EventRelay } from '../models/index.js';
 import {
   EVENT_RELAY_REFRESH_CHANNEL,
   EVENT_RELAY_SUBSCRIBER_PREFIX,
+  RECONCILE_INTERVAL_MS,
+  RELAY_REBAC_TTL_MS,
 } from './constants.js';
 import { groupRelaysByChannel, planChannelSubscriptions } from './channels.js';
-import { buildRelayEmissions, parseBusPayload } from './process.js';
+import { parseBusPayload } from './process.js';
 import { EventRelayPusher } from './push.js';
+import { compileRelay, CompiledRelay } from './compile.js';
+import { RelayRebacCache } from './rebacCache.js';
+import { eventRelayRoomPrefix } from './rooms.js';
 
 export type { EventRelayPusher } from './push.js';
 export { createEventRelayPusher } from './push.js';
 
+export type EventRelaySocketAccess = {
+  getLocalRoomUserIds: (room: string) => Promise<string[]>;
+  getLocalRoomsWithPrefix: (prefix: string) => Promise<string[]>;
+};
+
 export class EventRelayManager {
-  private readonly relaysByChannel = new Map<string, EventRelay[]>();
+  private readonly relaysById = new Map<string, EventRelay>();
+  private readonly relaysByChannel = new Map<string, CompiledRelay[]>();
   private readonly subscribedChannels = new Set<string>();
+  private readonly rebacCache = new RelayRebacCache(RELAY_REBAC_TTL_MS);
   private started = false;
+  private reconcilePending = false;
+  private reconciling = false;
+  private reconcileTimer?: NodeJS.Timeout;
 
   constructor(
     private readonly grpcSdk: ConduitGrpcSdk,
     private readonly push: EventRelayPusher,
+    private readonly sockets: EventRelaySocketAccess,
   ) {}
 
   async start(): Promise<void> {
@@ -26,47 +42,104 @@ export class EventRelayManager {
       this.grpcSdk.bus?.subscribe(
         EVENT_RELAY_REFRESH_CHANNEL,
         () => {
-          this.reconcile().catch(err => {
-            ConduitGrpcSdk.Logger.error(err as Error);
-          });
+          void this.reconcile();
         },
         'router-event-relays-refresh',
       );
+      this.reconcileTimer = setInterval(() => {
+        void this.reconcile();
+      }, RECONCILE_INTERVAL_MS);
       this.started = true;
     }
     await this.reconcile();
   }
 
   async stop(): Promise<void> {
+    if (this.reconcileTimer) {
+      clearInterval(this.reconcileTimer);
+      this.reconcileTimer = undefined;
+    }
     for (const channel of [...this.subscribedChannels]) {
       this.grpcSdk.bus?.unsubscribe(`${EVENT_RELAY_SUBSCRIBER_PREFIX}${channel}`);
       this.subscribedChannels.delete(channel);
     }
     this.relaysByChannel.clear();
+    this.relaysById.clear();
+    this.rebacCache.clear();
     if (this.started) {
       this.grpcSdk.bus?.unsubscribe('router-event-relays-refresh');
       this.started = false;
     }
+    ConduitGrpcSdk.Metrics?.set('event_relays_active_total', 0);
+    ConduitGrpcSdk.Metrics?.set('event_relays_subscribed_channels_total', 0);
   }
 
-  async notifyChanged(): Promise<void> {
+  async notifyChanged(options?: { evictRelayIds?: string[] }): Promise<void> {
+    if (options?.evictRelayIds?.length) {
+      for (const relayId of options.evictRelayIds) {
+        await this.evictRelayRooms(relayId);
+      }
+    }
     if (this.started) {
       await this.reconcile();
     }
     this.grpcSdk.bus?.publish(EVENT_RELAY_REFRESH_CHANNEL, '');
   }
 
+  async evictRelayRooms(relayId: string): Promise<void> {
+    const prefix = eventRelayRoomPrefix(relayId);
+    const rooms = await this.sockets.getLocalRoomsWithPrefix(prefix);
+    if (rooms.length === 0) {
+      return;
+    }
+    await this.push('leave-room', undefined, rooms);
+  }
+
+  getActiveRelay(id: string): EventRelay | undefined {
+    return this.relaysById.get(id);
+  }
+
   async reconcile(): Promise<void> {
+    this.reconcilePending = true;
+    if (this.reconciling) {
+      return;
+    }
+    this.reconciling = true;
+    try {
+      while (this.reconcilePending) {
+        this.reconcilePending = false;
+        await this.runReconcile();
+      }
+    } finally {
+      this.reconciling = false;
+    }
+  }
+
+  private async runReconcile(): Promise<void> {
+    const previousIds = new Set(this.relaysById.keys());
     const relays = await EventRelay.getInstance().findMany({ active: true });
-    const next = groupRelaysByChannel(relays);
+    const nextByChannel = groupRelaysByChannel(relays);
     const { toSubscribe, toUnsubscribe } = planChannelSubscriptions(
       this.subscribedChannels,
-      next.keys(),
+      nextByChannel.keys(),
     );
 
+    this.relaysById.clear();
     this.relaysByChannel.clear();
-    for (const [channel, list] of next) {
-      this.relaysByChannel.set(channel, list);
+    for (const relay of relays) {
+      this.relaysById.set(relay._id, relay);
+    }
+    for (const [channel, channelRelays] of nextByChannel) {
+      this.relaysByChannel.set(
+        channel,
+        channelRelays.map(relay => compileRelay(relay)),
+      );
+    }
+
+    for (const id of previousIds) {
+      if (!this.relaysById.has(id)) {
+        await this.evictRelayRooms(id);
+      }
     }
 
     for (const channel of toUnsubscribe) {
@@ -82,14 +155,12 @@ export class EventRelayManager {
       );
       this.subscribedChannels.add(channel);
     }
-  }
 
-  getActiveRelay(id: string): EventRelay | undefined {
-    for (const relays of this.relaysByChannel.values()) {
-      const match = relays.find(relay => relay._id === id);
-      if (match) return match;
-    }
-    return undefined;
+    ConduitGrpcSdk.Metrics?.set('event_relays_active_total', this.relaysById.size);
+    ConduitGrpcSdk.Metrics?.set(
+      'event_relays_subscribed_channels_total',
+      this.subscribedChannels.size,
+    );
   }
 
   private onBusMessage(channel: string, message: string): void {
@@ -103,6 +174,13 @@ export class EventRelayManager {
       payload = parseBusPayload(message);
     } catch (err) {
       ConduitGrpcSdk.Metrics?.increment('event_relays_failed_total');
+      if (
+        err instanceof Error &&
+        err.message.includes('exceeds') &&
+        err.message.includes('bytes')
+      ) {
+        ConduitGrpcSdk.Metrics?.increment('event_relays_inbound_dropped_total');
+      }
       ConduitGrpcSdk.Logger.error(
         `Event relay failed to parse payload for ${channel}: ${
           err instanceof Error ? err.message : String(err)
@@ -111,27 +189,71 @@ export class EventRelayManager {
       return;
     }
 
-    const { emissions, failures } = buildRelayEmissions(relays, payload);
-    for (const failure of failures) {
+    for (const relay of relays) {
+      void this.emitCompiledRelay(relay, payload, channel);
+    }
+  }
+
+  private async emitCompiledRelay(
+    relay: CompiledRelay,
+    payload: unknown,
+    channel: string,
+  ): Promise<void> {
+    let room: string;
+    let data: unknown;
+    let resourceId: string;
+    try {
+      ({ room, data, resourceId } = relay.buildEmission(payload));
+    } catch (err) {
       ConduitGrpcSdk.Metrics?.increment('event_relays_failed_total');
       ConduitGrpcSdk.Logger.warn(
-        `Event relay ${failure.relayId} skipped on ${failure.busEvent}: ${failure.reason}`,
+        `Event relay ${relay.relayId} skipped on ${relay.busEvent}: ${
+          err instanceof Error ? err.message : String(err)
+        }`,
       );
+      return;
     }
 
-    for (const emission of emissions) {
-      this.push(emission.socketEvent, emission.data, [emission.room]).then(
-        () => {
-          ConduitGrpcSdk.Metrics?.increment('event_relays_emitted_total');
-        },
-        err => {
-          ConduitGrpcSdk.Metrics?.increment('event_relays_failed_total');
-          ConduitGrpcSdk.Logger.error(
-            `Event relay ${emission.relayId} emit failed on ${channel}: ${
-              err instanceof Error ? err.message : String(err)
-            }`,
-          );
-        },
+    const userIds = await this.sockets.getLocalRoomUserIds(room);
+    if (userIds.length === 0) {
+      ConduitGrpcSdk.Metrics?.increment('event_relays_empty_room_total');
+      return;
+    }
+
+    const allowedUsers: string[] = [];
+    for (const userId of userIds) {
+      const allowed = await this.rebacCache.can(
+        this.grpcSdk,
+        userId,
+        relay.permission,
+        relay.resourceType,
+        resourceId,
+      );
+      if (allowed) {
+        allowedUsers.push(userId);
+      } else {
+        await this.push('leave-room', undefined, [room], [userId]);
+        ConduitGrpcSdk.Metrics?.increment('event_relay_subscriptions_denied_total');
+      }
+    }
+
+    if (allowedUsers.length === 0) {
+      return;
+    }
+
+    try {
+      const emitted = await this.push(relay.socketEvent, data, [room]);
+      if (emitted) {
+        ConduitGrpcSdk.Metrics?.increment('event_relays_emitted_total');
+      } else {
+        ConduitGrpcSdk.Metrics?.increment('event_relays_empty_room_total');
+      }
+    } catch (err) {
+      ConduitGrpcSdk.Metrics?.increment('event_relays_failed_total');
+      ConduitGrpcSdk.Logger.error(
+        `Event relay ${relay.relayId} emit failed on ${channel}: ${
+          err instanceof Error ? err.message : String(err)
+        }`,
       );
     }
   }

--- a/modules/router/src/event-relays/EventRelaySockets.ts
+++ b/modules/router/src/event-relays/EventRelaySockets.ts
@@ -1,11 +1,23 @@
 import { status } from '@grpc/grpc-js';
 import { ConduitGrpcSdk, GrpcError, TYPE } from '@conduitplatform/grpc-sdk';
 import { ConduitSocket, ConduitSocketEvent } from '@conduitplatform/hermes';
-import { EVENTS_NAMESPACE } from './constants.js';
+import {
+  EVENTS_NAMESPACE,
+  MAX_ROOMS_PER_SOCKET,
+  MAX_SUBSCRIBE_PER_MINUTE,
+} from './constants.js';
 import { EventRelayManager } from './EventRelayManager.js';
 import { eventRelayRoom } from './rooms.js';
 import { validateResourceId } from './validation.js';
 import { authorizeRelaySubscription, toSubscriptionError } from './authorize.js';
+
+type RelaySubscription = {
+  relayId: string;
+  resourceId: string;
+};
+
+const subscriptionsBySocket = new Map<string, RelaySubscription[]>();
+const subscribeTimestamps = new Map<string, number[]>();
 
 export function createEventsSocket(
   grpcSdk: ConduitGrpcSdk,
@@ -20,16 +32,27 @@ export function createEventsSocket(
 
   events.set('disconnect', {
     name: 'disconnect',
-    handler: async () => ({ event: 'leave-room', rooms: [] }),
+    handler: async request => {
+      subscriptionsBySocket.delete(request.socketId);
+      subscribeTimestamps.delete(request.socketId);
+      return { event: 'leave-room', rooms: [] };
+    },
   });
 
   events.set('subscribe', {
     name: 'subscribe',
     params: [TYPE.String, TYPE.String],
     handler: async request => {
+      assertSubscribeRateLimit(request.socketId);
       const userId = request.context?.user?._id as string | undefined;
       const [relayId, resourceId] = request.params ?? [];
       const room = await authorizeOrThrow(grpcSdk, manager, userId, relayId, resourceId);
+      trackSubscription(
+        request.socketId,
+        String(relayId),
+        validateResourceId(resourceId),
+        room,
+      );
       return { event: 'join-room', rooms: [room] };
     },
   });
@@ -44,6 +67,7 @@ export function createEventsSocket(
       }
       try {
         const validatedResourceId = validateResourceId(resourceId);
+        removeSubscription(request.socketId, relayId, validatedResourceId);
         return {
           event: 'leave-room',
           rooms: [eventRelayRoom(relayId, validatedResourceId)],
@@ -60,8 +84,89 @@ export function createEventsSocket(
       name: 'eventRelays',
       description: 'Declarative bus-to-socket event relays',
       middlewares: ['authMiddleware'],
+      onRecovered: async request =>
+        reauthorizeRecoveredSubscriptions(grpcSdk, manager, request),
     },
     events,
+  );
+}
+
+async function reauthorizeRecoveredSubscriptions(
+  grpcSdk: ConduitGrpcSdk,
+  manager: EventRelayManager,
+  request: { socketId: string; context?: { user?: { _id?: string } } },
+) {
+  const userId = request.context?.user?._id as string | undefined;
+  const subs = subscriptionsBySocket.get(request.socketId) ?? [];
+  const keepRooms: string[] = [];
+  for (const sub of subs) {
+    try {
+      const room = await authorizeRelaySubscription(
+        grpcSdk,
+        manager,
+        userId,
+        sub.relayId,
+        sub.resourceId,
+        () => {
+          ConduitGrpcSdk.Metrics?.increment('event_relay_subscriptions_denied_total');
+        },
+      );
+      keepRooms.push(room);
+    } catch {
+      ConduitGrpcSdk.Metrics?.increment('event_relay_subscriptions_denied_total');
+    }
+  }
+  const leaveRooms = subs
+    .map(sub => eventRelayRoom(sub.relayId, sub.resourceId))
+    .filter(room => !keepRooms.includes(room));
+  if (leaveRooms.length > 0) {
+    return { event: 'leave-room' as const, rooms: leaveRooms };
+  }
+  return { event: 'join-room' as const, rooms: [] };
+}
+
+function assertSubscribeRateLimit(socketId: string): void {
+  const now = Date.now();
+  const windowStart = now - 60_000;
+  const timestamps = (subscribeTimestamps.get(socketId) ?? []).filter(
+    t => t >= windowStart,
+  );
+  if (timestamps.length >= MAX_SUBSCRIBE_PER_MINUTE) {
+    throw new GrpcError(status.RESOURCE_EXHAUSTED, 'Subscribe rate limit exceeded');
+  }
+  timestamps.push(now);
+  subscribeTimestamps.set(socketId, timestamps);
+}
+
+function trackSubscription(
+  socketId: string,
+  relayId: string,
+  resourceId: string,
+  room: string,
+): void {
+  const subs = subscriptionsBySocket.get(socketId) ?? [];
+  const withoutDuplicate = subs.filter(
+    sub => !(sub.relayId === relayId && sub.resourceId === resourceId),
+  );
+  withoutDuplicate.push({ relayId, resourceId });
+  if (withoutDuplicate.length > MAX_ROOMS_PER_SOCKET) {
+    throw new GrpcError(
+      status.RESOURCE_EXHAUSTED,
+      `Cannot subscribe to more than ${MAX_ROOMS_PER_SOCKET} relay rooms`,
+    );
+  }
+  subscriptionsBySocket.set(socketId, withoutDuplicate);
+  void room;
+}
+
+function removeSubscription(socketId: string, relayId: string, resourceId: string): void {
+  const subs = subscriptionsBySocket.get(socketId);
+  if (!subs) {
+    return;
+  }
+  subscriptionsBySocket.set(
+    socketId,
+    subs.filter(sub => !(sub.relayId === relayId && sub.resourceId === resourceId)),
   );
 }
 
@@ -94,3 +199,9 @@ function toGrpcError(err: unknown): GrpcError {
 }
 
 export { authorizeRelaySubscription } from './authorize.js';
+
+/** @internal test helper */
+export function _clearEventRelaySocketStateForTests(): void {
+  subscriptionsBySocket.clear();
+  subscribeTimestamps.clear();
+}

--- a/modules/router/src/event-relays/EventRelaySockets.ts
+++ b/modules/router/src/event-relays/EventRelaySockets.ts
@@ -9,10 +9,10 @@ import { EventRelayManager } from './EventRelayManager.js';
 import { eventRelayRoom } from './rooms.js';
 import { validateResourceId } from './validation.js';
 import { authorizeRelaySubscription, toSubscriptionError } from './authorize.js';
+import { reauthorizeRecoveredSubscriptions } from './recovery.js';
 import {
-  clearSocketSubscriptionTracking,
+  releaseSocketSubscriptions,
   removeSubscription,
-  subscriptionsForUser,
   trackSubscription,
   _clearEventRelaySubscriptionStateForTests,
 } from './subscriptions.js';
@@ -33,7 +33,8 @@ export function createEventsSocket(
   events.set('disconnect', {
     name: 'disconnect',
     handler: async request => {
-      clearSocketSubscriptionTracking(request.socketId);
+      const userId = request.context?.user?._id as string | undefined;
+      releaseSocketSubscriptions(request.socketId, userId);
       subscribeTimestamps.delete(request.socketId);
       return { event: 'leave-room', rooms: [] };
     },
@@ -100,45 +101,6 @@ export function createEventsSocket(
     },
     events,
   );
-}
-
-async function reauthorizeRecoveredSubscriptions(
-  grpcSdk: ConduitGrpcSdk,
-  manager: EventRelayManager,
-  request: { socketId: string; context?: { user?: { _id?: string } } },
-) {
-  const userId = request.context?.user?._id as string | undefined;
-  if (!userId) {
-    return { event: 'leave-room' as const, rooms: [] };
-  }
-  const subs = subscriptionsForUser(userId);
-  const keepRooms: string[] = [];
-  for (const sub of subs) {
-    try {
-      const room = await authorizeRelaySubscription(
-        grpcSdk,
-        manager,
-        userId,
-        sub.relayId,
-        sub.resourceId,
-        () => {
-          ConduitGrpcSdk.Metrics?.increment('event_relay_subscriptions_denied_total');
-        },
-      );
-      keepRooms.push(room);
-      trackSubscription(request.socketId, userId, sub.relayId, sub.resourceId);
-    } catch {
-      removeSubscription(request.socketId, userId, sub.relayId, sub.resourceId);
-      ConduitGrpcSdk.Metrics?.increment('event_relay_subscriptions_denied_total');
-    }
-  }
-  const leaveRooms = subs
-    .map(sub => eventRelayRoom(sub.relayId, sub.resourceId))
-    .filter(room => !keepRooms.includes(room));
-  if (leaveRooms.length > 0) {
-    return { event: 'leave-room' as const, rooms: leaveRooms };
-  }
-  return { event: 'join-room' as const, rooms: [] };
 }
 
 function assertSubscribeRateLimit(socketId: string): void {

--- a/modules/router/src/event-relays/EventRelaySockets.ts
+++ b/modules/router/src/event-relays/EventRelaySockets.ts
@@ -16,6 +16,10 @@ import {
   trackSubscription,
   _clearEventRelaySubscriptionStateForTests,
 } from './subscriptions.js';
+import {
+  persistRelaySubscriptionOnContext,
+  removeRelaySubscriptionFromContext,
+} from './relaySocketData.js';
 
 const subscribeTimestamps = new Map<string, number[]>();
 
@@ -50,14 +54,16 @@ export function createEventsSocket(
         throw new GrpcError(status.UNAUTHENTICATED, 'Authentication required');
       }
       const [relayId, resourceId] = request.params ?? [];
+      const validatedResourceId = validateResourceId(resourceId);
       const room = await authorizeOrThrow(grpcSdk, manager, userId, relayId, resourceId);
       try {
         trackSubscription(
           request.socketId,
           userId,
           String(relayId),
-          validateResourceId(resourceId),
+          validatedResourceId,
         );
+        persistRelaySubscriptionOnContext(request.context, String(relayId), validatedResourceId);
       } catch (err) {
         throw new GrpcError(
           status.RESOURCE_EXHAUSTED,
@@ -80,6 +86,7 @@ export function createEventsSocket(
       try {
         const validatedResourceId = validateResourceId(resourceId);
         removeSubscription(request.socketId, userId, relayId, validatedResourceId);
+        removeRelaySubscriptionFromContext(request.context, relayId, validatedResourceId);
         return {
           event: 'leave-room',
           rooms: [eventRelayRoom(relayId, validatedResourceId)],

--- a/modules/router/src/event-relays/EventRelaySockets.ts
+++ b/modules/router/src/event-relays/EventRelaySockets.ts
@@ -3,20 +3,20 @@ import { ConduitGrpcSdk, GrpcError, TYPE } from '@conduitplatform/grpc-sdk';
 import { ConduitSocket, ConduitSocketEvent } from '@conduitplatform/hermes';
 import {
   EVENTS_NAMESPACE,
-  MAX_ROOMS_PER_SOCKET,
   MAX_SUBSCRIBE_PER_MINUTE,
 } from './constants.js';
 import { EventRelayManager } from './EventRelayManager.js';
 import { eventRelayRoom } from './rooms.js';
 import { validateResourceId } from './validation.js';
 import { authorizeRelaySubscription, toSubscriptionError } from './authorize.js';
+import {
+  clearSocketSubscriptionTracking,
+  removeSubscription,
+  subscriptionsForUser,
+  trackSubscription,
+  _clearEventRelaySubscriptionStateForTests,
+} from './subscriptions.js';
 
-type RelaySubscription = {
-  relayId: string;
-  resourceId: string;
-};
-
-const subscriptionsBySocket = new Map<string, RelaySubscription[]>();
 const subscribeTimestamps = new Map<string, number[]>();
 
 export function createEventsSocket(
@@ -33,7 +33,7 @@ export function createEventsSocket(
   events.set('disconnect', {
     name: 'disconnect',
     handler: async request => {
-      subscriptionsBySocket.delete(request.socketId);
+      clearSocketSubscriptionTracking(request.socketId);
       subscribeTimestamps.delete(request.socketId);
       return { event: 'leave-room', rooms: [] };
     },
@@ -45,14 +45,24 @@ export function createEventsSocket(
     handler: async request => {
       assertSubscribeRateLimit(request.socketId);
       const userId = request.context?.user?._id as string | undefined;
+      if (!userId) {
+        throw new GrpcError(status.UNAUTHENTICATED, 'Authentication required');
+      }
       const [relayId, resourceId] = request.params ?? [];
       const room = await authorizeOrThrow(grpcSdk, manager, userId, relayId, resourceId);
-      trackSubscription(
-        request.socketId,
-        String(relayId),
-        validateResourceId(resourceId),
-        room,
-      );
+      try {
+        trackSubscription(
+          request.socketId,
+          userId,
+          String(relayId),
+          validateResourceId(resourceId),
+        );
+      } catch (err) {
+        throw new GrpcError(
+          status.RESOURCE_EXHAUSTED,
+          err instanceof Error ? err.message : 'Subscription limit exceeded',
+        );
+      }
       return { event: 'join-room', rooms: [room] };
     },
   });
@@ -61,13 +71,14 @@ export function createEventsSocket(
     name: 'unsubscribe',
     params: [TYPE.String, TYPE.String],
     handler: async request => {
+      const userId = request.context?.user?._id as string | undefined;
       const [relayId, resourceId] = request.params ?? [];
       if (typeof relayId !== 'string' || relayId.trim() === '') {
         throw new GrpcError(status.INVALID_ARGUMENT, 'Relay ID is required');
       }
       try {
         const validatedResourceId = validateResourceId(resourceId);
-        removeSubscription(request.socketId, relayId, validatedResourceId);
+        removeSubscription(request.socketId, userId, relayId, validatedResourceId);
         return {
           event: 'leave-room',
           rooms: [eventRelayRoom(relayId, validatedResourceId)],
@@ -97,7 +108,10 @@ async function reauthorizeRecoveredSubscriptions(
   request: { socketId: string; context?: { user?: { _id?: string } } },
 ) {
   const userId = request.context?.user?._id as string | undefined;
-  const subs = subscriptionsBySocket.get(request.socketId) ?? [];
+  if (!userId) {
+    return { event: 'leave-room' as const, rooms: [] };
+  }
+  const subs = subscriptionsForUser(userId);
   const keepRooms: string[] = [];
   for (const sub of subs) {
     try {
@@ -112,7 +126,9 @@ async function reauthorizeRecoveredSubscriptions(
         },
       );
       keepRooms.push(room);
+      trackSubscription(request.socketId, userId, sub.relayId, sub.resourceId);
     } catch {
+      removeSubscription(request.socketId, userId, sub.relayId, sub.resourceId);
       ConduitGrpcSdk.Metrics?.increment('event_relay_subscriptions_denied_total');
     }
   }
@@ -136,38 +152,6 @@ function assertSubscribeRateLimit(socketId: string): void {
   }
   timestamps.push(now);
   subscribeTimestamps.set(socketId, timestamps);
-}
-
-function trackSubscription(
-  socketId: string,
-  relayId: string,
-  resourceId: string,
-  room: string,
-): void {
-  const subs = subscriptionsBySocket.get(socketId) ?? [];
-  const withoutDuplicate = subs.filter(
-    sub => !(sub.relayId === relayId && sub.resourceId === resourceId),
-  );
-  withoutDuplicate.push({ relayId, resourceId });
-  if (withoutDuplicate.length > MAX_ROOMS_PER_SOCKET) {
-    throw new GrpcError(
-      status.RESOURCE_EXHAUSTED,
-      `Cannot subscribe to more than ${MAX_ROOMS_PER_SOCKET} relay rooms`,
-    );
-  }
-  subscriptionsBySocket.set(socketId, withoutDuplicate);
-  void room;
-}
-
-function removeSubscription(socketId: string, relayId: string, resourceId: string): void {
-  const subs = subscriptionsBySocket.get(socketId);
-  if (!subs) {
-    return;
-  }
-  subscriptionsBySocket.set(
-    socketId,
-    subs.filter(sub => !(sub.relayId === relayId && sub.resourceId === resourceId)),
-  );
 }
 
 async function authorizeOrThrow(
@@ -202,6 +186,6 @@ export { authorizeRelaySubscription } from './authorize.js';
 
 /** @internal test helper */
 export function _clearEventRelaySocketStateForTests(): void {
-  subscriptionsBySocket.clear();
+  _clearEventRelaySubscriptionStateForTests();
   subscribeTimestamps.clear();
 }

--- a/modules/router/src/event-relays/authorize.ts
+++ b/modules/router/src/event-relays/authorize.ts
@@ -62,7 +62,6 @@ export async function authorizeRelaySubscription(
   }
 
   if (!grpcSdk.authorization || !grpcSdk.isAvailable('authorization')) {
-    onDenied?.();
     throw new RelaySubscriptionError(status.UNAVAILABLE, 'Authorization is unavailable');
   }
 
@@ -75,7 +74,6 @@ export async function authorizeRelaySubscription(
     });
     allowed = decision.allow;
   } catch {
-    onDenied?.();
     throw new RelaySubscriptionError(status.UNAVAILABLE, 'Authorization check failed');
   }
 

--- a/modules/router/src/event-relays/compile.ts
+++ b/modules/router/src/event-relays/compile.ts
@@ -1,0 +1,50 @@
+import { requireOwnPath } from './path.js';
+import { eventRelayRoom } from './rooms.js';
+import { renderMessageTemplate } from './template.js';
+import { validateResourceId } from './validation.js';
+
+export type RelayCompileInput = {
+  _id: string;
+  busEvent: string;
+  socketEvent: string;
+  resourceIdPath: string;
+  messageTemplate: unknown;
+  permission: string;
+  resourceType: string;
+};
+
+export type CompiledRelay = {
+  relayId: string;
+  busEvent: string;
+  socketEvent: string;
+  permission: string;
+  resourceType: string;
+  buildEmission: (payload: unknown) => {
+    room: string;
+    data: unknown;
+    resourceId: string;
+  };
+};
+
+export function compileRelay(relay: RelayCompileInput): CompiledRelay {
+  const resourceIdPath = relay.resourceIdPath;
+  const template = relay.messageTemplate;
+  return {
+    relayId: relay._id,
+    busEvent: relay.busEvent,
+    socketEvent: relay.socketEvent,
+    permission: relay.permission,
+    resourceType: relay.resourceType,
+    buildEmission: (payload: unknown) => {
+      const resourceId = validateResourceId(
+        requireOwnPath(payload, resourceIdPath, 'Resource ID path'),
+      );
+      const data = renderMessageTemplate(template, payload);
+      return {
+        room: eventRelayRoom(relay._id, resourceId),
+        data,
+        resourceId,
+      };
+    },
+  };
+}

--- a/modules/router/src/event-relays/constants.ts
+++ b/modules/router/src/event-relays/constants.ts
@@ -15,6 +15,12 @@ export const MAX_RESOURCE_ID_LENGTH = 128;
 export const MAX_RESOURCE_ID_PATH_LENGTH = 128;
 export const MAX_PERMISSION_LENGTH = 64;
 
+export const MAX_INBOUND_BUS_BYTES = 256 * 1024;
+export const RECONCILE_INTERVAL_MS = 30_000;
+export const MAX_SUBSCRIBE_PER_MINUTE = 30;
+export const MAX_ROOMS_PER_SOCKET = 32;
+export const RELAY_REBAC_TTL_MS = 12_000;
+
 export const FORBIDDEN_PATH_SEGMENTS = new Set(['__proto__', 'constructor', 'prototype']);
 
 export const RESERVED_SOCKET_EVENTS = new Set([

--- a/modules/router/src/event-relays/follow-up.test.ts
+++ b/modules/router/src/event-relays/follow-up.test.ts
@@ -1,16 +1,29 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 import {
+  releaseSocketSubscriptions,
+  removeSubscriptionsForRelay,
   subscriptionsForUser,
   trackSubscription,
-  removeSubscriptionsForRelay,
   _clearEventRelaySubscriptionStateForTests,
 } from './subscriptions.js';
+import { eventRelayRoom } from './rooms.js';
+import { reauthorizeRecoveredSubscriptions } from './recovery.js';
+import { RelayLookup } from './authorize.js';
 
 describe('event relay subscription tracking', () => {
-  it('keeps user subscriptions after socket disconnect for recovery', () => {
+  it('clears user map entries when the only socket disconnects', () => {
     _clearEventRelaySubscriptionStateForTests();
     trackSubscription('socket-a', 'user-1', 'relay-1', 'order-1');
+    releaseSocketSubscriptions('socket-a', 'user-1');
+    assert.deepEqual(subscriptionsForUser('user-1'), []);
+  });
+
+  it('keeps user map entries when another socket still holds the subscription', () => {
+    _clearEventRelaySubscriptionStateForTests();
+    trackSubscription('socket-a', 'user-1', 'relay-1', 'order-1');
+    trackSubscription('socket-b', 'user-1', 'relay-1', 'order-1');
+    releaseSocketSubscriptions('socket-a', 'user-1');
     assert.deepEqual(subscriptionsForUser('user-1'), [
       { relayId: 'relay-1', resourceId: 'order-1' },
     ]);
@@ -20,6 +33,102 @@ describe('event relay subscription tracking', () => {
     _clearEventRelaySubscriptionStateForTests();
     trackSubscription('socket-a', 'user-1', 'relay-1', 'order-1');
     removeSubscriptionsForRelay('relay-1');
+    assert.deepEqual(subscriptionsForUser('user-1'), []);
+  });
+});
+
+describe('recovery re-authorization', () => {
+  const room = eventRelayRoom('relay-1', 'order-1');
+  const relay = {
+    _id: 'relay-1',
+    permission: 'read',
+    resourceType: 'Order',
+  };
+
+  it('keeps restored rooms when Authorization is unavailable', async () => {
+    _clearEventRelaySubscriptionStateForTests();
+    trackSubscription('old-socket', 'user-1', 'relay-1', 'order-1');
+    releaseSocketSubscriptions('old-socket', 'user-1');
+
+    const manager = {
+      getActiveRelay: (id: string) => (id === 'relay-1' ? relay : undefined),
+    } as unknown as RelayLookup;
+
+    const grpcSdk = {
+      isAvailable: () => false,
+      authorization: null,
+    };
+
+    const result = await reauthorizeRecoveredSubscriptions(grpcSdk, manager, {
+      socketId: 'new-socket',
+      context: { user: { _id: 'user-1' } },
+      recoveredRooms: [room],
+    });
+
+    assert.deepEqual(result, { event: 'join-room', rooms: [] });
+    assert.deepEqual(subscriptionsForUser('user-1'), [
+      { relayId: 'relay-1', resourceId: 'order-1' },
+    ]);
+  });
+
+  it('leaves restored rooms on permission deny', async () => {
+    _clearEventRelaySubscriptionStateForTests();
+    trackSubscription('old-socket', 'user-1', 'relay-1', 'order-1');
+    releaseSocketSubscriptions('old-socket', 'user-1');
+
+    const manager = {
+      getActiveRelay: (id: string) => (id === 'relay-1' ? relay : undefined),
+    } as unknown as RelayLookup;
+
+    const grpcSdk = {
+      isAvailable: () => true,
+      authorization: {
+        can: async () => ({ allow: false }),
+      },
+    };
+
+    const result = await reauthorizeRecoveredSubscriptions(grpcSdk, manager, {
+      socketId: 'new-socket',
+      context: { user: { _id: 'user-1' } },
+      recoveredRooms: [room],
+    });
+
+    assert.deepEqual(result, { event: 'leave-room', rooms: [room] });
+    assert.deepEqual(subscriptionsForUser('user-1'), []);
+  });
+
+  it('does not re-auth rooms outside the recovered socket session', async () => {
+    _clearEventRelaySubscriptionStateForTests();
+    trackSubscription('old-socket', 'user-1', 'relay-1', 'order-1');
+    trackSubscription('old-socket', 'user-1', 'relay-2', 'order-2');
+    releaseSocketSubscriptions('old-socket', 'user-1');
+
+    const manager = {
+      getActiveRelay: (id: string) =>
+        id === 'relay-2'
+          ? { _id: 'relay-2', permission: 'read', resourceType: 'Order' }
+          : undefined,
+    } as unknown as RelayLookup;
+
+    let canCalls = 0;
+    const grpcSdk = {
+      isAvailable: () => true,
+      authorization: {
+        can: async () => {
+          canCalls++;
+          return { allow: false };
+        },
+      },
+    };
+
+    const otherRoom = eventRelayRoom('relay-2', 'order-2');
+    await reauthorizeRecoveredSubscriptions(grpcSdk, manager, {
+      socketId: 'new-socket',
+      context: { user: { _id: 'user-1' } },
+      recoveredRooms: [otherRoom],
+    });
+
+    assert.equal(canCalls, 1);
     assert.deepEqual(subscriptionsForUser('user-1'), []);
   });
 });

--- a/modules/router/src/event-relays/follow-up.test.ts
+++ b/modules/router/src/event-relays/follow-up.test.ts
@@ -3,6 +3,7 @@ import { describe, it } from 'node:test';
 import {
   releaseSocketSubscriptions,
   removeSubscriptionsForRelay,
+  subscriptionsForRecoveredRooms,
   subscriptionsForUser,
   trackSubscription,
   _clearEventRelaySubscriptionStateForTests,
@@ -61,7 +62,10 @@ describe('recovery re-authorization', () => {
 
     const result = await reauthorizeRecoveredSubscriptions(grpcSdk, manager, {
       socketId: 'new-socket',
-      context: { user: { _id: 'user-1' } },
+      context: {
+        user: { _id: 'user-1' },
+        eventRelaySubs: [{ relayId: 'relay-1', resourceId: 'order-1' }],
+      },
       recoveredRooms: [room],
     });
 
@@ -89,7 +93,10 @@ describe('recovery re-authorization', () => {
 
     const result = await reauthorizeRecoveredSubscriptions(grpcSdk, manager, {
       socketId: 'new-socket',
-      context: { user: { _id: 'user-1' } },
+      context: {
+        user: { _id: 'user-1' },
+        eventRelaySubs: [{ relayId: 'relay-1', resourceId: 'order-1' }],
+      },
       recoveredRooms: [room],
     });
 
@@ -124,11 +131,56 @@ describe('recovery re-authorization', () => {
     const otherRoom = eventRelayRoom('relay-2', 'order-2');
     await reauthorizeRecoveredSubscriptions(grpcSdk, manager, {
       socketId: 'new-socket',
-      context: { user: { _id: 'user-1' } },
+      context: {
+        user: { _id: 'user-1' },
+        eventRelaySubs: [{ relayId: 'relay-2', resourceId: 'order-2' }],
+      },
       recoveredRooms: [otherRoom],
     });
 
     assert.equal(canCalls, 1);
     assert.deepEqual(subscriptionsForUser('user-1'), []);
+  });
+
+  it('re-auths the first user after a second user subscribed to the same room', async () => {
+    _clearEventRelaySubscriptionStateForTests();
+    trackSubscription('socket-a', 'user-a', 'relay-1', 'order-1');
+    trackSubscription('socket-b', 'user-b', 'relay-1', 'order-1');
+    releaseSocketSubscriptions('socket-b', 'user-b');
+
+    let checkedSubject = '';
+    const manager = {
+      getActiveRelay: (id: string) => (id === 'relay-1' ? relay : undefined),
+    } as unknown as RelayLookup;
+    const grpcSdk = {
+      isAvailable: () => true,
+      authorization: {
+        can: async (request: { subject: string }) => {
+          checkedSubject = request.subject;
+          return { allow: true };
+        },
+      },
+    };
+
+    await reauthorizeRecoveredSubscriptions(grpcSdk, manager, {
+      socketId: 'socket-a-new',
+      context: { user: { _id: 'user-a' } },
+      recoveredRooms: [room],
+    });
+
+    assert.equal(checkedSubject, 'User:user-a');
+  });
+
+  it('prefers socket.data subscriptions when the room map was pruned on disconnect', () => {
+    _clearEventRelaySubscriptionStateForTests();
+    trackSubscription('socket-a', 'user-a', 'relay-1', 'order-1');
+    releaseSocketSubscriptions('socket-a', 'user-a');
+    assert.deepEqual(subscriptionsForRecoveredRooms([room]), []);
+    assert.deepEqual(
+      subscriptionsForRecoveredRooms([room], [
+        { relayId: 'relay-1', resourceId: 'order-1' },
+      ]),
+      [{ relayId: 'relay-1', resourceId: 'order-1' }],
+    );
   });
 });

--- a/modules/router/src/event-relays/follow-up.test.ts
+++ b/modules/router/src/event-relays/follow-up.test.ts
@@ -1,0 +1,25 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import {
+  subscriptionsForUser,
+  trackSubscription,
+  removeSubscriptionsForRelay,
+  _clearEventRelaySubscriptionStateForTests,
+} from './subscriptions.js';
+
+describe('event relay subscription tracking', () => {
+  it('keeps user subscriptions after socket disconnect for recovery', () => {
+    _clearEventRelaySubscriptionStateForTests();
+    trackSubscription('socket-a', 'user-1', 'relay-1', 'order-1');
+    assert.deepEqual(subscriptionsForUser('user-1'), [
+      { relayId: 'relay-1', resourceId: 'order-1' },
+    ]);
+  });
+
+  it('clears relay subscriptions on eviction', () => {
+    _clearEventRelaySubscriptionStateForTests();
+    trackSubscription('socket-a', 'user-1', 'relay-1', 'order-1');
+    removeSubscriptionsForRelay('relay-1');
+    assert.deepEqual(subscriptionsForUser('user-1'), []);
+  });
+});

--- a/modules/router/src/event-relays/interventions.test.ts
+++ b/modules/router/src/event-relays/interventions.test.ts
@@ -1,0 +1,23 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { MAX_INBOUND_BUS_BYTES } from './constants.js';
+import { parseBusPayload } from './process.js';
+import { renderMessageTemplate } from './template.js';
+
+describe('parseBusPayload inbound cap', () => {
+  it('drops payloads larger than 256KiB before JSON.parse', () => {
+    const oversized = JSON.stringify({ blob: 'x'.repeat(MAX_INBOUND_BUS_BYTES) });
+    assert.throws(() => parseBusPayload(oversized), /exceeds/);
+  });
+});
+
+describe('preview renderer parity', () => {
+  it('renders templates the same as runtime processing', () => {
+    const payload = { documentId: 'doc-1', nested: { value: 2 } };
+    const template = { id: '{{payload.documentId}}', n: '{{payload.nested.value}}' };
+    assert.deepEqual(renderMessageTemplate(template, payload), {
+      id: 'doc-1',
+      n: 2,
+    });
+  });
+});

--- a/modules/router/src/event-relays/process.test.ts
+++ b/modules/router/src/event-relays/process.test.ts
@@ -69,6 +69,7 @@ describe('createEventRelayPusher', () => {
     const calls: unknown[] = [];
     const push = createEventRelayPusher(async data => {
       calls.push(data);
+      return true;
     });
     await push('order-updated', { id: '1' }, ['room-1']);
     assert.deepEqual(calls, [
@@ -79,6 +80,8 @@ describe('createEventRelayPusher', () => {
         rooms: ['room-1'],
         namespace: EVENTS_NAMESPACE,
         localOnly: true,
+        skipEmptyRooms: true,
+        boundedEmit: true,
       },
     ]);
   });

--- a/modules/router/src/event-relays/process.ts
+++ b/modules/router/src/event-relays/process.ts
@@ -49,6 +49,21 @@ export function parseBusPayload(
   }
 }
 
+export function assertJsonPayloadSize(
+  payload: unknown,
+  maxBytes: number = MAX_INBOUND_BUS_BYTES,
+): void {
+  let serialized: string;
+  try {
+    serialized = JSON.stringify(payload);
+  } catch {
+    throw new EventRelayValidationError('Sample payload must be valid JSON');
+  }
+  if (Buffer.byteLength(serialized, 'utf8') > maxBytes) {
+    throw new EventRelayValidationError(`Sample payload exceeds ${maxBytes} bytes`);
+  }
+}
+
 export function buildRelayEmissions(
   relays: RelayProcessInput[],
   payload: unknown,

--- a/modules/router/src/event-relays/process.ts
+++ b/modules/router/src/event-relays/process.ts
@@ -3,6 +3,7 @@ import { eventRelayRoom } from './rooms.js';
 import { renderMessageTemplate } from './template.js';
 import { validateResourceId } from './validation.js';
 import { EventRelayValidationError } from './validationError.js';
+import { MAX_INBOUND_BUS_BYTES } from './constants.js';
 
 export type RelayProcessInput = {
   _id: string;
@@ -31,9 +32,15 @@ export type ProcessResult = {
   failures: RelayFailure[];
 };
 
-export function parseBusPayload(rawMessage: string): unknown {
+export function parseBusPayload(
+  rawMessage: string,
+  maxBytes: number = MAX_INBOUND_BUS_BYTES,
+): unknown {
   if (typeof rawMessage !== 'string' || rawMessage.trim() === '') {
     throw new EventRelayValidationError('Bus payload is empty');
+  }
+  if (Buffer.byteLength(rawMessage, 'utf8') > maxBytes) {
+    throw new EventRelayValidationError(`Bus payload exceeds ${maxBytes} bytes`);
   }
   try {
     return JSON.parse(rawMessage);

--- a/modules/router/src/event-relays/push.ts
+++ b/modules/router/src/event-relays/push.ts
@@ -4,7 +4,8 @@ export type EventRelayPusher = (
   event: string,
   data: unknown,
   rooms: string[],
-) => Promise<void>;
+  receivers?: string[],
+) => Promise<boolean>;
 
 export type SocketPushFn = (data: {
   event: string;
@@ -13,16 +14,20 @@ export type SocketPushFn = (data: {
   rooms: string[];
   namespace: string;
   localOnly?: boolean;
-}) => Promise<void>;
+  skipEmptyRooms?: boolean;
+  boundedEmit?: boolean;
+}) => Promise<boolean>;
 
 export function createEventRelayPusher(socketPush: SocketPushFn): EventRelayPusher {
-  return (event, data, rooms) =>
+  return async (event, data, rooms, receivers = []) =>
     socketPush({
       event,
       data,
-      receivers: [],
+      receivers,
       rooms,
       namespace: EVENTS_NAMESPACE,
       localOnly: true,
+      skipEmptyRooms: event !== 'leave-room',
+      boundedEmit: event !== 'leave-room',
     });
 }

--- a/modules/router/src/event-relays/rebacCache.test.ts
+++ b/modules/router/src/event-relays/rebacCache.test.ts
@@ -1,0 +1,30 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { RelayRebacCache } from './rebacCache.js';
+
+describe('RelayRebacCache', () => {
+  it('denies after TTL when authorization revokes access', async () => {
+    let allow = true;
+    const cache = new RelayRebacCache(10);
+    const grpcSdk = {
+      isAvailable: () => true,
+      authorization: {
+        can: async () => ({ allow }),
+      },
+    };
+    assert.equal(
+      await cache.can(grpcSdk as never, 'user-1', 'read', 'Order', 'order-1'),
+      true,
+    );
+    allow = false;
+    assert.equal(
+      await cache.can(grpcSdk as never, 'user-1', 'read', 'Order', 'order-1'),
+      true,
+    );
+    await new Promise(resolve => setTimeout(resolve, 15));
+    assert.equal(
+      await cache.can(grpcSdk as never, 'user-1', 'read', 'Order', 'order-1'),
+      false,
+    );
+  });
+});

--- a/modules/router/src/event-relays/rebacCache.test.ts
+++ b/modules/router/src/event-relays/rebacCache.test.ts
@@ -13,18 +13,31 @@ describe('RelayRebacCache', () => {
       },
     };
     assert.equal(
-      await cache.can(grpcSdk as never, 'user-1', 'read', 'Order', 'order-1'),
-      true,
+      await cache.check(grpcSdk as never, 'user-1', 'read', 'Order', 'order-1'),
+      'allow',
     );
     allow = false;
     assert.equal(
-      await cache.can(grpcSdk as never, 'user-1', 'read', 'Order', 'order-1'),
-      true,
+      await cache.check(grpcSdk as never, 'user-1', 'read', 'Order', 'order-1'),
+      'allow',
     );
     await new Promise(resolve => setTimeout(resolve, 15));
     assert.equal(
-      await cache.can(grpcSdk as never, 'user-1', 'read', 'Order', 'order-1'),
-      false,
+      await cache.check(grpcSdk as never, 'user-1', 'read', 'Order', 'order-1'),
+      'deny',
+    );
+  });
+
+  it('returns unavailable without caching when Authorization is down', async () => {
+    const cache = new RelayRebacCache(10_000);
+    const grpcSdk = { isAvailable: () => false, authorization: null };
+    assert.equal(
+      await cache.check(grpcSdk as never, 'user-1', 'read', 'Order', 'order-1'),
+      'unavailable',
+    );
+    assert.equal(
+      await cache.check(grpcSdk as never, 'user-1', 'read', 'Order', 'order-1'),
+      'unavailable',
     );
   });
 });

--- a/modules/router/src/event-relays/rebacCache.ts
+++ b/modules/router/src/event-relays/rebacCache.ts
@@ -1,0 +1,59 @@
+type RebacSdk = {
+  isAvailable: (module: string) => boolean;
+  authorization?: {
+    can: (request: {
+      subject: string;
+      actions: string[];
+      resource: string;
+    }) => Promise<{ allow: boolean }>;
+  } | null;
+};
+
+const DEFAULT_TTL_MS = 12_000;
+
+type CacheEntry = {
+  allow: boolean;
+  expiresAt: number;
+};
+
+export class RelayRebacCache {
+  private readonly entries = new Map<string, CacheEntry>();
+  constructor(private readonly ttlMs: number = DEFAULT_TTL_MS) {}
+
+  async can(
+    grpcSdk: RebacSdk,
+    userId: string,
+    permission: string,
+    resourceType: string,
+    resourceId: string,
+  ): Promise<boolean> {
+    const resource = `${resourceType}:${resourceId}`;
+    const key = `${userId}:${permission}:${resource}`;
+    const now = Date.now();
+    const cached = this.entries.get(key);
+    if (cached && cached.expiresAt > now) {
+      return cached.allow;
+    }
+    if (!grpcSdk.authorization || !grpcSdk.isAvailable('authorization')) {
+      return false;
+    }
+    try {
+      const decision = await grpcSdk.authorization.can({
+        subject: `User:${userId}`,
+        actions: [permission],
+        resource,
+      });
+      this.entries.set(key, {
+        allow: decision.allow,
+        expiresAt: now + this.ttlMs,
+      });
+      return decision.allow;
+    } catch {
+      return false;
+    }
+  }
+
+  clear(): void {
+    this.entries.clear();
+  }
+}

--- a/modules/router/src/event-relays/rebacCache.ts
+++ b/modules/router/src/event-relays/rebacCache.ts
@@ -9,33 +9,40 @@ type RebacSdk = {
   } | null;
 };
 
+export type RebacDecision = 'allow' | 'deny' | 'unavailable';
+
 const DEFAULT_TTL_MS = 12_000;
+const DEFAULT_MAX_ENTRIES = 10_000;
 
 type CacheEntry = {
-  allow: boolean;
+  decision: 'allow' | 'deny';
   expiresAt: number;
 };
 
 export class RelayRebacCache {
   private readonly entries = new Map<string, CacheEntry>();
-  constructor(private readonly ttlMs: number = DEFAULT_TTL_MS) {}
+  constructor(
+    private readonly ttlMs: number = DEFAULT_TTL_MS,
+    private readonly maxEntries: number = DEFAULT_MAX_ENTRIES,
+  ) {}
 
-  async can(
+  async check(
     grpcSdk: RebacSdk,
     userId: string,
     permission: string,
     resourceType: string,
     resourceId: string,
-  ): Promise<boolean> {
+  ): Promise<RebacDecision> {
     const resource = `${resourceType}:${resourceId}`;
     const key = `${userId}:${permission}:${resource}`;
     const now = Date.now();
+    this.sweepExpired(now);
     const cached = this.entries.get(key);
     if (cached && cached.expiresAt > now) {
-      return cached.allow;
+      return cached.decision;
     }
     if (!grpcSdk.authorization || !grpcSdk.isAvailable('authorization')) {
-      return false;
+      return 'unavailable';
     }
     try {
       const decision = await grpcSdk.authorization.can({
@@ -43,17 +50,59 @@ export class RelayRebacCache {
         actions: [permission],
         resource,
       });
-      this.entries.set(key, {
-        allow: decision.allow,
-        expiresAt: now + this.ttlMs,
-      });
-      return decision.allow;
+      this.set(key, decision.allow ? 'allow' : 'deny', now);
+      return decision.allow ? 'allow' : 'deny';
     } catch {
-      return false;
+      return 'unavailable';
     }
   }
 
   clear(): void {
     this.entries.clear();
   }
+
+  private set(key: string, decision: 'allow' | 'deny', now: number): void {
+    if (this.entries.size >= this.maxEntries && !this.entries.has(key)) {
+      const firstKey = this.entries.keys().next().value;
+      if (firstKey) {
+        this.entries.delete(firstKey);
+      }
+    }
+    this.entries.set(key, { decision, expiresAt: now + this.ttlMs });
+  }
+
+  private sweepExpired(now: number): void {
+    for (const [key, entry] of this.entries) {
+      if (entry.expiresAt <= now) {
+        this.entries.delete(key);
+      }
+    }
+  }
+}
+
+export async function checkRebacBatch(
+  cache: RelayRebacCache,
+  grpcSdk: RebacSdk,
+  userIds: string[],
+  permission: string,
+  resourceType: string,
+  resourceId: string,
+  concurrency = 8,
+): Promise<Map<string, RebacDecision>> {
+  const results = new Map<string, RebacDecision>();
+  let index = 0;
+  async function worker(): Promise<void> {
+    while (index < userIds.length) {
+      const userId = userIds[index++];
+      results.set(
+        userId,
+        await cache.check(grpcSdk, userId, permission, resourceType, resourceId),
+      );
+    }
+  }
+  const workers = Array.from({ length: Math.min(concurrency, userIds.length) }, () =>
+    worker(),
+  );
+  await Promise.all(workers);
+  return results;
 }

--- a/modules/router/src/event-relays/recovery.ts
+++ b/modules/router/src/event-relays/recovery.ts
@@ -1,0 +1,77 @@
+import { status } from '@grpc/grpc-js';
+import { ConduitGrpcSdk } from '@conduitplatform/grpc-sdk';
+import {
+  authorizeRelaySubscription,
+  RelaySubscriptionError,
+  RelayLookup,
+  toSubscriptionError,
+} from './authorize.js';
+import { eventRelayRoom } from './rooms.js';
+import {
+  removeSubscription,
+  subscriptionsForRecoveredRooms,
+  trackSubscription,
+} from './subscriptions.js';
+
+type RelayAuthorizationSdk = Parameters<typeof authorizeRelaySubscription>[0];
+
+export async function reauthorizeRecoveredSubscriptions(
+  grpcSdk: RelayAuthorizationSdk,
+  manager: RelayLookup,
+  request: {
+    socketId: string;
+    context?: { user?: { _id?: string } };
+    recoveredRooms?: string[];
+  },
+): Promise<
+  { event: 'join-room'; rooms: string[] } | { event: 'leave-room'; rooms: string[] }
+> {
+  const userId = request.context?.user?._id as string | undefined;
+  if (!userId) {
+    return { event: 'leave-room', rooms: [] };
+  }
+
+  const recoveredRooms = request.recoveredRooms ?? [];
+  const subs = subscriptionsForRecoveredRooms(userId, recoveredRooms);
+  const leaveRooms: string[] = [];
+
+  for (const sub of subs) {
+    const room = eventRelayRoom(sub.relayId, sub.resourceId);
+    try {
+      await authorizeRelaySubscription(
+        grpcSdk,
+        manager,
+        userId,
+        sub.relayId,
+        sub.resourceId,
+        () => {
+          ConduitGrpcSdk.Metrics?.increment('event_relay_subscriptions_denied_total');
+        },
+      );
+      trackSubscription(request.socketId, userId, sub.relayId, sub.resourceId);
+    } catch (err) {
+      const mapped =
+        err instanceof RelaySubscriptionError ? err : toSubscriptionError(err);
+      if (mapped.code === status.UNAVAILABLE) {
+        trackSubscription(request.socketId, userId, sub.relayId, sub.resourceId);
+        continue;
+      }
+      if (
+        mapped.code === status.PERMISSION_DENIED ||
+        mapped.code === status.NOT_FOUND
+      ) {
+        removeSubscription(request.socketId, userId, sub.relayId, sub.resourceId);
+        leaveRooms.push(room);
+        ConduitGrpcSdk.Metrics?.increment('event_relay_subscriptions_denied_total');
+        continue;
+      }
+      removeSubscription(request.socketId, userId, sub.relayId, sub.resourceId);
+      leaveRooms.push(room);
+    }
+  }
+
+  if (leaveRooms.length > 0) {
+    return { event: 'leave-room', rooms: leaveRooms };
+  }
+  return { event: 'join-room', rooms: [] };
+}

--- a/modules/router/src/event-relays/recovery.ts
+++ b/modules/router/src/event-relays/recovery.ts
@@ -73,6 +73,7 @@ export async function reauthorizeRecoveredSubscriptions(
         continue;
       }
       removeSubscription(request.socketId, userId, sub.relayId, sub.resourceId);
+      removeRelaySubscriptionFromContext(request.context, sub.relayId, sub.resourceId);
       leaveRooms.push(room);
     }
   }

--- a/modules/router/src/event-relays/recovery.ts
+++ b/modules/router/src/event-relays/recovery.ts
@@ -67,6 +67,7 @@ export async function reauthorizeRecoveredSubscriptions(
         mapped.code === status.NOT_FOUND
       ) {
         removeSubscription(request.socketId, userId, sub.relayId, sub.resourceId);
+        removeRelaySubscriptionFromContext(request.context, sub.relayId, sub.resourceId);
         leaveRooms.push(room);
         ConduitGrpcSdk.Metrics?.increment('event_relay_subscriptions_denied_total');
         continue;

--- a/modules/router/src/event-relays/recovery.ts
+++ b/modules/router/src/event-relays/recovery.ts
@@ -12,6 +12,7 @@ import {
   subscriptionsForRecoveredRooms,
   trackSubscription,
 } from './subscriptions.js';
+import { relaySubscriptionsFromContext, persistRelaySubscriptionOnContext, removeRelaySubscriptionFromContext } from './relaySocketData.js';
 
 type RelayAuthorizationSdk = Parameters<typeof authorizeRelaySubscription>[0];
 
@@ -20,7 +21,7 @@ export async function reauthorizeRecoveredSubscriptions(
   manager: RelayLookup,
   request: {
     socketId: string;
-    context?: { user?: { _id?: string } };
+    context?: { user?: { _id?: string } } & Record<string, unknown>;
     recoveredRooms?: string[];
   },
 ): Promise<
@@ -32,7 +33,10 @@ export async function reauthorizeRecoveredSubscriptions(
   }
 
   const recoveredRooms = request.recoveredRooms ?? [];
-  const subs = subscriptionsForRecoveredRooms(userId, recoveredRooms);
+  const subs = subscriptionsForRecoveredRooms(
+    recoveredRooms,
+    relaySubscriptionsFromContext(request.context),
+  );
   const leaveRooms: string[] = [];
 
   for (const sub of subs) {
@@ -49,11 +53,13 @@ export async function reauthorizeRecoveredSubscriptions(
         },
       );
       trackSubscription(request.socketId, userId, sub.relayId, sub.resourceId);
+      persistRelaySubscriptionOnContext(request.context, sub.relayId, sub.resourceId);
     } catch (err) {
       const mapped =
         err instanceof RelaySubscriptionError ? err : toSubscriptionError(err);
       if (mapped.code === status.UNAVAILABLE) {
         trackSubscription(request.socketId, userId, sub.relayId, sub.resourceId);
+        persistRelaySubscriptionOnContext(request.context, sub.relayId, sub.resourceId);
         continue;
       }
       if (

--- a/modules/router/src/event-relays/relaySocketData.ts
+++ b/modules/router/src/event-relays/relaySocketData.ts
@@ -1,0 +1,65 @@
+import { Indexable } from '@conduitplatform/grpc-sdk';
+import { RelaySubscription } from './subscriptions.js';
+
+const CONTEXT_KEY = 'eventRelaySubs';
+
+export function relaySubscriptionsFromContext(
+  context: Indexable | undefined,
+): RelaySubscription[] {
+  if (!context) {
+    return [];
+  }
+  const raw = context[CONTEXT_KEY];
+  if (!Array.isArray(raw)) {
+    return [];
+  }
+  const subs: RelaySubscription[] = [];
+  for (const item of raw) {
+    if (
+      item &&
+      typeof item === 'object' &&
+      typeof (item as RelaySubscription).relayId === 'string' &&
+      typeof (item as RelaySubscription).resourceId === 'string'
+    ) {
+      subs.push({
+        relayId: (item as RelaySubscription).relayId,
+        resourceId: (item as RelaySubscription).resourceId,
+      });
+    }
+  }
+  return subs;
+}
+
+export function persistRelaySubscriptionOnContext(
+  context: Indexable | undefined,
+  relayId: string,
+  resourceId: string,
+): void {
+  if (!context) {
+    return;
+  }
+  const subs = relaySubscriptionsFromContext(context);
+  const withoutDup = subs.filter(
+    sub => !(sub.relayId === relayId && sub.resourceId === resourceId),
+  );
+  withoutDup.push({ relayId, resourceId });
+  context[CONTEXT_KEY] = withoutDup;
+}
+
+export function removeRelaySubscriptionFromContext(
+  context: Indexable | undefined,
+  relayId: string,
+  resourceId: string,
+): void {
+  if (!context) {
+    return;
+  }
+  const next = relaySubscriptionsFromContext(context).filter(
+    sub => !(sub.relayId === relayId && sub.resourceId === resourceId),
+  );
+  if (next.length === 0) {
+    delete context[CONTEXT_KEY];
+  } else {
+    context[CONTEXT_KEY] = next;
+  }
+}

--- a/modules/router/src/event-relays/rooms.ts
+++ b/modules/router/src/event-relays/rooms.ts
@@ -4,3 +4,7 @@ export function eventRelayRoom(relayId: string, resourceId: string): string {
   const digest = createHash('sha256').update(resourceId).digest('hex');
   return `er:${relayId}:${digest}`;
 }
+
+export function eventRelayRoomPrefix(relayId: string): string {
+  return `er:${relayId}:`;
+}

--- a/modules/router/src/event-relays/subscriptions.ts
+++ b/modules/router/src/event-relays/subscriptions.ts
@@ -6,9 +6,34 @@ export type RelaySubscription = {
   resourceId: string;
 };
 
+const RECOVERY_ROOM_MAP_TTL_MS = 120_000;
+
 const subscriptionsBySocket = new Map<string, RelaySubscription[]>();
 const subscriptionsByUser = new Map<string, RelaySubscription[]>();
-const subscriptionsByRoom = new Map<string, RelaySubscription & { userId: string }>();
+const subscriptionsByRoom = new Map<string, RelaySubscription & { expiresAt: number }>();
+
+function pruneExpiredRoomEntries(now = Date.now()): void {
+  for (const [room, entry] of subscriptionsByRoom) {
+    if (entry.expiresAt <= now) {
+      subscriptionsByRoom.delete(room);
+    }
+  }
+}
+
+function touchRoomEntry(relayId: string, resourceId: string): void {
+  const room = eventRelayRoom(relayId, resourceId);
+  subscriptionsByRoom.set(room, {
+    relayId,
+    resourceId,
+    expiresAt: Date.now() + RECOVERY_ROOM_MAP_TTL_MS,
+  });
+}
+
+function pruneRoomEntryIfUnused(relayId: string, resourceId: string): void {
+  if (!isSubscriptionTrackedOnAnySocket(relayId, resourceId)) {
+    subscriptionsByRoom.delete(eventRelayRoom(relayId, resourceId));
+  }
+}
 
 export function trackSubscription(
   socketId: string,
@@ -17,7 +42,6 @@ export function trackSubscription(
   resourceId: string,
 ): void {
   const entry = { relayId, resourceId };
-  const room = eventRelayRoom(relayId, resourceId);
   const socketSubs = subscriptionsBySocket.get(socketId) ?? [];
   const withoutDup = socketSubs.filter(
     sub => !(sub.relayId === relayId && sub.resourceId === resourceId),
@@ -34,7 +58,7 @@ export function trackSubscription(
   );
   userWithoutDup.push(entry);
   subscriptionsByUser.set(userId, userWithoutDup);
-  subscriptionsByRoom.set(room, { relayId, resourceId, userId });
+  touchRoomEntry(relayId, resourceId);
 }
 
 export function removeSubscription(
@@ -66,9 +90,7 @@ export function removeSubscription(
         subscriptionsByUser.set(userId, next);
       }
     }
-    if (!isSubscriptionTrackedOnAnySocket(relayId, resourceId)) {
-      subscriptionsByRoom.delete(eventRelayRoom(relayId, resourceId));
-    }
+    pruneRoomEntryIfUnused(relayId, resourceId);
   }
 }
 
@@ -119,24 +141,39 @@ export function releaseSocketSubscriptions(socketId: string, userId?: string): v
         subscriptionsByUser.set(userId, next);
       }
     }
+    pruneRoomEntryIfUnused(sub.relayId, sub.resourceId);
   }
 }
 
 export function subscriptionsForRecoveredRooms(
-  userId: string,
   recoveredRooms: string[],
+  contextSubs: RelaySubscription[] = [],
 ): RelaySubscription[] {
-  const subs: RelaySubscription[] = [];
-  for (const room of recoveredRooms) {
-    if (!room.startsWith('er:')) {
+  pruneExpiredRoomEntries();
+  const seen = new Set<string>();
+  const result: RelaySubscription[] = [];
+  const recoveredSet = new Set(recoveredRooms.filter(room => room.startsWith('er:')));
+
+  for (const sub of contextSubs) {
+    const room = eventRelayRoom(sub.relayId, sub.resourceId);
+    if (recoveredSet.has(room) && !seen.has(room)) {
+      seen.add(room);
+      result.push(sub);
+    }
+  }
+
+  for (const room of recoveredSet) {
+    if (seen.has(room)) {
       continue;
     }
     const entry = subscriptionsByRoom.get(room);
-    if (entry?.userId === userId) {
-      subs.push({ relayId: entry.relayId, resourceId: entry.resourceId });
+    if (entry) {
+      seen.add(room);
+      result.push({ relayId: entry.relayId, resourceId: entry.resourceId });
     }
   }
-  return subs;
+
+  return result;
 }
 
 export function subscriptionsForUser(userId: string): RelaySubscription[] {

--- a/modules/router/src/event-relays/subscriptions.ts
+++ b/modules/router/src/event-relays/subscriptions.ts
@@ -1,0 +1,108 @@
+import { eventRelayRoom } from './rooms.js';
+import { MAX_ROOMS_PER_SOCKET } from './constants.js';
+
+export type RelaySubscription = {
+  relayId: string;
+  resourceId: string;
+};
+
+const subscriptionsBySocket = new Map<string, RelaySubscription[]>();
+const subscriptionsByUser = new Map<string, RelaySubscription[]>();
+
+export function trackSubscription(
+  socketId: string,
+  userId: string,
+  relayId: string,
+  resourceId: string,
+): void {
+  const entry = { relayId, resourceId };
+  const socketSubs = subscriptionsBySocket.get(socketId) ?? [];
+  const withoutDup = socketSubs.filter(
+    sub => !(sub.relayId === relayId && sub.resourceId === resourceId),
+  );
+  withoutDup.push(entry);
+  if (withoutDup.length > MAX_ROOMS_PER_SOCKET) {
+    throw new Error(`Cannot subscribe to more than ${MAX_ROOMS_PER_SOCKET} relay rooms`);
+  }
+  subscriptionsBySocket.set(socketId, withoutDup);
+
+  const userSubs = subscriptionsByUser.get(userId) ?? [];
+  const userWithoutDup = userSubs.filter(
+    sub => !(sub.relayId === relayId && sub.resourceId === resourceId),
+  );
+  userWithoutDup.push(entry);
+  subscriptionsByUser.set(userId, userWithoutDup);
+}
+
+export function removeSubscription(
+  socketId: string,
+  userId: string | undefined,
+  relayId: string,
+  resourceId: string,
+): void {
+  const socketSubs = subscriptionsBySocket.get(socketId);
+  if (socketSubs) {
+    subscriptionsBySocket.set(
+      socketId,
+      socketSubs.filter(
+        sub => !(sub.relayId === relayId && sub.resourceId === resourceId),
+      ),
+    );
+  }
+  if (userId) {
+    const userSubs = subscriptionsByUser.get(userId);
+    if (userSubs) {
+      subscriptionsByUser.set(
+        userId,
+        userSubs.filter(
+          sub => !(sub.relayId === relayId && sub.resourceId === resourceId),
+        ),
+      );
+    }
+  }
+}
+
+export function clearSocketSubscriptionTracking(socketId: string): void {
+  subscriptionsBySocket.delete(socketId);
+}
+
+export function subscriptionsForUser(userId: string): RelaySubscription[] {
+  return [...(subscriptionsByUser.get(userId) ?? [])];
+}
+
+export function removeSubscriptionsForRelay(relayId: string): void {
+  for (const [socketId, subs] of subscriptionsBySocket) {
+    const next = subs.filter(sub => sub.relayId !== relayId);
+    if (next.length === 0) {
+      subscriptionsBySocket.delete(socketId);
+    } else {
+      subscriptionsBySocket.set(socketId, next);
+    }
+  }
+  for (const [userId, subs] of subscriptionsByUser) {
+    const next = subs.filter(sub => sub.relayId !== relayId);
+    if (next.length === 0) {
+      subscriptionsByUser.delete(userId);
+    } else {
+      subscriptionsByUser.set(userId, next);
+    }
+  }
+}
+
+export function leaveRoomsForRelay(relayId: string): string[] {
+  const rooms = new Set<string>();
+  for (const subs of subscriptionsByUser.values()) {
+    for (const sub of subs) {
+      if (sub.relayId === relayId) {
+        rooms.add(eventRelayRoom(relayId, sub.resourceId));
+      }
+    }
+  }
+  return [...rooms];
+}
+
+/** @internal test helper */
+export function _clearEventRelaySubscriptionStateForTests(): void {
+  subscriptionsBySocket.clear();
+  subscriptionsByUser.clear();
+}

--- a/modules/router/src/event-relays/subscriptions.ts
+++ b/modules/router/src/event-relays/subscriptions.ts
@@ -8,6 +8,7 @@ export type RelaySubscription = {
 
 const subscriptionsBySocket = new Map<string, RelaySubscription[]>();
 const subscriptionsByUser = new Map<string, RelaySubscription[]>();
+const subscriptionsByRoom = new Map<string, RelaySubscription & { userId: string }>();
 
 export function trackSubscription(
   socketId: string,
@@ -16,6 +17,7 @@ export function trackSubscription(
   resourceId: string,
 ): void {
   const entry = { relayId, resourceId };
+  const room = eventRelayRoom(relayId, resourceId);
   const socketSubs = subscriptionsBySocket.get(socketId) ?? [];
   const withoutDup = socketSubs.filter(
     sub => !(sub.relayId === relayId && sub.resourceId === resourceId),
@@ -32,6 +34,7 @@ export function trackSubscription(
   );
   userWithoutDup.push(entry);
   subscriptionsByUser.set(userId, userWithoutDup);
+  subscriptionsByRoom.set(room, { relayId, resourceId, userId });
 }
 
 export function removeSubscription(
@@ -42,28 +45,98 @@ export function removeSubscription(
 ): void {
   const socketSubs = subscriptionsBySocket.get(socketId);
   if (socketSubs) {
-    subscriptionsBySocket.set(
-      socketId,
-      socketSubs.filter(
-        sub => !(sub.relayId === relayId && sub.resourceId === resourceId),
-      ),
+    const next = socketSubs.filter(
+      sub => !(sub.relayId === relayId && sub.resourceId === resourceId),
     );
+    if (next.length === 0) {
+      subscriptionsBySocket.delete(socketId);
+    } else {
+      subscriptionsBySocket.set(socketId, next);
+    }
   }
-  if (userId) {
+  if (userId && !isSubscriptionTrackedOnOtherSocket(relayId, resourceId, socketId)) {
     const userSubs = subscriptionsByUser.get(userId);
     if (userSubs) {
-      subscriptionsByUser.set(
-        userId,
-        userSubs.filter(
-          sub => !(sub.relayId === relayId && sub.resourceId === resourceId),
-        ),
+      const next = userSubs.filter(
+        sub => !(sub.relayId === relayId && sub.resourceId === resourceId),
       );
+      if (next.length === 0) {
+        subscriptionsByUser.delete(userId);
+      } else {
+        subscriptionsByUser.set(userId, next);
+      }
+    }
+    if (!isSubscriptionTrackedOnAnySocket(relayId, resourceId)) {
+      subscriptionsByRoom.delete(eventRelayRoom(relayId, resourceId));
     }
   }
 }
 
-export function clearSocketSubscriptionTracking(socketId: string): void {
+function isSubscriptionTrackedOnOtherSocket(
+  relayId: string,
+  resourceId: string,
+  exceptSocketId: string,
+): boolean {
+  for (const [socketId, subs] of subscriptionsBySocket) {
+    if (socketId === exceptSocketId) {
+      continue;
+    }
+    if (subs.some(sub => sub.relayId === relayId && sub.resourceId === resourceId)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function isSubscriptionTrackedOnAnySocket(relayId: string, resourceId: string): boolean {
+  for (const subs of subscriptionsBySocket.values()) {
+    if (subs.some(sub => sub.relayId === relayId && sub.resourceId === resourceId)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+export function releaseSocketSubscriptions(socketId: string, userId?: string): void {
+  const subs = subscriptionsBySocket.get(socketId) ?? [];
   subscriptionsBySocket.delete(socketId);
+  if (!userId) {
+    return;
+  }
+  for (const sub of subs) {
+    if (!isSubscriptionTrackedOnOtherSocket(sub.relayId, sub.resourceId, socketId)) {
+      const userSubs = subscriptionsByUser.get(userId);
+      if (!userSubs) {
+        continue;
+      }
+      const next = userSubs.filter(
+        entry =>
+          !(entry.relayId === sub.relayId && entry.resourceId === sub.resourceId),
+      );
+      if (next.length === 0) {
+        subscriptionsByUser.delete(userId);
+      } else {
+        subscriptionsByUser.set(userId, next);
+      }
+    }
+  }
+}
+
+export function subscriptionsForRecoveredRooms(
+  userId: string,
+  recoveredRooms: string[],
+): RelaySubscription[] {
+  const subs: RelaySubscription[] = [];
+  for (const room of recoveredRooms) {
+    if (!room.startsWith('er:')) {
+      continue;
+    }
+    const entry = subscriptionsByRoom.get(room);
+    if (entry?.userId === userId) {
+      subs.push({ relayId: entry.relayId, resourceId: entry.resourceId });
+    }
+  }
+  return subs;
 }
 
 export function subscriptionsForUser(userId: string): RelaySubscription[] {
@@ -87,6 +160,11 @@ export function removeSubscriptionsForRelay(relayId: string): void {
       subscriptionsByUser.set(userId, next);
     }
   }
+  for (const [room, entry] of subscriptionsByRoom) {
+    if (entry.relayId === relayId) {
+      subscriptionsByRoom.delete(room);
+    }
+  }
 }
 
 export function leaveRoomsForRelay(relayId: string): string[] {
@@ -105,4 +183,5 @@ export function leaveRoomsForRelay(relayId: string): string[] {
 export function _clearEventRelaySubscriptionStateForTests(): void {
   subscriptionsBySocket.clear();
   subscriptionsByUser.clear();
+  subscriptionsByRoom.clear();
 }

--- a/modules/router/src/index.ts
+++ b/modules/router/src/index.ts
@@ -1,7 +1,25 @@
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { ConduitGrpcSdk } from '@conduitplatform/grpc-sdk';
 import ConduitDefaultRouter from './Router.js';
 
 const peerManifestRoot = path.join(path.dirname(fileURLToPath(import.meta.url)), '..');
 const router = new ConduitDefaultRouter(peerManifestRoot);
+
+function registerShutdownSignals(): void {
+  const shutdown = (signal: NodeJS.Signals) => {
+    void router
+      .shutdown()
+      .catch(err => {
+        ConduitGrpcSdk.Logger.error(err as Error);
+      })
+      .finally(() => {
+        process.exit(signal === 'SIGINT' ? 130 : 0);
+      });
+  };
+  process.once('SIGTERM', () => shutdown('SIGTERM'));
+  process.once('SIGINT', () => shutdown('SIGINT'));
+}
+
+registerShutdownSignals();
 router.start();

--- a/modules/router/src/metrics/index.ts
+++ b/modules/router/src/metrics/index.ts
@@ -38,4 +38,39 @@ export default {
       help: 'Tracks denied or unavailable event-relay socket subscriptions',
     },
   },
+  eventRelaysActive: {
+    type: MetricType.Gauge,
+    config: {
+      name: 'event_relays_active_total',
+      help: 'Active event relays on this router replica',
+    },
+  },
+  eventRelaysSubscribedChannels: {
+    type: MetricType.Gauge,
+    config: {
+      name: 'event_relays_subscribed_channels_total',
+      help: 'Bus channels this router replica subscribes to for event relays',
+    },
+  },
+  eventRelaysEmptyRoom: {
+    type: MetricType.Counter,
+    config: {
+      name: 'event_relays_empty_room_total',
+      help: 'Skipped emits because no local sockets were in the relay room',
+    },
+  },
+  eventRelaysInboundDropped: {
+    type: MetricType.Counter,
+    config: {
+      name: 'event_relays_inbound_dropped_total',
+      help: 'Inbound bus payloads dropped for exceeding the size cap',
+    },
+  },
+  eventRelaysEmitDropped: {
+    type: MetricType.Counter,
+    config: {
+      name: 'event_relays_emit_dropped_total',
+      help: 'Socket emits dropped or disconnected due to backpressure',
+    },
+  },
 };

--- a/modules/router/tsconfig.test.json
+++ b/modules/router/tsconfig.test.json
@@ -19,6 +19,8 @@
     "src/event-relays/search.ts",
     "src/event-relays/channels.ts",
     "src/event-relays/authorize.ts",
+    "src/event-relays/compile.ts",
+    "src/event-relays/rebacCache.ts",
     "src/event-relays/*.test.ts"
   ]
 }

--- a/modules/router/tsconfig.test.json
+++ b/modules/router/tsconfig.test.json
@@ -21,6 +21,7 @@
     "src/event-relays/authorize.ts",
     "src/event-relays/compile.ts",
     "src/event-relays/rebacCache.ts",
+    "src/event-relays/subscriptions.ts",
     "src/event-relays/*.test.ts"
   ]
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Implements the Conduit backend slice of the Event Relays interventions plan on top of #1600.

## Summary
- **EventBus:** single Redis `message` dispatcher, callbacks keyed by `subscriberId`, SIGTERM/SIGINT `quit`, subscribe only after Redis ACK; unit tests for churn.
- **Hermes:** engine global middleware installed once with namespace derived from handshake URL; no namespace broadcast when `rooms` and `receivers` are empty; hot-path logs at debug; recovered `/events/` sockets re-run relay authorization; `isSocketHandshake` matches `EIO`+`transport` only (for admin ticket hardening in #1601).
- **EventRelayManager:** relays indexed by id; coalesced + 30s periodic reconcile; templates compiled at reconcile; 256KiB inbound cap; TTL cached emit-time ReBAC with fail-closed deny → leave-room; room eviction on deactivate/delete/permission or resourceType change; bounded local emit backpressure; metrics gauges/counters.
- **Admin:** `POST /router/event-relays/preview` uses the runtime template renderer.
- **Docs:** subscribe-only, dual-publish warning, polling stickiness, EventBus self-publish, room naming (`er:<relayId>:<sha256(resourceId)>`), no tenant/team in rooms.

## Tests added/updated
- `EventBus.test.ts`, `isSocketHandshake.test.ts`, router `rebacCache.test.ts`, `interventions.test.ts` (inbound cap + preview parity), existing event-relay unit suite updated for push flags.

## Out of scope (follow-ups)
- Conduit-UI (#327)
- Integration tests: dual-router HA emit, live `/events/` middleware E2E, deactivate relay E2E
- Wiring `isSocketHandshake` into admin auth middleware (lands with database admin realtime PR)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e5c8d4eb-90a7-56ec-a367-8c85668677ca?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e5c8d4eb-90a7-56ec-a367-8c85668677ca&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

